### PR TITLE
feat(examples): add portable agent session engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .env
 .env.*
 !.env.example
+.agent-sessions/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Then follow the [getting-started guide](./docs/getting-started.md) or inspect:
   that run before authorization;
 - [`spec-engine`](./examples/spec-engine/) for a spec-driven development
   workflow whose ordering, state, and per-step authorization live in the domain
-  rather than in a workflow engine.
+  rather than in a workflow engine;
+- [`agent-session-engine`](./examples/agent-session-engine/) for durable task,
+  phase, checkpoint, and handoff state plus CLI-backed hooks for Cursor,
+  Antigravity, Claude Code, and Codex.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ conflicts with a contract or ADR, the normative source takes precedence.
 - [`support-harness`: private MCP consumer](../examples/support-harness/)
 - [`crawl-engine`: outbound provider integration with Firecrawl](../examples/crawl-engine/)
 - [`spec-engine`: spec-driven development workflow as domain rules](../examples/spec-engine/)
+- [`agent-session-engine`: durable cross-harness sessions and CLI-backed hooks](../examples/agent-session-engine/)
 - [`community-capabilities`: atomic and library capability publication fixture](../examples/community-capabilities/)
 - [`composed-engine`: local, atomic, and library capability composition](../examples/composed-engine/)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,11 +9,14 @@ For complete, runnable compositions, see
 [`hello-engine`](../examples/hello-engine/) and
 [`support-engine`](../examples/support-engine/). The hello example is the shortest
 onboarding path. The support example demonstrates injected ports and a domain
-authorization rule. Two further examples apply the same contracts to harder
-cases: [`crawl-engine`](../examples/crawl-engine/) integrates an external
-provider (Firecrawl) behind a port, and [`spec-engine`](../examples/spec-engine/)
-runs a multi-step, spec-driven workflow using domain stage rules instead of a
-workflow engine.
+authorization rule. Further examples apply the same contracts to harder cases:
+[`crawl-engine`](../examples/crawl-engine/) integrates an external provider
+(Firecrawl) behind a port, and [`spec-engine`](../examples/spec-engine/) runs a
+multi-step, spec-driven workflow using domain stage rules. The
+[`agent-session-engine`](../examples/agent-session-engine/) shows how command
+hooks from Cursor, Antigravity, Claude Code, and Codex can record durable agent
+session metadata through the CLI adapter while another harness resumes from a
+portable checkpoint.
 
 ## Prerequisites
 

--- a/examples/agent-session-engine/README.md
+++ b/examples/agent-session-engine/README.md
@@ -29,9 +29,12 @@ as an operator's CLI command.
 
 The default `FileAgentSessionStore` writes one JSON document per portable
 session under `AGENT_SESSION_ENGINE_DATA_DIR`, or `.agent-sessions/` in the
-current directory when the variable is absent. It uses a per-session exclusive
-file lock, optimistic revisions, a synced temporary file, and atomic rename.
-A lock left by a terminated process becomes recoverable after 30 seconds.
+current directory when the variable is absent. Files use a fixed-length SHA-256
+name derived from the validated session ID. The store uses a per-session
+exclusive file lock with an owner token and process identity, optimistic
+revisions, a synced temporary file, and atomic rename. A lock left by a
+terminated process becomes recoverable after 30 seconds; elapsed time alone
+never permits one live process to steal another process's lock.
 
 The example makes these operational limits explicit:
 
@@ -42,12 +45,16 @@ The example makes these operational limits explicit:
 - 2,000 milliseconds to acquire a live session lock;
 - 4,000 characters per checkpoint, next action, or evidence value;
 - 20 open tasks in injected resume context; `agent-session.get` retains the
-  complete task list.
+  complete task list;
+- 16,000 characters in injected resume context, with an explicit truncation
+  notice when the complete state is larger.
 
 A process crash cannot partially replace a valid session document. This local
 file adapter is not a distributed database: place the data directory on one
 host-local filesystem and replace the store port when multiple hosts must write
-the same session.
+the same session. The JSON layout is an example-version persistence format, not
+a cross-version migration contract; migrate or replace the store before changing
+its schema in an existing deployment.
 
 ## Build and create a session
 
@@ -120,6 +127,12 @@ On a resumed Codex or Claude Code `SessionStart`, the hook returns
 `PreInvocation`. Other configured handlers return the neutral output required
 by that harness.
 
+Hook events are observations. They do not implicitly advance the portable
+phase, task status, checkpoint, or owner. A coordinator must invoke the task and
+checkpoint capabilities for those state transitions. Concurrent hook events are
+returned in successful persistence order; `observedAt` records each recorder's
+wall-clock observation and is not a distributed causal clock.
+
 ### Coverage is bounded by the harness
 
 The configurations capture the safe session, agent, task, compaction, model
@@ -134,16 +147,19 @@ into an action for which the harness emits no hook.
   invocation/stop events are recorded.
 - Claude Code `WorktreeCreate` changes worktree creation behavior and
   `FileChanged` requires an explicit watch list. Neither is a neutral lifecycle
-  observer, so this example does not register them.
+  observer, so this example omits those two events and registers every other
+  currently documented Claude Code event.
 - Cursor coverage is the set of events emitted by the installed Cursor version;
   generic and legacy tool events may both fire and are stored as distinct event
   names.
 
-The normalizer creates a deterministic event ID from the harness, native
-session, event metadata, and SHA-256 of the received payload. An identical
-redelivery is idempotent. Hooks without a stable native occurrence identifier
-can still be delivered at least once by the harness, so this example does not
-promise distributed exactly-once delivery.
+When a hook supplies a stable native occurrence identifier, the normalizer
+creates a deterministic event ID from that occurrence and the SHA-256 of the
+received payload, so a byte-identical redelivery is idempotent. When a hook does
+not supply one, each hook process assigns a new delivery identity so distinct
+byte-identical lifecycle occurrences are never collapsed. Such events can be
+duplicated if the harness retries them, so this example promises neither
+distributed exactly-once delivery nor automatic retry deduplication.
 
 ## Payload privacy
 

--- a/examples/agent-session-engine/README.md
+++ b/examples/agent-session-engine/README.md
@@ -1,0 +1,188 @@
+# Agent session engine example
+
+This example persists an agent session independently of Cursor, Antigravity,
+Claude Code, or Codex. A coordinator can inspect the current phase, checkpoint,
+tasks, owners, and verification evidence, then hand work to another harness
+without depending on the first harness's private transcript format.
+
+The framework still does not become a harness or workflow runtime. Session
+ordering, task ownership, persistence, and hook normalization are domain rules
+and injected infrastructure of this custom engine.
+
+## Capabilities
+
+| Capability | Observable behavior |
+| --- | --- |
+| `agent-session.start` | Creates one portable session identifier and objective. |
+| `agent-session.record-hook-event` | Stores payload-free lifecycle metadata from a harness hook. |
+| `agent-session.create-task` | Creates a task with a phase and optional harness/agent owner. |
+| `agent-session.update-task` | Advances, checkpoints, completes, unassigns, or hands off a task using its expected revision. |
+| `agent-session.checkpoint` | Records the session phase, status, checkpoint, and next action using the expected session revision. |
+| `agent-session.get` | Returns the complete state and a bounded `resumeContext` for another harness. |
+
+Every direct, CLI, and MCP call reaches these handlers only through
+`engine.invoke`. The command hook also calls `runCli`, so hook events exercise
+the same validation, authorization, execution, persistence, and engine events
+as an operator's CLI command.
+
+## Durable state and concurrency
+
+The default `FileAgentSessionStore` writes one JSON document per portable
+session under `AGENT_SESSION_ENGINE_DATA_DIR`, or `.agent-sessions/` in the
+current directory when the variable is absent. It uses a per-session exclusive
+file lock, optimistic revisions, a synced temporary file, and atomic rename.
+A lock left by a terminated process becomes recoverable after 30 seconds.
+
+The example makes these operational limits explicit:
+
+- 256 tasks per session;
+- 10,000 hook events per session;
+- 64 linked native harness sessions;
+- 4,194,304 input bytes per hook process;
+- 2,000 milliseconds to acquire a live session lock;
+- 4,000 characters per checkpoint, next action, or evidence value;
+- 20 open tasks in injected resume context; `agent-session.get` retains the
+  complete task list.
+
+A process crash cannot partially replace a valid session document. This local
+file adapter is not a distributed database: place the data directory on one
+host-local filesystem and replace the store port when multiple hosts must write
+the same session.
+
+## Build and create a session
+
+From the repository root:
+
+```sh
+yarn build
+
+export AGENT_SESSION_ENGINE_DATA_DIR="$PWD/.agent-sessions"
+export AGENT_SESSION_ENGINE_SESSION_ID="delivery-42"
+
+node examples/agent-session-engine/dist/cli.js run agent-session.start --input \
+  '{"sessionId":"delivery-42","objective":"Deliver the hook integration","workspaceRoot":"/workspace/ai-engines"}'
+
+node examples/agent-session-engine/dist/cli.js run agent-session.create-task --input \
+  '{"sessionId":"delivery-42","taskId":"implement-hooks","title":"Implement harness hook adapters","phase":"implementation","assignedHarness":"codex","assignedAgentId":"primary"}'
+```
+
+The environment variables must be inherited by every harness process that
+participates in the handoff. `AGENT_SESSION_ENGINE_SESSION_ID` maps different
+native conversation IDs onto the same portable session. Without it, the hook
+uses `<harness>:<native-session-id>` as an isolated default when the native ID
+is filename-safe, or a deterministic hash of that native ID otherwise.
+
+Record a resumable checkpoint with the latest session revision returned by the
+previous mutation:
+
+```sh
+node examples/agent-session-engine/dist/cli.js run agent-session.checkpoint --input \
+  '{"sessionId":"delivery-42","expectedRevision":2,"phase":"implementation","status":"paused","checkpoint":"The contracts and tests are complete.","nextAction":"Implement the hook adapter and run the focused suite."}'
+```
+
+Hand the task to a Claude Code agent with the task revision returned by the
+previous task mutation:
+
+```sh
+node examples/agent-session-engine/dist/cli.js run agent-session.update-task --input \
+  '{"sessionId":"delivery-42","taskId":"implement-hooks","expectedTaskRevision":1,"assignedHarness":"claude-code","assignedAgentId":"implementer"}'
+```
+
+Stale task or session revisions fail instead of silently overwriting another
+agent's progress. Completing a task also requires non-empty `evidence`.
+
+## Connect harness hooks
+
+The example configurations follow the current official hook references for
+[Cursor](https://cursor.com/docs/hooks),
+[Antigravity](https://antigravity.google/docs/hooks),
+[Claude Code](https://code.claude.com/docs/en/hooks), and
+[Codex](https://developers.openai.com/codex/config-advanced#hooks).
+
+After building, copy or merge the applicable example from `hooks/`:
+
+| Harness | Example | Project location |
+| --- | --- | --- |
+| Cursor | `cursor.hooks.json` | `.cursor/hooks.json` |
+| Antigravity | `antigravity.hooks.json` | `.agents/hooks.json` |
+| Claude Code | `claude-code.settings.json` | `.claude/settings.json` |
+| Codex | `codex.hooks.json` | `.codex/hooks.json` |
+
+Do not overwrite an existing settings file; merge its hook map. The example
+commands assume the harness starts at this repository root. In another project,
+install the built example in a stable location and replace each command with an
+absolute path. Codex project hooks also require the project to be trusted and
+the hook definition to be reviewed in `/hooks` before they run.
+
+On a resumed Codex or Claude Code `SessionStart`, the hook returns
+`hookSpecificOutput.additionalContext`. Cursor receives `additional_context` on
+`sessionStart`. Antigravity receives an ephemeral resume step on its first
+`PreInvocation`. Other configured handlers return the neutral output required
+by that harness.
+
+### Coverage is bounded by the harness
+
+The configurations capture the safe session, agent, task, compaction, model
+invocation, and tool events each harness exposes. They do not claim visibility
+into an action for which the harness emits no hook.
+
+- Codex documents that hosted tools and specialized tool paths may bypass local
+  tool hooks. Its config still registers every documented Codex lifecycle event.
+- Antigravity requires `PreToolUse` hooks to return an authorization decision.
+  This observer deliberately omits that event because choosing `allow`, `ask`,
+  or `deny` would change permission behavior. `PostToolUse` and all neutral
+  invocation/stop events are recorded.
+- Claude Code `WorktreeCreate` changes worktree creation behavior and
+  `FileChanged` requires an explicit watch list. Neither is a neutral lifecycle
+  observer, so this example does not register them.
+- Cursor coverage is the set of events emitted by the installed Cursor version;
+  generic and legacy tool events may both fire and are stored as distinct event
+  names.
+
+The normalizer creates a deterministic event ID from the harness, native
+session, event metadata, and SHA-256 of the received payload. An identical
+redelivery is idempotent. Hooks without a stable native occurrence identifier
+can still be delivered at least once by the harness, so this example does not
+promise distributed exactly-once delivery.
+
+## Payload privacy
+
+The hook process reads the harness JSON only to select bounded metadata:
+portable/native session IDs, event name, tool name, native agent/task IDs,
+outcome category, workspace root, observation time, and a SHA-256 digest. It
+does not persist prompts, assistant responses, reasoning, tool arguments, tool
+responses, transcripts, credentials, or raw error messages. The digest proves
+whether two received payloads were byte-identical; it is not a recovery copy.
+
+Hook recording errors go to `stderr`. Monitor them: a full disk, corrupt state,
+expired event budget, or hook timeout means the harness event was not durably
+recorded.
+
+## Other adapters
+
+Run the deterministic direct flow:
+
+```sh
+node examples/agent-session-engine/dist/direct.js direct-demo
+```
+
+Publish the same capabilities over MCP stdio:
+
+```sh
+node examples/agent-session-engine/dist/mcp-stdio.js
+```
+
+Or over authenticated stateless MCP HTTP:
+
+```sh
+AGENT_SESSION_ENGINE_BEARER_TOKEN=development-only-token \
+  node examples/agent-session-engine/dist/mcp-http.js
+```
+
+## Verify
+
+```sh
+yarn workspace @ai-engine/example-agent-session test
+yarn workspace @ai-engine/example-agent-session typecheck
+yarn workspace @ai-engine/example-agent-session build
+```

--- a/examples/agent-session-engine/hooks/antigravity.hooks.json
+++ b/examples/agent-session-engine/hooks/antigravity.hooks.json
@@ -1,0 +1,38 @@
+{
+  "agent-session-recorder": {
+    "enabled": true,
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js antigravity PostToolUse",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js antigravity PreInvocation",
+        "timeout": 10
+      }
+    ],
+    "PostInvocation": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js antigravity PostInvocation",
+        "timeout": 10
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js antigravity Stop",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/examples/agent-session-engine/hooks/claude-code.settings.json
+++ b/examples/agent-session-engine/hooks/claude-code.settings.json
@@ -1,0 +1,158 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TaskCreated": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/agent-session-engine/hooks/claude-code.settings.json
+++ b/examples/agent-session-engine/hooks/claude-code.settings.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "Setup": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [
@@ -33,7 +44,40 @@
         ]
       }
     ],
+    "UserPromptExpansion": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PermissionDenied": [
       {
         "hooks": [
           {
@@ -56,6 +100,39 @@
       }
     ],
     "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolBatch": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "MessageDisplay": [
       {
         "hooks": [
           {
@@ -110,6 +187,61 @@
         ]
       }
     ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [
@@ -122,6 +254,28 @@
       }
     ],
     "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Elicitation": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js claude-code",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "ElicitationResult": [
       {
         "hooks": [
           {

--- a/examples/agent-session-engine/hooks/codex.hooks.json
+++ b/examples/agent-session-engine/hooks/codex.hooks.json
@@ -1,0 +1,127 @@
+{
+  "description": "Record Codex lifecycle metadata in the agent session engine.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10,
+            "additionalContextLimit": 4000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node examples/agent-session-engine/dist/hook-cli.js codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/agent-session-engine/hooks/cursor.hooks.json
+++ b/examples/agent-session-engine/hooks/cursor.hooks.json
@@ -1,0 +1,152 @@
+{
+  "version": 1,
+  "hooks": {
+    "workspaceOpen": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "sessionStart": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "afterAgentResponse": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "afterAgentThought": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "postToolUseFailure": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "afterShellExecution": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "beforeMCPExecution": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "afterMCPExecution": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "beforeReadFile": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "beforeTabFileRead": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "afterTabFileEdit": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "subagentStart": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "subagentStop": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "preCompact": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ],
+    "stop": [
+      {
+        "type": "command",
+        "command": "node examples/agent-session-engine/dist/hook-cli.js cursor",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@ai-engine/example-agent-session",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "typecheck": "tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false --noEmit",
+    "test": "vitest run test",
+    "direct": "node dist/direct.js",
+    "cli": "node dist/cli.js",
+    "hook": "node dist/hook-cli.js",
+    "mcp:stdio": "node dist/mcp-stdio.js",
+    "mcp:http": "node dist/mcp-http.js"
+  },
+  "dependencies": {
+    "@ai-engine/cli": "0.1.0",
+    "@ai-engine/core": "0.1.0",
+    "@ai-engine/mcp": "0.1.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  }
+}

--- a/examples/agent-session-engine/src/application/authorization.ts
+++ b/examples/agent-session-engine/src/application/authorization.ts
@@ -1,0 +1,18 @@
+import type { Principal } from "@ai-engine/core";
+
+export type AgentSessionPermission =
+  | "agent-session:read"
+  | "agent-session:write"
+  | "agent-session:hooks";
+
+export function hasPermission(
+  principal: Principal | null,
+  permission: AgentSessionPermission,
+): boolean {
+  if (principal === null) return false;
+  const permissions = principal.attributes?.permissions;
+  return (
+    Array.isArray(permissions) &&
+    permissions.some((candidate) => candidate === permission)
+  );
+}

--- a/examples/agent-session-engine/src/application/ports.ts
+++ b/examples/agent-session-engine/src/application/ports.ts
@@ -1,0 +1,29 @@
+import type { AgentSession } from "../domain/agent-session.js";
+
+export interface StoreOptions {
+  readonly signal?: AbortSignal;
+}
+
+export type CreateSessionResult = "created" | "exists";
+export type SaveSessionResult = "saved" | "missing" | "conflict";
+
+export interface AgentSessionStore {
+  create(
+    session: AgentSession,
+    options?: StoreOptions,
+  ): Promise<CreateSessionResult>;
+  findById(
+    sessionId: string,
+    options?: StoreOptions,
+  ): Promise<AgentSession | null>;
+  save(
+    session: AgentSession,
+    expectedRevision: number,
+    options?: StoreOptions,
+  ): Promise<SaveSessionResult>;
+}
+
+export interface AgentSessionDependencies {
+  readonly sessions: AgentSessionStore;
+  readonly now: () => Date;
+}

--- a/examples/agent-session-engine/src/application/session-schema.ts
+++ b/examples/agent-session-engine/src/application/session-schema.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+export const identifierSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u, {
+    message:
+      "An identifier may contain only letters, digits, dot, underscore, colon, and hyphen.",
+  });
+
+export const harnessSchema = z.enum([
+  "cursor",
+  "antigravity",
+  "claude-code",
+  "codex",
+]);
+
+export const phaseSchema = z.enum([
+  "discovery",
+  "planning",
+  "implementation",
+  "validation",
+  "delivery",
+]);
+
+export const sessionStatusSchema = z.enum(["active", "paused", "completed"]);
+export const taskStatusSchema = z.enum([
+  "pending",
+  "in_progress",
+  "blocked",
+  "completed",
+]);
+
+export const taskOwnerSchema = z.object({
+  harness: harnessSchema,
+  agentId: identifierSchema,
+});
+
+export const agentTaskSchema = z.object({
+  id: identifierSchema,
+  title: z.string().trim().min(1).max(200),
+  phase: phaseSchema,
+  status: taskStatusSchema,
+  owner: taskOwnerSchema.nullable(),
+  checkpoint: z.string().max(4_000).nullable(),
+  evidence: z.string().max(4_000).nullable(),
+  revision: z.number().int().min(1),
+  createdAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+});
+
+export const harnessSessionSchema = z.object({
+  harness: harnessSchema,
+  nativeSessionId: z.string().trim().min(1).max(256),
+});
+
+export const agentHookEventSchema = z.object({
+  id: identifierSchema,
+  harness: harnessSchema,
+  nativeSessionId: z.string().trim().min(1).max(256),
+  eventName: z.string().trim().min(1).max(128),
+  observedAt: z.string().min(1).max(64),
+  toolName: z.string().trim().min(1).max(256).nullable(),
+  nativeAgentId: z.string().trim().min(1).max(256).nullable(),
+  nativeTaskId: z.string().trim().min(1).max(256).nullable(),
+  outcome: z.string().trim().min(1).max(128).nullable(),
+  payloadSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+});
+
+export const agentSessionSchema = z.object({
+  sessionId: identifierSchema,
+  objective: z.string().trim().min(1).max(2_000),
+  workspaceRoot: z.string().trim().min(1).max(2_000),
+  phase: phaseSchema,
+  status: sessionStatusSchema,
+  checkpoint: z.string().max(4_000).nullable(),
+  nextAction: z.string().max(4_000).nullable(),
+  revision: z.number().int().min(1),
+  tasks: z.array(agentTaskSchema).max(256),
+  harnessSessions: z.array(harnessSessionSchema).max(64),
+  events: z.array(agentHookEventSchema).max(10_000),
+  createdAt: z.string().min(1).max(64),
+  updatedAt: z.string().min(1).max(64),
+});
+
+export const sessionViewSchema = agentSessionSchema.extend({
+  eventCount: z.number().int().min(0).max(10_000),
+  resumeContext: z.string().min(1).max(16_000),
+});

--- a/examples/agent-session-engine/src/application/session-schema.ts
+++ b/examples/agent-session-engine/src/application/session-schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { MAX_RESUME_CONTEXT_CHARACTERS } from "../domain/agent-session.js";
+
 export const identifierSchema = z
   .string()
   .trim()
@@ -87,5 +89,5 @@ export const agentSessionSchema = z.object({
 
 export const sessionViewSchema = agentSessionSchema.extend({
   eventCount: z.number().int().min(0).max(10_000),
-  resumeContext: z.string().min(1).max(16_000),
+  resumeContext: z.string().min(1).max(MAX_RESUME_CONTEXT_CHARACTERS),
 });

--- a/examples/agent-session-engine/src/capabilities/checkpoint-session.ts
+++ b/examples/agent-session-engine/src/capabilities/checkpoint-session.ts
@@ -1,0 +1,88 @@
+import { defineCapability, EngineError } from "@ai-engine/core";
+import { z } from "zod";
+
+import { hasPermission } from "../application/authorization.js";
+import type { AgentSessionDependencies } from "../application/ports.js";
+import {
+  identifierSchema,
+  phaseSchema,
+  sessionStatusSchema,
+} from "../application/session-schema.js";
+import {
+  loadSession,
+  sessionNotFound,
+  sessionViewSchema,
+  toSessionView,
+} from "./session-contract.js";
+
+export function createCheckpointSession(
+  dependencies: AgentSessionDependencies,
+) {
+  return defineCapability({
+    title: "Checkpoint agent session",
+    description:
+      "Persist the current execution phase, status, checkpoint, and next action for a later harness.",
+    input: z.object({
+      sessionId: identifierSchema,
+      expectedRevision: z.number().int().min(1),
+      phase: phaseSchema,
+      status: sessionStatusSchema,
+      checkpoint: z.string().trim().min(1).max(4_000),
+      nextAction: z.string().trim().min(1).max(4_000).nullable(),
+    }),
+    output: sessionViewSchema,
+    access: ({ principal }) => hasPermission(principal, "agent-session:write"),
+    timeoutMs: 10_000,
+    annotations: {
+      readOnly: false,
+      destructive: false,
+      idempotent: false,
+      openWorld: false,
+    },
+    async run({ input, context }) {
+      const current = await loadSession(
+        dependencies,
+        input.sessionId,
+        context.signal,
+      );
+      if (current.revision !== input.expectedRevision) {
+        throw new EngineError({
+          code: "EXECUTION_FAILED",
+          message: "The session changed before this checkpoint.",
+          publicDetails: {
+            sessionId: input.sessionId,
+            expectedRevision: input.expectedRevision,
+          },
+        });
+      }
+      const updated = {
+        ...current,
+        phase: input.phase,
+        status: input.status,
+        checkpoint: input.checkpoint,
+        nextAction: input.nextAction,
+        revision: current.revision + 1,
+        updatedAt: dependencies.now().toISOString(),
+      };
+      const saved = await dependencies.sessions.save(
+        updated,
+        current.revision,
+        {
+          signal: context.signal,
+        },
+      );
+      if (saved === "missing") throw sessionNotFound(input.sessionId);
+      if (saved === "conflict") {
+        throw new EngineError({
+          code: "EXECUTION_FAILED",
+          message: "The session changed before this checkpoint.",
+          publicDetails: {
+            sessionId: input.sessionId,
+            expectedRevision: input.expectedRevision,
+          },
+        });
+      }
+      return toSessionView(updated);
+    },
+  });
+}

--- a/examples/agent-session-engine/src/capabilities/create-task.ts
+++ b/examples/agent-session-engine/src/capabilities/create-task.ts
@@ -1,0 +1,121 @@
+import { defineCapability, EngineError } from "@ai-engine/core";
+import { z } from "zod";
+
+import { hasPermission } from "../application/authorization.js";
+import type { AgentSessionDependencies } from "../application/ports.js";
+import {
+  agentTaskSchema,
+  harnessSchema,
+  identifierSchema,
+  phaseSchema,
+} from "../application/session-schema.js";
+import { MAX_SESSION_TASKS } from "../domain/agent-session.js";
+import { mutateSession } from "./session-contract.js";
+
+const createTaskInput = z
+  .object({
+    sessionId: identifierSchema,
+    taskId: identifierSchema,
+    title: z.string().trim().min(1).max(200),
+    phase: phaseSchema,
+    assignedHarness: harnessSchema.optional(),
+    assignedAgentId: identifierSchema.optional(),
+  })
+  .superRefine((input, context) => {
+    if (
+      (input.assignedHarness === undefined) !==
+      (input.assignedAgentId === undefined)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message:
+          "assignedHarness and assignedAgentId must be provided together.",
+      });
+    }
+  });
+
+export function createCreateTask(dependencies: AgentSessionDependencies) {
+  return defineCapability({
+    title: "Create agent task",
+    description:
+      "Create a portable task, optionally assigned to a harness and native agent identifier.",
+    input: createTaskInput,
+    output: z.object({
+      sessionId: identifierSchema,
+      sessionRevision: z.number().int().min(1),
+      task: agentTaskSchema,
+    }),
+    access: ({ principal }) => hasPermission(principal, "agent-session:write"),
+    timeoutMs: 10_000,
+    annotations: {
+      readOnly: false,
+      destructive: false,
+      idempotent: false,
+      openWorld: false,
+    },
+    async run({ input, context }) {
+      const updated = await mutateSession(
+        dependencies,
+        input.sessionId,
+        context.signal,
+        (current, now) => {
+          if (current.tasks.some(({ id }) => id === input.taskId)) {
+            throw new EngineError({
+              code: "EXECUTION_FAILED",
+              message: "Task already exists in this agent session.",
+              publicDetails: {
+                sessionId: input.sessionId,
+                taskId: input.taskId,
+              },
+            });
+          }
+          if (current.tasks.length >= MAX_SESSION_TASKS) {
+            throw new EngineError({
+              code: "EXECUTION_FAILED",
+              message: "The agent session task limit was reached.",
+              publicDetails: {
+                sessionId: input.sessionId,
+                limit: MAX_SESSION_TASKS,
+              },
+            });
+          }
+          const owner =
+            input.assignedHarness === undefined ||
+            input.assignedAgentId === undefined
+              ? null
+              : {
+                  harness: input.assignedHarness,
+                  agentId: input.assignedAgentId,
+                };
+          return {
+            ...current,
+            revision: current.revision + 1,
+            updatedAt: now,
+            tasks: [
+              ...current.tasks,
+              {
+                id: input.taskId,
+                title: input.title,
+                phase: input.phase,
+                status: "pending" as const,
+                owner,
+                checkpoint: null,
+                evidence: null,
+                revision: 1,
+                createdAt: now,
+                updatedAt: now,
+              },
+            ],
+          };
+        },
+      );
+      const task = updated.tasks.find(({ id }) => id === input.taskId);
+      if (task === undefined) throw new Error("Created task is unavailable.");
+      return {
+        sessionId: updated.sessionId,
+        sessionRevision: updated.revision,
+        task,
+      };
+    },
+  });
+}

--- a/examples/agent-session-engine/src/capabilities/get-session.ts
+++ b/examples/agent-session-engine/src/capabilities/get-session.ts
@@ -1,0 +1,34 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import { hasPermission } from "../application/authorization.js";
+import type { AgentSessionDependencies } from "../application/ports.js";
+import { identifierSchema } from "../application/session-schema.js";
+import {
+  loadSession,
+  sessionViewSchema,
+  toSessionView,
+} from "./session-contract.js";
+
+export function createGetSession(dependencies: AgentSessionDependencies) {
+  return defineCapability({
+    title: "Get portable agent session",
+    description:
+      "Return the complete durable session and a bounded context block for the next harness.",
+    input: z.object({ sessionId: identifierSchema }),
+    output: sessionViewSchema,
+    access: ({ principal }) => hasPermission(principal, "agent-session:read"),
+    timeoutMs: 10_000,
+    annotations: {
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+      openWorld: false,
+    },
+    async run({ input, context }) {
+      return toSessionView(
+        await loadSession(dependencies, input.sessionId, context.signal),
+      );
+    },
+  });
+}

--- a/examples/agent-session-engine/src/capabilities/record-hook-event.ts
+++ b/examples/agent-session-engine/src/capabilities/record-hook-event.ts
@@ -1,0 +1,179 @@
+import { defineCapability, EngineError } from "@ai-engine/core";
+import { z } from "zod";
+
+import { hasPermission } from "../application/authorization.js";
+import type { AgentSessionDependencies } from "../application/ports.js";
+import {
+  harnessSchema,
+  identifierSchema,
+} from "../application/session-schema.js";
+import {
+  type AgentHookEvent,
+  type AgentSession,
+  buildResumeContext,
+  createAgentSession,
+  MAX_SESSION_EVENTS,
+} from "../domain/agent-session.js";
+import {
+  concurrentSessionChange,
+  loadSession,
+  sessionNotFound,
+} from "./session-contract.js";
+
+const MAX_RECORD_ATTEMPTS = 8;
+
+const recordHookEventInput = z.object({
+  sessionId: identifierSchema,
+  harness: harnessSchema,
+  nativeSessionId: z.string().trim().min(1).max(256),
+  eventId: identifierSchema,
+  eventName: z.string().trim().min(1).max(128),
+  observedAt: z.string().min(1).max(64),
+  workspaceRoot: z.string().trim().min(1).max(2_000),
+  toolName: z.string().trim().min(1).max(256).nullable(),
+  nativeAgentId: z.string().trim().min(1).max(256).nullable(),
+  nativeTaskId: z.string().trim().min(1).max(256).nullable(),
+  outcome: z.string().trim().min(1).max(128).nullable(),
+  payloadSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+});
+
+function appendEvent(
+  session: AgentSession,
+  event: AgentHookEvent,
+  updatedAt: string,
+): AgentSession {
+  if (session.events.length >= MAX_SESSION_EVENTS) {
+    throw new EngineError({
+      code: "EXECUTION_FAILED",
+      message: "The agent session event limit was reached.",
+      publicDetails: {
+        sessionId: session.sessionId,
+        limit: MAX_SESSION_EVENTS,
+      },
+    });
+  }
+  const linked = session.harnessSessions.some(
+    (candidate) =>
+      candidate.harness === event.harness &&
+      candidate.nativeSessionId === event.nativeSessionId,
+  );
+  if (!linked && session.harnessSessions.length >= 64) {
+    throw new EngineError({
+      code: "EXECUTION_FAILED",
+      message: "The agent session harness-link limit was reached.",
+      publicDetails: { sessionId: session.sessionId, limit: 64 },
+    });
+  }
+  return {
+    ...session,
+    revision: session.revision + 1,
+    updatedAt,
+    harnessSessions: linked
+      ? session.harnessSessions
+      : [
+          ...session.harnessSessions,
+          {
+            harness: event.harness,
+            nativeSessionId: event.nativeSessionId,
+          },
+        ],
+    events: [...session.events, event],
+  };
+}
+
+export function createRecordHookEvent(dependencies: AgentSessionDependencies) {
+  return defineCapability({
+    title: "Record agent harness hook event",
+    description:
+      "Persist normalized lifecycle metadata from a supported agent harness without prompts or tool payloads.",
+    input: recordHookEventInput,
+    output: z.object({
+      sessionId: identifierSchema,
+      sessionRevision: z.number().int().min(1),
+      recorded: z.boolean(),
+      resumed: z.boolean(),
+      resumeContext: z.string().min(1).max(16_000),
+    }),
+    access: ({ principal }) => hasPermission(principal, "agent-session:hooks"),
+    timeoutMs: 10_000,
+    annotations: {
+      readOnly: false,
+      destructive: false,
+      idempotent: true,
+      openWorld: false,
+    },
+    async run({ input, context }) {
+      let initial = await dependencies.sessions.findById(input.sessionId, {
+        signal: context.signal,
+      });
+      let resumed = initial !== null;
+      if (initial === null) {
+        const createdAt = dependencies.now().toISOString();
+        const candidate = createAgentSession({
+          sessionId: input.sessionId,
+          objective: `Observe ${input.harness} agent session ${input.nativeSessionId}.`,
+          workspaceRoot: input.workspaceRoot,
+          createdAt,
+        });
+        const created = await dependencies.sessions.create(candidate, {
+          signal: context.signal,
+        });
+        resumed = created === "exists";
+        initial =
+          created === "created"
+            ? candidate
+            : await loadSession(dependencies, input.sessionId, context.signal);
+      }
+
+      const event: AgentHookEvent = {
+        id: input.eventId,
+        harness: input.harness,
+        nativeSessionId: input.nativeSessionId,
+        eventName: input.eventName,
+        observedAt: input.observedAt,
+        toolName: input.toolName,
+        nativeAgentId: input.nativeAgentId,
+        nativeTaskId: input.nativeTaskId,
+        outcome: input.outcome,
+        payloadSha256: input.payloadSha256,
+      };
+
+      for (let attempt = 0; attempt < MAX_RECORD_ATTEMPTS; attempt += 1) {
+        const current =
+          attempt === 0
+            ? initial
+            : await loadSession(dependencies, input.sessionId, context.signal);
+        if (current.events.some(({ id }) => id === event.id)) {
+          return {
+            sessionId: current.sessionId,
+            sessionRevision: current.revision,
+            recorded: false,
+            resumed,
+            resumeContext: buildResumeContext(current),
+          };
+        }
+        const updated = appendEvent(
+          current,
+          event,
+          dependencies.now().toISOString(),
+        );
+        const saved = await dependencies.sessions.save(
+          updated,
+          current.revision,
+          { signal: context.signal },
+        );
+        if (saved === "saved") {
+          return {
+            sessionId: updated.sessionId,
+            sessionRevision: updated.revision,
+            recorded: true,
+            resumed,
+            resumeContext: buildResumeContext(updated),
+          };
+        }
+        if (saved === "missing") throw sessionNotFound(input.sessionId);
+      }
+      throw concurrentSessionChange(input.sessionId);
+    },
+  });
+}

--- a/examples/agent-session-engine/src/capabilities/session-contract.ts
+++ b/examples/agent-session-engine/src/capabilities/session-contract.ts
@@ -1,0 +1,70 @@
+import { EngineError } from "@ai-engine/core";
+import type { z } from "zod";
+
+import type { AgentSessionDependencies } from "../application/ports.js";
+import {
+  agentSessionSchema,
+  sessionViewSchema,
+} from "../application/session-schema.js";
+import {
+  type AgentSession,
+  buildResumeContext,
+} from "../domain/agent-session.js";
+
+const MAX_MUTATION_ATTEMPTS = 8;
+
+export { agentSessionSchema, sessionViewSchema };
+
+export type SessionView = z.infer<typeof sessionViewSchema>;
+
+export function toSessionView(session: AgentSession): SessionView {
+  return sessionViewSchema.parse({
+    ...structuredClone(session),
+    eventCount: session.events.length,
+    resumeContext: buildResumeContext(session),
+  });
+}
+
+export function sessionNotFound(sessionId: string): EngineError {
+  return new EngineError({
+    code: "EXECUTION_FAILED",
+    message: "Agent session not found.",
+    publicDetails: { sessionId },
+  });
+}
+
+export function concurrentSessionChange(sessionId: string): EngineError {
+  return new EngineError({
+    code: "EXECUTION_FAILED",
+    message: "The agent session changed during this operation.",
+    publicDetails: { sessionId },
+  });
+}
+
+export async function loadSession(
+  dependencies: AgentSessionDependencies,
+  sessionId: string,
+  signal: AbortSignal,
+): Promise<AgentSession> {
+  const session = await dependencies.sessions.findById(sessionId, { signal });
+  if (session === null) throw sessionNotFound(sessionId);
+  return session;
+}
+
+export async function mutateSession(
+  dependencies: AgentSessionDependencies,
+  sessionId: string,
+  signal: AbortSignal,
+  mutate: (current: AgentSession, now: string) => AgentSession,
+): Promise<AgentSession> {
+  for (let attempt = 0; attempt < MAX_MUTATION_ATTEMPTS; attempt += 1) {
+    const current = await loadSession(dependencies, sessionId, signal);
+    const updated = mutate(current, dependencies.now().toISOString());
+    const saved = await dependencies.sessions.save(updated, current.revision, {
+      signal,
+    });
+    if (saved === "saved") return updated;
+    if (saved === "missing") throw sessionNotFound(sessionId);
+  }
+  throw concurrentSessionChange(sessionId);
+}

--- a/examples/agent-session-engine/src/capabilities/start-session.ts
+++ b/examples/agent-session-engine/src/capabilities/start-session.ts
@@ -1,0 +1,45 @@
+import { defineCapability, EngineError } from "@ai-engine/core";
+import { z } from "zod";
+
+import { hasPermission } from "../application/authorization.js";
+import type { AgentSessionDependencies } from "../application/ports.js";
+import { identifierSchema } from "../application/session-schema.js";
+import { createAgentSession } from "../domain/agent-session.js";
+import { sessionViewSchema, toSessionView } from "./session-contract.js";
+
+export function createStartSession(dependencies: AgentSessionDependencies) {
+  return defineCapability({
+    title: "Start portable agent session",
+    description:
+      "Create a durable, harness-independent session that can be resumed by another agent harness.",
+    input: z.object({
+      sessionId: identifierSchema,
+      objective: z.string().trim().min(1).max(2_000),
+      workspaceRoot: z.string().trim().min(1).max(2_000),
+    }),
+    output: sessionViewSchema,
+    access: ({ principal }) => hasPermission(principal, "agent-session:write"),
+    timeoutMs: 10_000,
+    annotations: {
+      readOnly: false,
+      destructive: false,
+      idempotent: false,
+      openWorld: false,
+    },
+    async run({ input, context }) {
+      const createdAt = dependencies.now().toISOString();
+      const session = createAgentSession({ ...input, createdAt });
+      const result = await dependencies.sessions.create(session, {
+        signal: context.signal,
+      });
+      if (result === "exists") {
+        throw new EngineError({
+          code: "EXECUTION_FAILED",
+          message: "Agent session already exists.",
+          publicDetails: { sessionId: input.sessionId },
+        });
+      }
+      return toSessionView(session);
+    },
+  });
+}

--- a/examples/agent-session-engine/src/capabilities/update-task.ts
+++ b/examples/agent-session-engine/src/capabilities/update-task.ts
@@ -1,0 +1,171 @@
+import { defineCapability, EngineError } from "@ai-engine/core";
+import { z } from "zod";
+
+import { hasPermission } from "../application/authorization.js";
+import type { AgentSessionDependencies } from "../application/ports.js";
+import {
+  agentTaskSchema,
+  harnessSchema,
+  identifierSchema,
+  phaseSchema,
+  taskStatusSchema,
+} from "../application/session-schema.js";
+import type { TaskOwner } from "../domain/agent-session.js";
+import { mutateSession } from "./session-contract.js";
+
+const updateTaskInput = z
+  .object({
+    sessionId: identifierSchema,
+    taskId: identifierSchema,
+    expectedTaskRevision: z.number().int().min(1),
+    status: taskStatusSchema.optional(),
+    phase: phaseSchema.optional(),
+    assignedHarness: harnessSchema.nullable().optional(),
+    assignedAgentId: identifierSchema.nullable().optional(),
+    checkpoint: z.string().trim().min(1).max(4_000).nullable().optional(),
+    evidence: z.string().trim().min(1).max(4_000).nullable().optional(),
+  })
+  .superRefine((input, context) => {
+    const ownerTouched =
+      input.assignedHarness !== undefined ||
+      input.assignedAgentId !== undefined;
+    const ownerComplete =
+      input.assignedHarness !== undefined &&
+      input.assignedAgentId !== undefined;
+    const bothNull =
+      input.assignedHarness === null && input.assignedAgentId === null;
+    const bothValues =
+      typeof input.assignedHarness === "string" &&
+      typeof input.assignedAgentId === "string";
+    if (ownerTouched && (!ownerComplete || (!bothNull && !bothValues))) {
+      context.addIssue({
+        code: "custom",
+        message:
+          "assignedHarness and assignedAgentId must both be values or both be null.",
+      });
+    }
+    if (
+      input.status === undefined &&
+      input.phase === undefined &&
+      !ownerTouched &&
+      input.checkpoint === undefined &&
+      input.evidence === undefined
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "At least one task field must be updated.",
+      });
+    }
+  });
+
+export function createUpdateTask(dependencies: AgentSessionDependencies) {
+  return defineCapability({
+    title: "Update or hand off agent task",
+    description:
+      "Advance a task, record its checkpoint or evidence, or assign it to another harness and agent.",
+    input: updateTaskInput,
+    output: z.object({
+      sessionId: identifierSchema,
+      sessionRevision: z.number().int().min(1),
+      task: agentTaskSchema,
+    }),
+    access: ({ principal }) => hasPermission(principal, "agent-session:write"),
+    timeoutMs: 10_000,
+    annotations: {
+      readOnly: false,
+      destructive: false,
+      idempotent: false,
+      openWorld: false,
+    },
+    async run({ input, context }) {
+      const updated = await mutateSession(
+        dependencies,
+        input.sessionId,
+        context.signal,
+        (current, now) => {
+          const task = current.tasks.find(({ id }) => id === input.taskId);
+          if (task === undefined) {
+            throw new EngineError({
+              code: "EXECUTION_FAILED",
+              message: "Task not found in this agent session.",
+              publicDetails: {
+                sessionId: input.sessionId,
+                taskId: input.taskId,
+              },
+            });
+          }
+          if (task.revision !== input.expectedTaskRevision) {
+            throw new EngineError({
+              code: "EXECUTION_FAILED",
+              message: "The task changed before this update.",
+              publicDetails: {
+                sessionId: input.sessionId,
+                taskId: input.taskId,
+                expectedTaskRevision: input.expectedTaskRevision,
+              },
+            });
+          }
+          let owner: TaskOwner | null = task.owner;
+          if (
+            input.assignedHarness === null &&
+            input.assignedAgentId === null
+          ) {
+            owner = null;
+          } else if (
+            input.assignedHarness !== undefined &&
+            input.assignedHarness !== null &&
+            input.assignedAgentId !== undefined &&
+            input.assignedAgentId !== null
+          ) {
+            owner = {
+              harness: input.assignedHarness,
+              agentId: input.assignedAgentId,
+            };
+          }
+          const changedTask = {
+            ...task,
+            ...(input.status === undefined ? {} : { status: input.status }),
+            ...(input.phase === undefined ? {} : { phase: input.phase }),
+            owner,
+            ...(input.checkpoint === undefined
+              ? {}
+              : { checkpoint: input.checkpoint }),
+            ...(input.evidence === undefined
+              ? {}
+              : { evidence: input.evidence }),
+            revision: task.revision + 1,
+            updatedAt: now,
+          };
+          if (
+            changedTask.status === "completed" &&
+            changedTask.evidence === null
+          ) {
+            throw new EngineError({
+              code: "EXECUTION_FAILED",
+              message: "A completed task requires verification evidence.",
+              publicDetails: {
+                sessionId: input.sessionId,
+                taskId: input.taskId,
+              },
+            });
+          }
+          return {
+            ...current,
+            revision: current.revision + 1,
+            updatedAt: now,
+            tasks: current.tasks.map((candidate) =>
+              candidate.id === input.taskId ? changedTask : candidate,
+            ),
+          };
+        },
+      );
+      const task = updated.tasks.find(({ id }) => id === input.taskId);
+      if (task === undefined) throw new Error("Updated task is unavailable.");
+      return {
+        sessionId: updated.sessionId,
+        sessionRevision: updated.revision,
+        task,
+      };
+    },
+  });
+}

--- a/examples/agent-session-engine/src/cli.ts
+++ b/examples/agent-session-engine/src/cli.ts
@@ -1,0 +1,20 @@
+import { pathToFileURL } from "node:url";
+
+import { runCli } from "@ai-engine/cli";
+
+import { createDefaultAgentSessionEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<number> {
+  return runCli(createDefaultAgentSessionEngine(), {
+    principal: localPrincipal,
+  });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  process.exitCode = await main();
+}

--- a/examples/agent-session-engine/src/direct.ts
+++ b/examples/agent-session-engine/src/direct.ts
@@ -1,0 +1,55 @@
+import { pathToFileURL } from "node:url";
+
+import { createDefaultAgentSessionEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<void> {
+  const sessionId = process.argv[2] ?? "agent-session-demo";
+  const engine = createDefaultAgentSessionEngine();
+  const invocation = { source: "direct", principal: localPrincipal } as const;
+  await engine.invoke(
+    "agent-session.start",
+    {
+      sessionId,
+      objective: "Demonstrate a portable agent session.",
+      workspaceRoot: process.cwd(),
+    },
+    invocation,
+  );
+  const created = await engine.invoke(
+    "agent-session.create-task",
+    {
+      sessionId,
+      taskId: "verify-handoff",
+      title: "Verify that another harness can resume the session",
+      phase: "validation",
+      assignedHarness: "codex",
+      assignedAgentId: "direct-demo-agent",
+    },
+    invocation,
+  );
+  const checkpointed = await engine.invoke(
+    "agent-session.checkpoint",
+    {
+      sessionId,
+      expectedRevision: created.sessionRevision,
+      phase: "validation",
+      status: "paused",
+      checkpoint: "The portable task was created from the direct adapter.",
+      nextAction: "Resume this session from a configured harness.",
+    },
+    invocation,
+  );
+  process.stdout.write(`${JSON.stringify(checkpointed, null, 2)}\n`);
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Agent session direct example failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/agent-session-engine/src/domain/agent-session.ts
+++ b/examples/agent-session-engine/src/domain/agent-session.ts
@@ -1,0 +1,127 @@
+export const MAX_SESSION_TASKS = 256;
+export const MAX_SESSION_EVENTS = 10_000;
+export const MAX_RESUME_TASKS = 20;
+
+export type AgentHarness = "cursor" | "antigravity" | "claude-code" | "codex";
+
+export type SessionPhase =
+  | "discovery"
+  | "planning"
+  | "implementation"
+  | "validation"
+  | "delivery";
+
+export type SessionStatus = "active" | "paused" | "completed";
+export type AgentTaskStatus =
+  | "pending"
+  | "in_progress"
+  | "blocked"
+  | "completed";
+
+export interface TaskOwner {
+  readonly harness: AgentHarness;
+  readonly agentId: string;
+}
+
+export interface AgentTask {
+  readonly id: string;
+  readonly title: string;
+  readonly phase: SessionPhase;
+  readonly status: AgentTaskStatus;
+  readonly owner: TaskOwner | null;
+  readonly checkpoint: string | null;
+  readonly evidence: string | null;
+  readonly revision: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface HarnessSession {
+  readonly harness: AgentHarness;
+  readonly nativeSessionId: string;
+}
+
+export interface AgentHookEvent {
+  readonly id: string;
+  readonly harness: AgentHarness;
+  readonly nativeSessionId: string;
+  readonly eventName: string;
+  readonly observedAt: string;
+  readonly toolName: string | null;
+  readonly nativeAgentId: string | null;
+  readonly nativeTaskId: string | null;
+  readonly outcome: string | null;
+  readonly payloadSha256: string;
+}
+
+export interface AgentSession {
+  readonly sessionId: string;
+  readonly objective: string;
+  readonly workspaceRoot: string;
+  readonly phase: SessionPhase;
+  readonly status: SessionStatus;
+  readonly checkpoint: string | null;
+  readonly nextAction: string | null;
+  readonly revision: number;
+  readonly tasks: ReadonlyArray<AgentTask>;
+  readonly harnessSessions: ReadonlyArray<HarnessSession>;
+  readonly events: ReadonlyArray<AgentHookEvent>;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export function createAgentSession(input: {
+  readonly sessionId: string;
+  readonly objective: string;
+  readonly workspaceRoot: string;
+  readonly createdAt: string;
+}): AgentSession {
+  return {
+    sessionId: input.sessionId,
+    objective: input.objective,
+    workspaceRoot: input.workspaceRoot,
+    phase: "discovery",
+    status: "active",
+    checkpoint: null,
+    nextAction: null,
+    revision: 1,
+    tasks: [],
+    harnessSessions: [],
+    events: [],
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+  };
+}
+
+export function buildResumeContext(session: AgentSession): string {
+  const actionableTasks = session.tasks.filter(
+    ({ status }) => status !== "completed",
+  );
+  const shownTasks = actionableTasks.slice(0, MAX_RESUME_TASKS);
+  const lines = [
+    `Portable agent session: ${session.sessionId}`,
+    `Objective: ${session.objective}`,
+    `Phase: ${session.phase}`,
+    `Status: ${session.status}`,
+    `Workspace: ${session.workspaceRoot}`,
+    `Checkpoint: ${session.checkpoint ?? "None recorded."}`,
+    `Next action: ${session.nextAction ?? "None recorded."}`,
+    "Open tasks:",
+    ...shownTasks.map((task) => {
+      const owner =
+        task.owner === null
+          ? "unassigned"
+          : `${task.owner.harness}/${task.owner.agentId}`;
+      return `- ${task.id} [${task.status}, ${task.phase}, ${owner}]: ${task.title}${
+        task.checkpoint === null ? "" : ` — ${task.checkpoint}`
+      }`;
+    }),
+  ];
+  if (shownTasks.length === 0) lines.push("- None.");
+  if (actionableTasks.length > shownTasks.length) {
+    lines.push(
+      `- ${String(actionableTasks.length - shownTasks.length)} additional task(s) omitted; call agent-session.get for the complete state.`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/examples/agent-session-engine/src/domain/agent-session.ts
+++ b/examples/agent-session-engine/src/domain/agent-session.ts
@@ -1,6 +1,7 @@
 export const MAX_SESSION_TASKS = 256;
 export const MAX_SESSION_EVENTS = 10_000;
 export const MAX_RESUME_TASKS = 20;
+export const MAX_RESUME_CONTEXT_CHARACTERS = 16_000;
 
 export type AgentHarness = "cursor" | "antigravity" | "claude-code" | "codex";
 
@@ -123,5 +124,16 @@ export function buildResumeContext(session: AgentSession): string {
       `- ${String(actionableTasks.length - shownTasks.length)} additional task(s) omitted; call agent-session.get for the complete state.`,
     );
   }
-  return lines.join("\n");
+  const context = lines.join("\n");
+  if (context.length <= MAX_RESUME_CONTEXT_CHARACTERS) return context;
+
+  const notice =
+    "\n- Resume context truncated; call agent-session.get for the complete state.";
+  const prefixLimit = MAX_RESUME_CONTEXT_CHARACTERS - notice.length - 1;
+  let prefix = context.slice(0, prefixLimit);
+  const finalCodeUnit = prefix.charCodeAt(prefix.length - 1);
+  if (finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff) {
+    prefix = prefix.slice(0, -1);
+  }
+  return `${prefix}…${notice}`;
 }

--- a/examples/agent-session-engine/src/engine.ts
+++ b/examples/agent-session-engine/src/engine.ts
@@ -1,0 +1,59 @@
+import { createEngine, type EngineEvent } from "@ai-engine/core";
+
+import type { AgentSessionDependencies } from "./application/ports.js";
+import { createCheckpointSession } from "./capabilities/checkpoint-session.js";
+import { createCreateTask } from "./capabilities/create-task.js";
+import { createGetSession } from "./capabilities/get-session.js";
+import { createRecordHookEvent } from "./capabilities/record-hook-event.js";
+import { createStartSession } from "./capabilities/start-session.js";
+import { createUpdateTask } from "./capabilities/update-task.js";
+import { createFileAgentSessionStore } from "./infrastructure/file-agent-session-store.js";
+
+export interface AgentSessionEngineOptions {
+  readonly onEvent?: (event: EngineEvent) => void | Promise<void>;
+}
+
+export function createAgentSessionEngine(
+  dependencies: AgentSessionDependencies,
+  options: AgentSessionEngineOptions = {},
+) {
+  return createEngine({
+    name: "agent-session-engine",
+    version: "0.1.0",
+    capabilities: {
+      "agent-session.start": createStartSession(dependencies),
+      "agent-session.record-hook-event": createRecordHookEvent(dependencies),
+      "agent-session.create-task": createCreateTask(dependencies),
+      "agent-session.update-task": createUpdateTask(dependencies),
+      "agent-session.checkpoint": createCheckpointSession(dependencies),
+      "agent-session.get": createGetSession(dependencies),
+    },
+    ...(options.onEvent === undefined ? {} : { onEvent: options.onEvent }),
+  });
+}
+
+export const AGENT_SESSION_DATA_DIRECTORY_ENV = "AGENT_SESSION_ENGINE_DATA_DIR";
+
+export function resolveAgentSessionDataDirectory(
+  environment: NodeJS.ProcessEnv = process.env,
+  cwd = process.cwd(),
+): string {
+  const configured = environment[AGENT_SESSION_DATA_DIRECTORY_ENV];
+  return configured === undefined || configured.trim() === ""
+    ? `${cwd}/.agent-sessions`
+    : configured;
+}
+
+export function createDefaultAgentSessionEngine(
+  environment: NodeJS.ProcessEnv = process.env,
+  cwd = process.cwd(),
+) {
+  return createAgentSessionEngine({
+    sessions: createFileAgentSessionStore({
+      dataDirectory: resolveAgentSessionDataDirectory(environment, cwd),
+    }),
+    now: () => new Date(),
+  });
+}
+
+export const engine = createDefaultAgentSessionEngine();

--- a/examples/agent-session-engine/src/hook-cli.ts
+++ b/examples/agent-session-engine/src/hook-cli.ts
@@ -1,0 +1,77 @@
+import { pathToFileURL } from "node:url";
+
+import type { AgentHarness } from "./domain/agent-session.js";
+import { createDefaultAgentSessionEngine } from "./engine.js";
+import { runHookCommand } from "./hooks/hook-adapter.js";
+import { hookPrincipal } from "./local-principal.js";
+
+export const AGENT_SESSION_ID_ENV = "AGENT_SESSION_ENGINE_SESSION_ID";
+export const MAX_HOOK_INPUT_BYTES = 4_194_304;
+
+const supportedHarnesses: ReadonlySet<string> = new Set([
+  "cursor",
+  "antigravity",
+  "claude-code",
+  "codex",
+]);
+
+async function readHookInput(): Promise<string> {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let decoded = "";
+  let bytes = 0;
+  for await (const chunk of process.stdin) {
+    const buffer =
+      typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+    bytes += buffer.byteLength;
+    if (bytes > MAX_HOOK_INPUT_BYTES) {
+      throw new Error("Hook input exceeds 4194304 bytes.");
+    }
+    decoded += decoder.decode(buffer, { stream: true });
+  }
+  decoded += decoder.decode();
+  return decoded;
+}
+
+export async function main(): Promise<number> {
+  const [harnessArgument, eventName] = process.argv.slice(2);
+  if (
+    harnessArgument === undefined ||
+    !supportedHarnesses.has(harnessArgument)
+  ) {
+    process.stderr.write(
+      "Usage: hook-cli <cursor|antigravity|claude-code|codex> [event-name]\n",
+    );
+    return 2;
+  }
+  const harness = harnessArgument as AgentHarness;
+  try {
+    return await runHookCommand(harness, {
+      rawInput: await readHookInput(),
+      ...(process.env[AGENT_SESSION_ID_ENV] === undefined
+        ? {}
+        : { portableSessionId: process.env[AGENT_SESSION_ID_ENV] }),
+      ...(eventName === undefined ? {} : { eventName }),
+      observedAt: new Date().toISOString(),
+      cwd: process.cwd(),
+      engine: createDefaultAgentSessionEngine(),
+      principal: hookPrincipal,
+      writeStdout: (text) => {
+        process.stdout.write(text);
+      },
+      writeStderr: (text) => {
+        process.stderr.write(text);
+      },
+    });
+  } catch {
+    process.stderr.write("Agent session hook recording failed.\n");
+    return 1;
+  }
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  process.exitCode = await main();
+}

--- a/examples/agent-session-engine/src/hooks/hook-adapter.ts
+++ b/examples/agent-session-engine/src/hooks/hook-adapter.ts
@@ -1,0 +1,341 @@
+import { createHash } from "node:crypto";
+
+import { runCli } from "@ai-engine/cli";
+import type { Principal } from "@ai-engine/core";
+
+import type { AgentHarness } from "../domain/agent-session.js";
+import type { createAgentSessionEngine } from "../engine.js";
+
+type AgentSessionEngine = ReturnType<typeof createAgentSessionEngine>;
+type JsonRecord = Record<string, unknown>;
+
+export interface NormalizeHookEventOptions {
+  readonly portableSessionId?: string;
+  readonly eventName?: string;
+  readonly observedAt: string;
+  readonly cwd?: string;
+}
+
+export interface NormalizedHookEvent {
+  readonly sessionId: string;
+  readonly harness: AgentHarness;
+  readonly nativeSessionId: string;
+  readonly eventId: string;
+  readonly eventName: string;
+  readonly observedAt: string;
+  readonly workspaceRoot: string;
+  readonly toolName: string | null;
+  readonly nativeAgentId: string | null;
+  readonly nativeTaskId: string | null;
+  readonly outcome: string | null;
+  readonly payloadSha256: string;
+}
+
+export interface RunHookCommandOptions {
+  readonly rawInput: string;
+  readonly portableSessionId?: string;
+  readonly eventName?: string;
+  readonly observedAt: string;
+  readonly cwd?: string;
+  readonly engine: AgentSessionEngine;
+  readonly principal: Principal;
+  readonly writeStdout: (text: string) => void | Promise<void>;
+  readonly writeStderr: (text: string) => void | Promise<void>;
+}
+
+interface RecordHookResult {
+  readonly recorded: boolean;
+  readonly resumed: boolean;
+  readonly resumeContext: string;
+  readonly sessionId: string;
+  readonly sessionRevision: number;
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function firstString(
+  object: JsonRecord,
+  keys: ReadonlyArray<string>,
+): string | null {
+  for (const key of keys) {
+    const value = object[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function firstNumber(
+  object: JsonRecord,
+  keys: ReadonlyArray<string>,
+): number | null {
+  for (const key of keys) {
+    const value = object[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function firstWorkspace(object: JsonRecord, fallback: string): string {
+  for (const key of ["workspace_roots", "workspacePaths"]) {
+    const value = object[key];
+    if (Array.isArray(value)) {
+      const first = value.find(
+        (candidate): candidate is string =>
+          typeof candidate === "string" && candidate.trim() !== "",
+      );
+      if (first !== undefined) return first.trim().slice(0, 2_000);
+    }
+  }
+  return (
+    firstString(object, ["cwd", "workspace_root", "workspaceRoot"]) ?? fallback
+  ).slice(0, 2_000);
+}
+
+function bounded(value: string | null, maximum: number): string | null {
+  return value === null ? null : value.slice(0, maximum);
+}
+
+const knownOutcomes: ReadonlySet<string> = new Set([
+  "startup",
+  "resume",
+  "clear",
+  "compact",
+  "manual",
+  "auto",
+  "completed",
+  "aborted",
+  "success",
+  "failure",
+  "error",
+  "other",
+  "logout",
+  "prompt_input_exit",
+  "bypass_permissions_disabled",
+  "model_stop",
+  "max_steps_exceeded",
+  "rate_limit",
+  "authentication_failed",
+  "billing_error",
+  "invalid_request",
+  "server_error",
+  "max_output_tokens",
+]);
+
+function payloadOutcome(object: JsonRecord): string | null {
+  const error = object.error;
+  if (typeof error === "string" && error !== "") return "error";
+  const candidate = firstString(object, [
+    "source",
+    "reason",
+    "status",
+    "terminationReason",
+    "termination_reason",
+  ]);
+  return candidate === null
+    ? null
+    : knownOutcomes.has(candidate)
+      ? candidate
+      : "other";
+}
+
+function defaultPortableSessionId(
+  harness: AgentHarness,
+  nativeSessionId: string,
+): string {
+  const component = /^[A-Za-z0-9][A-Za-z0-9._-]{0,95}$/u.test(nativeSessionId)
+    ? nativeSessionId
+    : createHash("sha256").update(nativeSessionId).digest("hex").slice(0, 32);
+  return `${harness}:${component}`;
+}
+
+export function normalizeHookEvent(
+  harness: AgentHarness,
+  rawInput: string,
+  options: NormalizeHookEventOptions,
+): NormalizedHookEvent {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawInput) as unknown;
+  } catch (cause) {
+    throw new Error("Hook input must be valid JSON.", { cause });
+  }
+  const input = asRecord(parsed);
+  if (input === null) throw new Error("Hook input must be a JSON object.");
+
+  const payloadSha256 = createHash("sha256").update(rawInput).digest("hex");
+  const nativeSessionId = bounded(
+    firstString(input, ["session_id", "conversation_id", "conversationId"]),
+    256,
+  );
+  const resolvedNativeSessionId = nativeSessionId ?? "unavailable";
+  const eventName = bounded(
+    options.eventName ??
+      firstString(input, ["hook_event_name", "hookEventName"]) ??
+      "unknown",
+    128,
+  ) as string;
+  const toolCall = asRecord(input.toolCall);
+  const toolName = bounded(
+    firstString(input, ["tool_name", "toolName"]) ??
+      (toolCall === null ? null : firstString(toolCall, ["name"])),
+    256,
+  );
+  const occurrence = [
+    firstString(input, [
+      "tool_use_id",
+      "generation_id",
+      "turn_id",
+      "task_id",
+      "agent_id",
+    ]),
+    firstNumber(input, ["stepIdx", "invocationNum", "executionNum"]),
+  ]
+    .filter((value) => value !== null)
+    .join(":");
+  const eventDigest = createHash("sha256")
+    .update(
+      [
+        harness,
+        resolvedNativeSessionId,
+        eventName,
+        occurrence,
+        payloadSha256,
+      ].join("\0"),
+    )
+    .digest("hex");
+
+  return {
+    sessionId:
+      options.portableSessionId ??
+      defaultPortableSessionId(harness, resolvedNativeSessionId),
+    harness,
+    nativeSessionId: resolvedNativeSessionId,
+    eventId: `evt_${eventDigest.slice(0, 32)}`,
+    eventName,
+    observedAt: options.observedAt,
+    workspaceRoot: firstWorkspace(input, options.cwd ?? process.cwd()),
+    toolName,
+    nativeAgentId: bounded(
+      firstString(input, ["agent_id", "teammate_name", "teammateName"]),
+      256,
+    ),
+    nativeTaskId: bounded(firstString(input, ["task_id", "taskId"]), 256),
+    outcome: payloadOutcome(input),
+    payloadSha256,
+  };
+}
+
+function parseRecordHookResult(encoded: string): RecordHookResult {
+  const parsed = JSON.parse(encoded) as unknown;
+  const result = asRecord(parsed);
+  if (
+    result === null ||
+    typeof result.recorded !== "boolean" ||
+    typeof result.resumed !== "boolean" ||
+    typeof result.resumeContext !== "string" ||
+    typeof result.sessionId !== "string" ||
+    typeof result.sessionRevision !== "number"
+  ) {
+    throw new Error("The hook capability returned an invalid result.");
+  }
+  return {
+    recorded: result.recorded,
+    resumed: result.resumed,
+    resumeContext: result.resumeContext,
+    sessionId: result.sessionId,
+    sessionRevision: result.sessionRevision,
+  };
+}
+
+function hookOutput(
+  harness: AgentHarness,
+  eventName: string,
+  input: JsonRecord,
+  result: RecordHookResult,
+): JsonRecord {
+  const resumeContext = result.resumed ? result.resumeContext : null;
+  if (
+    (harness === "codex" || harness === "claude-code") &&
+    eventName === "SessionStart" &&
+    resumeContext !== null
+  ) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: resumeContext,
+      },
+    };
+  }
+  if (
+    harness === "cursor" &&
+    eventName === "sessionStart" &&
+    resumeContext !== null
+  ) {
+    return { additional_context: resumeContext };
+  }
+  if (harness === "antigravity") {
+    if (eventName === "PreInvocation") {
+      const invocationNumber = input.invocationNum;
+      return {
+        injectSteps:
+          invocationNumber === 0 && resumeContext !== null
+            ? [{ ephemeralMessage: resumeContext }]
+            : [],
+      };
+    }
+    if (eventName === "PostInvocation") {
+      return { injectSteps: [], terminationBehavior: "" };
+    }
+    if (eventName === "Stop") return { decision: "stop" };
+  }
+  return {};
+}
+
+export async function runHookCommand(
+  harness: AgentHarness,
+  options: RunHookCommandOptions,
+): Promise<number> {
+  const normalized = normalizeHookEvent(harness, options.rawInput, {
+    ...(options.portableSessionId === undefined
+      ? {}
+      : { portableSessionId: options.portableSessionId }),
+    ...(options.eventName === undefined
+      ? {}
+      : { eventName: options.eventName }),
+    observedAt: options.observedAt,
+    ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+  });
+  let capabilityOutput = "";
+  const code = await runCli(options.engine, {
+    argv: [
+      "run",
+      "agent-session.record-hook-event",
+      "--input",
+      JSON.stringify(normalized),
+    ],
+    principal: options.principal,
+    io: {
+      readStdin: async () => "",
+      writeStdout: (text) => {
+        capabilityOutput += text;
+      },
+      writeStderr: options.writeStderr,
+    },
+  });
+  if (code !== 0) return code;
+
+  const rawParsed = JSON.parse(options.rawInput) as unknown;
+  const input = asRecord(rawParsed);
+  if (input === null) throw new Error("Hook input must be a JSON object.");
+  const result = parseRecordHookResult(capabilityOutput);
+  await options.writeStdout(
+    JSON.stringify(hookOutput(harness, normalized.eventName, input, result)),
+  );
+  return 0;
+}

--- a/examples/agent-session-engine/src/hooks/hook-adapter.ts
+++ b/examples/agent-session-engine/src/hooks/hook-adapter.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { runCli } from "@ai-engine/cli";
 import type { Principal } from "@ai-engine/core";
@@ -204,7 +204,9 @@ export function normalizeHookEvent(
         harness,
         resolvedNativeSessionId,
         eventName,
-        occurrence,
+        occurrence === ""
+          ? `delivery:${randomUUID()}`
+          : `occurrence:${occurrence}`,
         payloadSha256,
       ].join("\0"),
     )

--- a/examples/agent-session-engine/src/infrastructure/file-agent-session-store.ts
+++ b/examples/agent-session-engine/src/infrastructure/file-agent-session-store.ts
@@ -1,7 +1,15 @@
-import { mkdir, open, readFile, rename, stat, unlink } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  link,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+} from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { randomUUID } from "node:crypto";
 
 import type {
   AgentSessionStore,
@@ -22,6 +30,11 @@ export interface FileAgentSessionStoreOptions {
   readonly staleLockMs?: number;
 }
 
+interface LockRecord {
+  readonly ownerId: string | null;
+  readonly pid: number;
+}
+
 function errorCode(error: unknown): string | undefined {
   return error !== null &&
     typeof error === "object" &&
@@ -33,6 +46,37 @@ function errorCode(error: unknown): string | undefined {
 
 function ensureNotAborted(signal: AbortSignal | undefined): void {
   signal?.throwIfAborted();
+}
+
+function parseLockRecord(encoded: string): LockRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(encoded) as unknown;
+  } catch {
+    return null;
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    !("pid" in parsed) ||
+    !Number.isSafeInteger(parsed.pid) ||
+    (parsed.pid as number) < 1 ||
+    (parsed.pid as number) > 2_147_483_647
+  ) {
+    return null;
+  }
+  const ownerId = "ownerId" in parsed ? parsed.ownerId : null;
+  if (ownerId !== null && typeof ownerId !== "string") return null;
+  return { ownerId, pid: parsed.pid as number };
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
 }
 
 export function createFileAgentSessionStore(
@@ -48,7 +92,8 @@ export function createFileAgentSessionStore(
     throw new TypeError("staleLockMs must be a positive integer.");
   }
 
-  const fileStem = (sessionId: string) => encodeURIComponent(sessionId);
+  const fileStem = (sessionId: string) =>
+    createHash("sha256").update(sessionId).digest("hex");
   const pathsFor = (sessionId: string) => ({
     state: join(dataDirectory, `${fileStem(sessionId)}.json`),
     lock: join(dataDirectory, `${fileStem(sessionId)}.lock`),
@@ -82,6 +127,11 @@ export function createFileAgentSessionStore(
     try {
       const lockStat = await stat(lockPath);
       if (Date.now() - lockStat.mtimeMs <= staleLockMs) return;
+      const encoded = await readFile(lockPath, "utf8");
+      const record = parseLockRecord(encoded);
+      if (record !== null && processIsAlive(record.pid)) return;
+      const confirmation = await readFile(lockPath, "utf8");
+      if (confirmation !== encoded) return;
       await unlink(lockPath);
     } catch (error) {
       if (errorCode(error) !== "ENOENT") throw error;
@@ -95,44 +145,75 @@ export function createFileAgentSessionStore(
   ): Promise<Result> => {
     await mkdir(dataDirectory, { recursive: true, mode: 0o700 });
     const { lock } = pathsFor(sessionId);
+    const ownerId = randomUUID();
+    const lockCandidate = join(
+      dataDirectory,
+      `.${fileStem(sessionId)}.${ownerId}.lock-candidate`,
+    );
     const deadline = Date.now() + lockTimeoutMs;
     let acquired = false;
-    while (!acquired) {
-      ensureNotAborted(storeOptions?.signal);
+    let candidateCreated = false;
+    try {
+      const candidateHandle = await open(lockCandidate, "wx", 0o600);
+      candidateCreated = true;
       try {
-        const handle = await open(lock, "wx", 0o600);
+        await candidateHandle.writeFile(
+          `${JSON.stringify({ ownerId, pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+        );
+        await candidateHandle.sync();
+      } finally {
+        await candidateHandle.close();
+      }
+
+      while (!acquired) {
+        ensureNotAborted(storeOptions?.signal);
         try {
-          await handle.writeFile(
-            `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
-          );
-          await handle.sync();
-        } finally {
-          await handle.close();
+          await link(lockCandidate, lock);
+          acquired = true;
+          try {
+            await unlink(lockCandidate);
+            candidateCreated = false;
+          } catch {
+            // The owner link is complete; final cleanup retries the candidate.
+          }
+        } catch (error) {
+          if (errorCode(error) !== "EEXIST") throw error;
+          await removeStaleLock(lock);
+          if (Date.now() >= deadline) {
+            throw new Error(
+              "Timed out while waiting for the agent session lock.",
+            );
+          }
+          await delay(LOCK_RETRY_MS, undefined, {
+            ...(storeOptions?.signal === undefined
+              ? {}
+              : { signal: storeOptions.signal }),
+          });
         }
-        acquired = true;
+      }
+
+      const release = async (): Promise<void> => {
+        const record = parseLockRecord(await readFile(lock, "utf8"));
+        if (record?.ownerId !== ownerId) {
+          throw new Error("Agent session lock ownership was lost.");
+        }
+        await unlink(lock);
+      };
+      try {
+        ensureNotAborted(storeOptions?.signal);
+        const result = await operation();
+        await release();
+        return result;
       } catch (error) {
-        if (errorCode(error) !== "EEXIST") throw error;
-        await removeStaleLock(lock);
-        if (Date.now() >= deadline) {
-          throw new Error(
-            "Timed out while waiting for the agent session lock.",
-          );
-        }
-        await delay(LOCK_RETRY_MS, undefined, {
-          ...(storeOptions?.signal === undefined
-            ? {}
-            : { signal: storeOptions.signal }),
+        await release().catch(() => undefined);
+        throw error;
+      }
+    } finally {
+      if (candidateCreated) {
+        await unlink(lockCandidate).catch((error: unknown) => {
+          if (errorCode(error) !== "ENOENT") throw error;
         });
       }
-    }
-
-    try {
-      ensureNotAborted(storeOptions?.signal);
-      return await operation();
-    } finally {
-      await unlink(lock).catch((error: unknown) => {
-        if (errorCode(error) !== "ENOENT") throw error;
-      });
     }
   };
 

--- a/examples/agent-session-engine/src/infrastructure/file-agent-session-store.ts
+++ b/examples/agent-session-engine/src/infrastructure/file-agent-session-store.ts
@@ -1,0 +1,187 @@
+import { mkdir, open, readFile, rename, stat, unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { randomUUID } from "node:crypto";
+
+import type {
+  AgentSessionStore,
+  CreateSessionResult,
+  SaveSessionResult,
+  StoreOptions,
+} from "../application/ports.js";
+import { agentSessionSchema } from "../application/session-schema.js";
+import type { AgentSession } from "../domain/agent-session.js";
+
+const LOCK_RETRY_MS = 10;
+const DEFAULT_LOCK_TIMEOUT_MS = 2_000;
+const DEFAULT_STALE_LOCK_MS = 30_000;
+
+export interface FileAgentSessionStoreOptions {
+  readonly dataDirectory: string;
+  readonly lockTimeoutMs?: number;
+  readonly staleLockMs?: number;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function ensureNotAborted(signal: AbortSignal | undefined): void {
+  signal?.throwIfAborted();
+}
+
+export function createFileAgentSessionStore(
+  options: FileAgentSessionStoreOptions,
+): AgentSessionStore {
+  const dataDirectory = resolve(options.dataDirectory);
+  const lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+  if (!Number.isInteger(lockTimeoutMs) || lockTimeoutMs < 1) {
+    throw new TypeError("lockTimeoutMs must be a positive integer.");
+  }
+  if (!Number.isInteger(staleLockMs) || staleLockMs < 1) {
+    throw new TypeError("staleLockMs must be a positive integer.");
+  }
+
+  const fileStem = (sessionId: string) => encodeURIComponent(sessionId);
+  const pathsFor = (sessionId: string) => ({
+    state: join(dataDirectory, `${fileStem(sessionId)}.json`),
+    lock: join(dataDirectory, `${fileStem(sessionId)}.lock`),
+  });
+
+  const read = async (sessionId: string): Promise<AgentSession | null> => {
+    const { state } = pathsFor(sessionId);
+    let encoded: string;
+    try {
+      encoded = await readFile(state, "utf8");
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(encoded) as unknown;
+    } catch (cause) {
+      throw new Error("The persisted agent session is not valid JSON.", {
+        cause,
+      });
+    }
+    const result = agentSessionSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error("The persisted agent session does not match its schema.");
+    }
+    return result.data;
+  };
+
+  const removeStaleLock = async (lockPath: string): Promise<void> => {
+    try {
+      const lockStat = await stat(lockPath);
+      if (Date.now() - lockStat.mtimeMs <= staleLockMs) return;
+      await unlink(lockPath);
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+  };
+
+  const withLock = async <Result>(
+    sessionId: string,
+    storeOptions: StoreOptions | undefined,
+    operation: () => Promise<Result>,
+  ): Promise<Result> => {
+    await mkdir(dataDirectory, { recursive: true, mode: 0o700 });
+    const { lock } = pathsFor(sessionId);
+    const deadline = Date.now() + lockTimeoutMs;
+    let acquired = false;
+    while (!acquired) {
+      ensureNotAborted(storeOptions?.signal);
+      try {
+        const handle = await open(lock, "wx", 0o600);
+        try {
+          await handle.writeFile(
+            `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+          );
+          await handle.sync();
+        } finally {
+          await handle.close();
+        }
+        acquired = true;
+      } catch (error) {
+        if (errorCode(error) !== "EEXIST") throw error;
+        await removeStaleLock(lock);
+        if (Date.now() >= deadline) {
+          throw new Error(
+            "Timed out while waiting for the agent session lock.",
+          );
+        }
+        await delay(LOCK_RETRY_MS, undefined, {
+          ...(storeOptions?.signal === undefined
+            ? {}
+            : { signal: storeOptions.signal }),
+        });
+      }
+    }
+
+    try {
+      ensureNotAborted(storeOptions?.signal);
+      return await operation();
+    } finally {
+      await unlink(lock).catch((error: unknown) => {
+        if (errorCode(error) !== "ENOENT") throw error;
+      });
+    }
+  };
+
+  const write = async (session: AgentSession): Promise<void> => {
+    const validated = agentSessionSchema.parse(session);
+    const { state } = pathsFor(session.sessionId);
+    const temporary = join(
+      dataDirectory,
+      `.${fileStem(session.sessionId)}.${randomUUID()}.tmp`,
+    );
+    const handle = await open(temporary, "wx", 0o600);
+    let closed = false;
+    try {
+      await handle.writeFile(`${JSON.stringify(validated, null, 2)}\n`);
+      await handle.sync();
+      await handle.close();
+      closed = true;
+      await rename(temporary, state);
+    } catch (error) {
+      if (!closed) await handle.close().catch(() => undefined);
+      await unlink(temporary).catch(() => undefined);
+      throw error;
+    }
+  };
+
+  return {
+    async create(session, storeOptions): Promise<CreateSessionResult> {
+      return withLock(session.sessionId, storeOptions, async () => {
+        if ((await read(session.sessionId)) !== null) return "exists";
+        await write(session);
+        return "created";
+      });
+    },
+    async findById(sessionId, storeOptions) {
+      ensureNotAborted(storeOptions?.signal);
+      return read(sessionId);
+    },
+    async save(
+      session,
+      expectedRevision,
+      storeOptions,
+    ): Promise<SaveSessionResult> {
+      return withLock(session.sessionId, storeOptions, async () => {
+        const current = await read(session.sessionId);
+        if (current === null) return "missing";
+        if (current.revision !== expectedRevision) return "conflict";
+        await write(session);
+        return "saved";
+      });
+    },
+  };
+}

--- a/examples/agent-session-engine/src/local-principal.ts
+++ b/examples/agent-session-engine/src/local-principal.ts
@@ -1,0 +1,19 @@
+import type { Principal } from "@ai-engine/core";
+
+export const localPrincipal: Principal = Object.freeze({
+  id: "local:agent-session-coordinator",
+  attributes: Object.freeze({
+    permissions: Object.freeze([
+      "agent-session:read",
+      "agent-session:write",
+      "agent-session:hooks",
+    ]),
+  }),
+});
+
+export const hookPrincipal: Principal = Object.freeze({
+  id: "local:agent-session-hook",
+  attributes: Object.freeze({
+    permissions: Object.freeze(["agent-session:hooks"]),
+  }),
+});

--- a/examples/agent-session-engine/src/mcp-http.ts
+++ b/examples/agent-session-engine/src/mcp-http.ts
@@ -1,0 +1,61 @@
+import { pathToFileURL } from "node:url";
+
+import { type McpHttpServerHandle, serveMcpHttp } from "@ai-engine/mcp";
+
+import { createDefaultAgentSessionEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export interface AgentSessionMcpHttpOptions {
+  readonly expectedBearerToken: string;
+  readonly host?: string;
+  readonly port?: number;
+}
+
+export async function startAgentSessionMcpHttp(
+  options: AgentSessionMcpHttpOptions,
+): Promise<McpHttpServerHandle> {
+  return serveMcpHttp(createDefaultAgentSessionEngine(), {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.port === undefined ? {} : { port: options.port }),
+    auth: {
+      mode: "required",
+      authenticate(request) {
+        return request.headers.get("authorization") ===
+          `Bearer ${options.expectedBearerToken}`
+          ? localPrincipal
+          : null;
+      },
+    },
+  });
+}
+
+export async function main(): Promise<McpHttpServerHandle> {
+  const expectedBearerToken = process.env.AGENT_SESSION_ENGINE_BEARER_TOKEN;
+  if (expectedBearerToken === undefined || expectedBearerToken === "") {
+    throw new Error("AGENT_SESSION_ENGINE_BEARER_TOKEN is required.");
+  }
+  const configuredPort = process.env.PORT;
+  const port = configuredPort === undefined ? 3000 : Number(configuredPort);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error("PORT must be an integer between 0 and 65535.");
+  }
+  return startAgentSessionMcpHttp({ expectedBearerToken, port });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main()
+    .then((server) => {
+      const address = server.address();
+      process.stderr.write(
+        `Agent session MCP HTTP adapter listening on host ${address.host}, port ${address.port}\n`,
+      );
+    })
+    .catch(() => {
+      process.stderr.write("Agent session MCP HTTP adapter failed to start.\n");
+      process.exitCode = 1;
+    });
+}

--- a/examples/agent-session-engine/src/mcp-stdio.ts
+++ b/examples/agent-session-engine/src/mcp-stdio.ts
@@ -1,0 +1,23 @@
+import { pathToFileURL } from "node:url";
+
+import { serveMcpStdio } from "@ai-engine/mcp";
+
+import { createDefaultAgentSessionEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<void> {
+  await serveMcpStdio(createDefaultAgentSessionEngine(), {
+    principal: localPrincipal,
+  });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Agent session MCP stdio adapter failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/agent-session-engine/test/agent-session-engine.test.ts
+++ b/examples/agent-session-engine/test/agent-session-engine.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdtemp, readdir, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -6,6 +7,7 @@ import type { EngineError, EngineEvent, Principal } from "@ai-engine/core";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createAgentSessionEngine } from "../src/engine.js";
+import { createAgentSession } from "../src/domain/agent-session.js";
 import { createFileAgentSessionStore } from "../src/infrastructure/file-agent-session-store.js";
 
 const principal: Principal = {
@@ -154,6 +156,125 @@ describe("the agent session engine example", () => {
       checkpoint:
         "The contract tests are red; implement the file adapter next.",
     });
+  });
+
+  it("bounds resume context across maximum valid fields without failing after persistence", async () => {
+    const { create, engine } = await createTestEngine();
+    await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "bounded-resume-context",
+        objective: "o".repeat(2_000),
+        workspaceRoot: `/${"w".repeat(1_999)}`,
+      },
+      invocation,
+    );
+    await engine.invoke(
+      "agent-session.create-task",
+      {
+        sessionId: "bounded-resume-context",
+        taskId: "large-checkpoint-task",
+        title: "t".repeat(200),
+        phase: "implementation",
+      },
+      invocation,
+    );
+    await engine.invoke(
+      "agent-session.update-task",
+      {
+        sessionId: "bounded-resume-context",
+        taskId: "large-checkpoint-task",
+        expectedTaskRevision: 1,
+        checkpoint: "c".repeat(4_000),
+      },
+      invocation,
+    );
+
+    const checkpointed = await engine.invoke(
+      "agent-session.checkpoint",
+      {
+        sessionId: "bounded-resume-context",
+        expectedRevision: 3,
+        phase: "implementation",
+        status: "paused",
+        checkpoint: "s".repeat(4_000),
+        nextAction: "n".repeat(4_000),
+      },
+      invocation,
+    );
+    const resumed = await create().invoke(
+      "agent-session.get",
+      { sessionId: "bounded-resume-context" },
+      invocation,
+    );
+
+    expect(checkpointed.revision).toBe(4);
+    expect(checkpointed.resumeContext.length).toBeLessThanOrEqual(16_000);
+    expect(checkpointed.resumeContext).toContain("Next action: nnnn");
+    expect(resumed).toEqual(checkpointed);
+  });
+
+  it("keeps live stale-looking locks and recovers locks whose owner exited", async () => {
+    const dataDirectory = await mkdtemp(join(tmpdir(), "agent-session-lock-"));
+    temporaryDirectories.push(dataDirectory);
+    const sessionId = "lock-ownership";
+    const fileStem = createHash("sha256").update(sessionId).digest("hex");
+    const lockPath = join(dataDirectory, `${fileStem}.lock`);
+    const oldTime = new Date("2026-07-28T00:00:00.000Z");
+    const session = createAgentSession({
+      sessionId,
+      objective: "Preserve lock ownership.",
+      workspaceRoot: "/workspace/project",
+      createdAt: "2026-07-28T12:00:00.000Z",
+    });
+    const store = createFileAgentSessionStore({
+      dataDirectory,
+      lockTimeoutMs: 25,
+      staleLockMs: 1,
+    });
+
+    await writeFile(
+      lockPath,
+      `${JSON.stringify({ ownerId: "live-owner", pid: process.pid, acquiredAt: oldTime.toISOString() })}\n`,
+      { mode: 0o600 },
+    );
+    await utimes(lockPath, oldTime, oldTime);
+    await expect(store.create(session)).rejects.toThrow(
+      "Timed out while waiting for the agent session lock.",
+    );
+
+    await writeFile(
+      lockPath,
+      `${JSON.stringify({ ownerId: "exited-owner", pid: 2_147_483_647, acquiredAt: oldTime.toISOString() })}\n`,
+      { mode: 0o600 },
+    );
+    await utimes(lockPath, oldTime, oldTime);
+    await expect(store.create(session)).resolves.toBe("created");
+  });
+
+  it("persists every schema-valid maximum-length session identifier", async () => {
+    const { create, dataDirectory, engine } = await createTestEngine();
+    const sessionId = `a${":".repeat(127)}`;
+
+    await expect(
+      engine.invoke(
+        "agent-session.start",
+        {
+          sessionId,
+          objective: "Use a bounded filesystem key.",
+          workspaceRoot: "/workspace/project",
+        },
+        invocation,
+      ),
+    ).resolves.toMatchObject({ sessionId });
+    await expect(
+      create().invoke("agent-session.get", { sessionId }, invocation),
+    ).resolves.toMatchObject({ sessionId });
+
+    const filenames = await readdir(dataDirectory);
+    expect(filenames).toEqual([
+      `${createHash("sha256").update(sessionId).digest("hex")}.json`,
+    ]);
   });
 
   it("allows only one concurrent update from the same task revision", async () => {

--- a/examples/agent-session-engine/test/agent-session-engine.test.ts
+++ b/examples/agent-session-engine/test/agent-session-engine.test.ts
@@ -1,0 +1,459 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { EngineError, EngineEvent, Principal } from "@ai-engine/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createAgentSessionEngine } from "../src/engine.js";
+import { createFileAgentSessionStore } from "../src/infrastructure/file-agent-session-store.js";
+
+const principal: Principal = {
+  id: "agent:coordinator",
+  attributes: {
+    permissions: [
+      "agent-session:read",
+      "agent-session:write",
+      "agent-session:hooks",
+    ],
+  },
+};
+
+const invocation = { source: "direct", principal } as const;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function createTestEngine(events?: EngineEvent[]) {
+  const dataDirectory = await mkdtemp(join(tmpdir(), "agent-session-engine-"));
+  temporaryDirectories.push(dataDirectory);
+  const create = () =>
+    createAgentSessionEngine(
+      {
+        sessions: createFileAgentSessionStore({ dataDirectory }),
+        now: () => new Date("2026-07-28T12:00:00.000Z"),
+      },
+      events === undefined
+        ? undefined
+        : {
+            onEvent(event) {
+              events.push(event);
+            },
+          },
+    );
+  const store = createFileAgentSessionStore({ dataDirectory });
+  const engine = create();
+  return { dataDirectory, create, engine, store };
+}
+
+describe("the agent session engine example", () => {
+  it("persists a phase, tasks, checkpoints, and an owner handoff across engine processes", async () => {
+    const { create, engine } = await createTestEngine();
+
+    const started = await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "delivery-42",
+        objective: "Deliver the portable agent session example.",
+        workspaceRoot: "/workspace/ai-engines",
+      },
+      invocation,
+    );
+    expect(started).toMatchObject({
+      sessionId: "delivery-42",
+      phase: "discovery",
+      status: "active",
+      revision: 1,
+      tasks: [],
+      eventCount: 0,
+    });
+
+    const created = await engine.invoke(
+      "agent-session.create-task",
+      {
+        sessionId: "delivery-42",
+        taskId: "implement-store",
+        title: "Implement the durable store",
+        phase: "implementation",
+        assignedHarness: "codex",
+        assignedAgentId: "agent-a",
+      },
+      invocation,
+    );
+    expect(created.task).toMatchObject({
+      id: "implement-store",
+      status: "pending",
+      revision: 1,
+      owner: { harness: "codex", agentId: "agent-a" },
+    });
+
+    const inProgress = await engine.invoke(
+      "agent-session.update-task",
+      {
+        sessionId: "delivery-42",
+        taskId: "implement-store",
+        expectedTaskRevision: 1,
+        status: "in_progress",
+        checkpoint:
+          "The contract tests are red; implement the file adapter next.",
+      },
+      invocation,
+    );
+    expect(inProgress.task).toMatchObject({
+      status: "in_progress",
+      revision: 2,
+    });
+
+    const checkpointed = await engine.invoke(
+      "agent-session.checkpoint",
+      {
+        sessionId: "delivery-42",
+        expectedRevision: inProgress.sessionRevision,
+        phase: "implementation",
+        status: "paused",
+        checkpoint: "The domain and contract tests are complete.",
+        nextAction: "Implement and verify the file-backed adapter.",
+      },
+      invocation,
+    );
+
+    const resumed = await create().invoke(
+      "agent-session.get",
+      { sessionId: "delivery-42" },
+      invocation,
+    );
+    expect(resumed).toMatchObject({
+      phase: "implementation",
+      status: "paused",
+      revision: checkpointed.revision,
+      checkpoint: "The domain and contract tests are complete.",
+      nextAction: "Implement and verify the file-backed adapter.",
+    });
+    expect(resumed.resumeContext).toContain("Implement and verify");
+
+    const handedOff = await create().invoke(
+      "agent-session.update-task",
+      {
+        sessionId: "delivery-42",
+        taskId: "implement-store",
+        expectedTaskRevision: 2,
+        assignedHarness: "claude-code",
+        assignedAgentId: "agent-b",
+      },
+      invocation,
+    );
+    expect(handedOff.task).toMatchObject({
+      revision: 3,
+      owner: { harness: "claude-code", agentId: "agent-b" },
+      checkpoint:
+        "The contract tests are red; implement the file adapter next.",
+    });
+  });
+
+  it("allows only one concurrent update from the same task revision", async () => {
+    const { create, engine } = await createTestEngine();
+    await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "concurrent-session",
+        objective: "Prove optimistic task ownership.",
+        workspaceRoot: "/workspace/project",
+      },
+      invocation,
+    );
+    await engine.invoke(
+      "agent-session.create-task",
+      {
+        sessionId: "concurrent-session",
+        taskId: "task-1",
+        title: "Own this task exactly once",
+        phase: "implementation",
+      },
+      invocation,
+    );
+
+    const outcomes = await Promise.allSettled([
+      engine.invoke(
+        "agent-session.update-task",
+        {
+          sessionId: "concurrent-session",
+          taskId: "task-1",
+          expectedTaskRevision: 1,
+          assignedHarness: "codex",
+          assignedAgentId: "agent-a",
+        },
+        invocation,
+      ),
+      create().invoke(
+        "agent-session.update-task",
+        {
+          sessionId: "concurrent-session",
+          taskId: "task-1",
+          expectedTaskRevision: 1,
+          assignedHarness: "cursor",
+          assignedAgentId: "agent-b",
+        },
+        invocation,
+      ),
+    ]);
+
+    expect(
+      outcomes.filter(({ status }) => status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = outcomes.find(({ status }) => status === "rejected");
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: expect.objectContaining<Partial<EngineError>>({
+        code: "EXECUTION_FAILED",
+        message: "The task changed before this update.",
+        publicDetails: {
+          sessionId: "concurrent-session",
+          taskId: "task-1",
+          expectedTaskRevision: 1,
+        },
+      }),
+    });
+  });
+
+  it("records only hook metadata and a payload digest through the engine pipeline", async () => {
+    const events: EngineEvent[] = [];
+    const { engine } = await createTestEngine(events);
+
+    const recorded = await engine.invoke(
+      "agent-session.record-hook-event",
+      {
+        sessionId: "portable-session",
+        harness: "codex",
+        nativeSessionId: "thr_native",
+        eventId: "evt_0123456789abcdef0123456789abcdef",
+        eventName: "PreToolUse",
+        observedAt: "2026-07-28T12:00:00.000Z",
+        workspaceRoot: "/workspace/project",
+        toolName: "Bash",
+        nativeAgentId: null,
+        nativeTaskId: null,
+        outcome: null,
+        payloadSha256:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      },
+      invocation,
+    );
+    expect(recorded).toMatchObject({ recorded: true, resumed: false });
+
+    const session = await engine.invoke(
+      "agent-session.get",
+      { sessionId: "portable-session" },
+      invocation,
+    );
+    expect(session.harnessSessions).toEqual([
+      { harness: "codex", nativeSessionId: "thr_native" },
+    ]);
+    expect(session.events).toEqual([
+      expect.objectContaining({
+        eventName: "PreToolUse",
+        toolName: "Bash",
+        payloadSha256:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      }),
+    ]);
+    expect(JSON.stringify(session)).not.toContain("tool_input");
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "invocation.started",
+        capabilityId: "agent-session.record-hook-event",
+        source: "direct",
+      }),
+      expect.objectContaining({
+        type: "invocation.completed",
+        capabilityId: "agent-session.record-hook-event",
+      }),
+      expect.objectContaining({
+        type: "invocation.started",
+        capabilityId: "agent-session.get",
+      }),
+      expect.objectContaining({
+        type: "invocation.completed",
+        capabilityId: "agent-session.get",
+      }),
+    ]);
+  });
+
+  it("rejects anonymous access and stale session checkpoints", async () => {
+    const { engine } = await createTestEngine();
+    await expect(
+      engine.invoke(
+        "agent-session.get",
+        { sessionId: "missing" },
+        { source: "direct", principal: null },
+      ),
+    ).rejects.toMatchObject({ code: "UNAUTHENTICATED" });
+
+    await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "stale-session",
+        objective: "Reject lost session updates.",
+        workspaceRoot: "/workspace/project",
+      },
+      invocation,
+    );
+    await engine.invoke(
+      "agent-session.checkpoint",
+      {
+        sessionId: "stale-session",
+        expectedRevision: 1,
+        phase: "planning",
+        status: "active",
+        checkpoint: "Plan drafted.",
+        nextAction: "Create tasks.",
+      },
+      invocation,
+    );
+    await expect(
+      engine.invoke(
+        "agent-session.checkpoint",
+        {
+          sessionId: "stale-session",
+          expectedRevision: 1,
+          phase: "delivery",
+          status: "completed",
+          checkpoint: "Stale writer claims completion.",
+          nextAction: null,
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "The session changed before this checkpoint.",
+      publicDetails: { sessionId: "stale-session", expectedRevision: 1 },
+    });
+  });
+
+  it("deduplicates an identical hook redelivery", async () => {
+    const { engine } = await createTestEngine();
+    const input = {
+      sessionId: "deduplicated-session",
+      harness: "cursor" as const,
+      nativeSessionId: "cursor-native",
+      eventId: "evt_abcdefabcdefabcdefabcdefabcdefab",
+      eventName: "postToolUse",
+      observedAt: "2026-07-28T12:00:00.000Z",
+      workspaceRoot: "/workspace/project",
+      toolName: "Shell",
+      nativeAgentId: null,
+      nativeTaskId: null,
+      outcome: null,
+      payloadSha256:
+        "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    };
+
+    const first = await engine.invoke(
+      "agent-session.record-hook-event",
+      input,
+      invocation,
+    );
+    const duplicate = await engine.invoke(
+      "agent-session.record-hook-event",
+      input,
+      invocation,
+    );
+    const session = await engine.invoke(
+      "agent-session.get",
+      { sessionId: "deduplicated-session" },
+      invocation,
+    );
+
+    expect(first.recorded).toBe(true);
+    expect(duplicate).toMatchObject({
+      recorded: false,
+      sessionRevision: first.sessionRevision,
+    });
+    expect(session.eventCount).toBe(1);
+  });
+
+  it("enforces the task count and completion-evidence boundaries", async () => {
+    const { engine, store } = await createTestEngine();
+    await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "bounded-session",
+        objective: "Exercise public task limits.",
+        workspaceRoot: "/workspace/project",
+      },
+      invocation,
+    );
+    await engine.invoke(
+      "agent-session.create-task",
+      {
+        sessionId: "bounded-session",
+        taskId: "evidence-task",
+        title: "Require evidence",
+        phase: "validation",
+      },
+      invocation,
+    );
+    await expect(
+      engine.invoke(
+        "agent-session.update-task",
+        {
+          sessionId: "bounded-session",
+          taskId: "evidence-task",
+          expectedTaskRevision: 1,
+          status: "completed",
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({
+      message: "A completed task requires verification evidence.",
+    });
+
+    const current = await store.findById("bounded-session");
+    if (current === null) throw new Error("Expected the bounded session.");
+    const timestamp = "2026-07-28T12:00:00.000Z";
+    const tasks = Array.from({ length: 256 }, (_, index) => ({
+      id: `task-${String(index)}`,
+      title: `Task ${String(index)}`,
+      phase: "implementation" as const,
+      status: "pending" as const,
+      owner: null,
+      checkpoint: null,
+      evidence: null,
+      revision: 1,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }));
+    await expect(
+      store.save(
+        {
+          ...current,
+          revision: current.revision + 1,
+          tasks,
+          updatedAt: timestamp,
+        },
+        current.revision,
+      ),
+    ).resolves.toBe("saved");
+    await expect(
+      engine.invoke(
+        "agent-session.create-task",
+        {
+          sessionId: "bounded-session",
+          taskId: "one-too-many",
+          title: "Exceed the task limit",
+          phase: "implementation",
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "The agent session task limit was reached.",
+      publicDetails: { sessionId: "bounded-session", limit: 256 },
+    });
+  });
+});

--- a/examples/agent-session-engine/test/entrypoints.test.ts
+++ b/examples/agent-session-engine/test/entrypoints.test.ts
@@ -336,13 +336,71 @@ describe("agent session example entrypoints", () => {
 
   it("ships parseable hook configurations for all four harnesses", async () => {
     const expected = {
-      "cursor.hooks.json": ["sessionStart", "preToolUse", "stop"],
-      "codex.hooks.json": ["SessionStart", "PreToolUse", "Stop"],
+      "cursor.hooks.json": [
+        "workspaceOpen",
+        "sessionStart",
+        "sessionEnd",
+        "beforeSubmitPrompt",
+        "afterAgentResponse",
+        "afterAgentThought",
+        "preToolUse",
+        "postToolUse",
+        "postToolUseFailure",
+        "beforeShellExecution",
+        "afterShellExecution",
+        "beforeMCPExecution",
+        "afterMCPExecution",
+        "beforeReadFile",
+        "afterFileEdit",
+        "beforeTabFileRead",
+        "afterTabFileEdit",
+        "subagentStart",
+        "subagentStop",
+        "preCompact",
+        "stop",
+      ],
+      "codex.hooks.json": [
+        "SessionStart",
+        "SessionEnd",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PermissionRequest",
+        "PostToolUse",
+        "PreCompact",
+        "PostCompact",
+        "SubagentStart",
+        "SubagentStop",
+        "Stop",
+      ],
       "claude-code.settings.json": [
         "SessionStart",
+        "Setup",
+        "UserPromptSubmit",
+        "UserPromptExpansion",
+        "PreToolUse",
+        "PermissionRequest",
+        "PermissionDenied",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PostToolBatch",
+        "Notification",
+        "MessageDisplay",
+        "SubagentStart",
+        "SubagentStop",
         "TaskCreated",
         "TaskCompleted",
         "Stop",
+        "StopFailure",
+        "TeammateIdle",
+        "InstructionsLoaded",
+        "ConfigChange",
+        "CwdChanged",
+        "WorktreeRemove",
+        "PreCompact",
+        "PostCompact",
+        "Elicitation",
+        "ElicitationResult",
+        "SessionEnd",
       ],
       "antigravity.hooks.json": [
         "PreInvocation",
@@ -359,7 +417,16 @@ describe("agent session example entrypoints", () => {
       );
       const parsed = JSON.parse(encoded) as unknown;
       expect(parsed).toBeTypeOf("object");
-      for (const eventName of eventNames) expect(encoded).toContain(eventName);
+      const root = parsed as Record<string, unknown>;
+      const hookContainer =
+        filename === "antigravity.hooks.json"
+          ? (root["agent-session-recorder"] as Record<string, unknown>)
+          : (root.hooks as Record<string, unknown>);
+      expect(
+        Object.keys(hookContainer)
+          .filter((key) => key !== "enabled")
+          .sort(),
+      ).toEqual([...eventNames].sort());
       expect(encoded).toContain(
         "node examples/agent-session-engine/dist/hook-cli.js",
       );

--- a/examples/agent-session-engine/test/entrypoints.test.ts
+++ b/examples/agent-session-engine/test/entrypoints.test.ts
@@ -1,0 +1,368 @@
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+  spawnSync,
+} from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
+const dataDirectories: string[] = [];
+
+beforeAll(() => {
+  const build = spawnSync(
+    process.execPath,
+    ["../../node_modules/typescript/bin/tsc", "-b", "--pretty", "false"],
+    { cwd: exampleRoot, encoding: "utf8" },
+  );
+  if (build.status !== 0) {
+    throw new Error(`Example build failed:\n${build.stdout}${build.stderr}`);
+  }
+});
+
+afterEach(async () => {
+  await Promise.all(
+    dataDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function dataDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "agent-session-entrypoint-"));
+  dataDirectories.push(directory);
+  return directory;
+}
+
+function run(
+  entrypoint: string,
+  args: ReadonlyArray<string>,
+  directory: string,
+  input?: string,
+) {
+  return spawnSync(process.execPath, [`dist/${entrypoint}.js`, ...args], {
+    cwd: exampleRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENT_SESSION_ENGINE_DATA_DIR: directory,
+      AGENT_SESSION_ENGINE_SESSION_ID: "entrypoint-session",
+    },
+    ...(input === undefined ? {} : { input }),
+  });
+}
+
+function runAsync(
+  entrypoint: string,
+  args: ReadonlyArray<string>,
+  directory: string,
+  input: string,
+): Promise<{
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [`dist/${entrypoint}.js`, ...args], {
+      cwd: exampleRoot,
+      env: {
+        ...process.env,
+        AGENT_SESSION_ENGINE_DATA_DIR: directory,
+        AGENT_SESSION_ENGINE_SESSION_ID: "entrypoint-session",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(input);
+  });
+}
+
+function nextMessage(
+  child: ChildProcessWithoutNullStreams,
+  expectedId: number,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    const onData = (chunk: Buffer): void => {
+      buffer += chunk.toString("utf8");
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line === "") continue;
+        const message = JSON.parse(line) as Record<string, unknown>;
+        if (message.id === expectedId) {
+          child.stdout.off("data", onData);
+          resolve(message);
+        }
+      }
+    };
+    child.stdout.on("data", onData);
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      reject(new Error(`MCP stdio exited before response: ${String(code)}`));
+    });
+  });
+}
+
+function send(child: ChildProcessWithoutNullStreams, message: unknown): void {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+describe("agent session example entrypoints", () => {
+  it("persists CLI commands across processes and serves the same session over MCP", async () => {
+    const directory = await dataDirectory();
+    const started = run(
+      "cli",
+      [
+        "run",
+        "agent-session.start",
+        "--input",
+        JSON.stringify({
+          sessionId: "entrypoint-session",
+          objective: "Prove adapter convergence.",
+          workspaceRoot: "/workspace/project",
+        }),
+      ],
+      directory,
+    );
+    expect(started.status).toBe(0);
+    expect(started.stderr).toBe("");
+
+    const created = run(
+      "cli",
+      [
+        "run",
+        "agent-session.create-task",
+        "--input",
+        JSON.stringify({
+          sessionId: "entrypoint-session",
+          taskId: "cross-process",
+          title: "Read the state from another process",
+          phase: "validation",
+        }),
+      ],
+      directory,
+    );
+    expect(created.status).toBe(0);
+    expect(JSON.parse(created.stdout)).toMatchObject({ sessionRevision: 2 });
+
+    const child = spawn(process.execPath, ["dist/mcp-stdio.js"], {
+      cwd: exampleRoot,
+      env: {
+        ...process.env,
+        AGENT_SESSION_ENGINE_DATA_DIR: directory,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    try {
+      const initialized = nextMessage(child, 1);
+      send(child, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "agent-session-example-test",
+            version: "0.0.0-test",
+          },
+        },
+      });
+      await expect(initialized).resolves.toMatchObject({
+        result: {
+          serverInfo: { name: "agent-session-engine", version: "0.1.0" },
+        },
+      });
+      send(child, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+      const called = nextMessage(child, 2);
+      send(child, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "agent-session.get",
+          arguments: { sessionId: "entrypoint-session" },
+        },
+      });
+      await expect(called).resolves.toMatchObject({
+        result: {
+          structuredContent: {
+            sessionId: "entrypoint-session",
+            revision: 2,
+            tasks: [{ id: "cross-process", status: "pending" }],
+          },
+        },
+      });
+    } finally {
+      child.kill();
+    }
+  });
+
+  it("records a real hook process through the CLI adapter and returns resume context", async () => {
+    const directory = await dataDirectory();
+    const started = run(
+      "cli",
+      [
+        "run",
+        "agent-session.start",
+        "--input",
+        JSON.stringify({
+          sessionId: "entrypoint-session",
+          objective: "Resume from a Codex hook.",
+          workspaceRoot: "/workspace/project",
+        }),
+      ],
+      directory,
+    );
+    expect(started.status).toBe(0);
+
+    const hook = run(
+      "hook-cli",
+      ["codex"],
+      directory,
+      JSON.stringify({
+        session_id: "thr_codex",
+        hook_event_name: "SessionStart",
+        source: "resume",
+        cwd: "/workspace/project",
+      }),
+    );
+    expect(hook.status).toBe(0);
+    expect(hook.stderr).toBe("");
+    expect(JSON.parse(hook.stdout)).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: expect.stringContaining("Resume from a Codex hook."),
+      },
+    });
+
+    const inspected = run(
+      "cli",
+      [
+        "run",
+        "agent-session.get",
+        "--input",
+        '{"sessionId":"entrypoint-session"}',
+      ],
+      directory,
+    );
+    expect(inspected.status).toBe(0);
+    expect(JSON.parse(inspected.stdout)).toMatchObject({
+      eventCount: 1,
+      events: [
+        {
+          harness: "codex",
+          nativeSessionId: "thr_codex",
+          eventName: "SessionStart",
+        },
+      ],
+    });
+  });
+
+  it("serializes concurrent hook processes without losing lifecycle events", async () => {
+    const directory = await dataDirectory();
+    const started = run(
+      "cli",
+      [
+        "run",
+        "agent-session.start",
+        "--input",
+        JSON.stringify({
+          sessionId: "entrypoint-session",
+          objective: "Capture concurrent hook processes.",
+          workspaceRoot: "/workspace/project",
+        }),
+      ],
+      directory,
+    );
+    expect(started.status).toBe(0);
+
+    const hooks = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        runAsync(
+          "hook-cli",
+          ["codex"],
+          directory,
+          JSON.stringify({
+            session_id: "thr_concurrent",
+            hook_event_name: "PostToolUse",
+            turn_id: "turn_concurrent",
+            tool_use_id: `call_${String(index)}`,
+            tool_name: "Bash",
+            tool_response: { private: `payload-${String(index)}` },
+            cwd: "/workspace/project",
+          }),
+        ),
+      ),
+    );
+    expect(hooks).toEqual(
+      Array.from({ length: 8 }, () => ({ code: 0, stdout: "{}", stderr: "" })),
+    );
+
+    const inspected = run(
+      "cli",
+      [
+        "run",
+        "agent-session.get",
+        "--input",
+        '{"sessionId":"entrypoint-session"}',
+      ],
+      directory,
+    );
+    expect(inspected.status).toBe(0);
+    const session = JSON.parse(inspected.stdout) as {
+      readonly eventCount: number;
+      readonly events: ReadonlyArray<unknown>;
+    };
+    expect(session.eventCount).toBe(8);
+    expect(session.events).toHaveLength(8);
+    expect(inspected.stdout).not.toContain("payload-0");
+  });
+
+  it("ships parseable hook configurations for all four harnesses", async () => {
+    const expected = {
+      "cursor.hooks.json": ["sessionStart", "preToolUse", "stop"],
+      "codex.hooks.json": ["SessionStart", "PreToolUse", "Stop"],
+      "claude-code.settings.json": [
+        "SessionStart",
+        "TaskCreated",
+        "TaskCompleted",
+        "Stop",
+      ],
+      "antigravity.hooks.json": [
+        "PreInvocation",
+        "PostInvocation",
+        "PostToolUse",
+        "Stop",
+      ],
+    } as const;
+
+    for (const [filename, eventNames] of Object.entries(expected)) {
+      const encoded = await readFile(
+        join(exampleRoot, "hooks", filename),
+        "utf8",
+      );
+      const parsed = JSON.parse(encoded) as unknown;
+      expect(parsed).toBeTypeOf("object");
+      for (const eventName of eventNames) expect(encoded).toContain(eventName);
+      expect(encoded).toContain(
+        "node examples/agent-session-engine/dist/hook-cli.js",
+      );
+    }
+  });
+});

--- a/examples/agent-session-engine/test/hook-adapter.test.ts
+++ b/examples/agent-session-engine/test/hook-adapter.test.ts
@@ -1,0 +1,227 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { EngineEvent, Principal } from "@ai-engine/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createAgentSessionEngine } from "../src/engine.js";
+import {
+  normalizeHookEvent,
+  runHookCommand,
+} from "../src/hooks/hook-adapter.js";
+import { createFileAgentSessionStore } from "../src/infrastructure/file-agent-session-store.js";
+
+const principal: Principal = {
+  id: "hook:recorder",
+  attributes: { permissions: ["agent-session:hooks"] },
+};
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function fixture() {
+  const dataDirectory = await mkdtemp(join(tmpdir(), "agent-session-hook-"));
+  temporaryDirectories.push(dataDirectory);
+  const events: EngineEvent[] = [];
+  const engine = createAgentSessionEngine(
+    {
+      sessions: createFileAgentSessionStore({ dataDirectory }),
+      now: () => new Date("2026-07-28T12:00:00.000Z"),
+    },
+    {
+      onEvent(event) {
+        events.push(event);
+      },
+    },
+  );
+  return { dataDirectory, engine, events };
+}
+
+describe("agent harness hook adapters", () => {
+  it("normalizes the same native occurrence to a stable event without retaining payload data", () => {
+    const rawInput = JSON.stringify({
+      session_id: "thr_123",
+      hook_event_name: "PreToolUse",
+      cwd: "/workspace/project",
+      turn_id: "turn_1",
+      tool_use_id: "call_1",
+      tool_name: "Bash",
+      tool_input: { command: "deploy --token secret-value" },
+      prompt: "private prompt",
+      reason: "secret-reason",
+    });
+    const first = normalizeHookEvent("codex", rawInput, {
+      portableSessionId: "portable-session",
+      observedAt: "2026-07-28T12:00:00.000Z",
+    });
+    const second = normalizeHookEvent("codex", rawInput, {
+      portableSessionId: "portable-session",
+      observedAt: "2026-07-28T12:00:01.000Z",
+    });
+
+    expect(first.eventId).toBe(second.eventId);
+    expect(first).toMatchObject({
+      sessionId: "portable-session",
+      nativeSessionId: "thr_123",
+      eventName: "PreToolUse",
+      toolName: "Bash",
+      nativeAgentId: null,
+      nativeTaskId: null,
+    });
+    expect(first.payloadSha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(JSON.stringify(first)).not.toContain("private prompt");
+    expect(JSON.stringify(first)).not.toContain("secret-value");
+    expect(first.outcome).toBe("other");
+
+    const filesystemSafeDefault = normalizeHookEvent(
+      "cursor",
+      JSON.stringify({
+        conversation_id: "native/session with spaces",
+        hook_event_name: "sessionStart",
+      }),
+      { observedAt: "2026-07-28T12:00:00.000Z" },
+    );
+    expect(filesystemSafeDefault.sessionId).toMatch(/^cursor:[a-f0-9]{32}$/u);
+  });
+
+  it("records through runCli and injects resume context for Codex and Claude Code", async () => {
+    const { engine, events } = await fixture();
+    await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "handoff-session",
+        objective: "Continue this work in another harness.",
+        workspaceRoot: "/workspace/project",
+      },
+      {
+        source: "direct",
+        principal: {
+          id: "agent:coordinator",
+          attributes: { permissions: ["agent-session:write"] },
+        },
+      },
+    );
+
+    for (const harness of ["codex", "claude-code"] as const) {
+      let stdout = "";
+      let stderr = "";
+      const code = await runHookCommand(harness, {
+        rawInput: JSON.stringify({
+          session_id: `${harness}-native-session`,
+          hook_event_name: "SessionStart",
+          source: "resume",
+          cwd: "/workspace/project",
+        }),
+        portableSessionId: "handoff-session",
+        engine,
+        principal,
+        observedAt: "2026-07-28T12:00:00.000Z",
+        writeStdout: (text) => {
+          stdout += text;
+        },
+        writeStderr: (text) => {
+          stderr += text;
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: "SessionStart",
+          additionalContext: expect.stringContaining(
+            "Continue this work in another harness.",
+          ),
+        },
+      });
+    }
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "invocation.started",
+        capabilityId: "agent-session.record-hook-event",
+        source: "cli",
+      }),
+    );
+  });
+
+  it("uses each harness neutral output and resumes Antigravity on its first invocation", async () => {
+    const { engine } = await fixture();
+    await engine.invoke(
+      "agent-session.start",
+      {
+        sessionId: "multi-harness",
+        objective: "Resume safely.",
+        workspaceRoot: "/workspace/project",
+      },
+      {
+        source: "direct",
+        principal: {
+          id: "agent:coordinator",
+          attributes: { permissions: ["agent-session:write"] },
+        },
+      },
+    );
+
+    const cases = [
+      {
+        harness: "cursor" as const,
+        input: {
+          conversation_id: "cursor-native",
+          hook_event_name: "sessionStart",
+          workspace_roots: ["/workspace/project"],
+        },
+        expected: {
+          additional_context: expect.stringContaining("Resume safely."),
+        },
+      },
+      {
+        harness: "antigravity" as const,
+        input: {
+          conversationId: "agy-native",
+          hook_event_name: "PreInvocation",
+          invocationNum: 0,
+          workspacePaths: ["/workspace/project"],
+        },
+        expected: {
+          injectSteps: [
+            { ephemeralMessage: expect.stringContaining("Resume safely.") },
+          ],
+        },
+      },
+      {
+        harness: "antigravity" as const,
+        input: {
+          conversationId: "agy-native",
+          hook_event_name: "PostToolUse",
+          stepIdx: 2,
+          workspacePaths: ["/workspace/project"],
+        },
+        expected: {},
+      },
+    ];
+
+    for (const testCase of cases) {
+      let stdout = "";
+      const code = await runHookCommand(testCase.harness, {
+        rawInput: JSON.stringify(testCase.input),
+        portableSessionId: "multi-harness",
+        engine,
+        principal,
+        observedAt: "2026-07-28T12:00:00.000Z",
+        writeStdout: (text) => {
+          stdout += text;
+        },
+        writeStderr: () => undefined,
+      });
+      expect(code).toBe(0);
+      expect(JSON.parse(stdout)).toEqual(testCase.expected);
+    }
+  });
+});

--- a/examples/agent-session-engine/test/hook-adapter.test.ts
+++ b/examples/agent-session-engine/test/hook-adapter.test.ts
@@ -151,6 +151,51 @@ describe("agent harness hook adapters", () => {
     );
   });
 
+  it("records repeated lifecycle deliveries that have no native occurrence identifier", async () => {
+    const { engine } = await fixture();
+    const rawInput = JSON.stringify({
+      session_id: "codex-native-session",
+      hook_event_name: "SessionStart",
+      source: "resume",
+      cwd: "/workspace/project",
+    });
+
+    for (const observedAt of [
+      "2026-07-28T12:00:00.000Z",
+      "2026-07-28T13:00:00.000Z",
+    ]) {
+      await expect(
+        runHookCommand("codex", {
+          rawInput,
+          portableSessionId: "repeated-session-start",
+          engine,
+          principal,
+          observedAt,
+          writeStdout: () => undefined,
+          writeStderr: () => undefined,
+        }),
+      ).resolves.toBe(0);
+    }
+
+    const session = await engine.invoke(
+      "agent-session.get",
+      { sessionId: "repeated-session-start" },
+      {
+        source: "direct",
+        principal: {
+          id: "reviewer",
+          attributes: { permissions: ["agent-session:read"] },
+        },
+      },
+    );
+    expect(session.events).toHaveLength(2);
+    expect(session.events.map(({ observedAt }) => observedAt)).toEqual([
+      "2026-07-28T12:00:00.000Z",
+      "2026-07-28T13:00:00.000Z",
+    ]);
+    expect(session.events[0]?.id).not.toBe(session.events[1]?.id);
+  });
+
   it("uses each harness neutral output and resumes Antigravity on its first invocation", async () => {
     const { engine } = await fixture();
     await engine.invoke(

--- a/examples/agent-session-engine/tsconfig.json
+++ b/examples/agent-session-engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/example-agent-session.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/cli" },
+    { "path": "../../packages/mcp" }
+  ]
+}

--- a/examples/agent-session-engine/tsconfig.test.json
+++ b/examples/agent-session-engine/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "./examples/community-capabilities" },
     { "path": "./examples/composed-engine" },
     { "path": "./examples/crawl-engine" },
+    { "path": "./examples/agent-session-engine" },
     { "path": "./examples/hello-engine" },
     { "path": "./examples/spec-engine" },
     { "path": "./examples/support-engine" },


### PR DESCRIPTION
## Summary

- Add a durable agent-session example with lifecycle, checkpoints, task ownership, evidence, and cross-harness handoff capabilities.
- Route Cursor, Antigravity, Claude Code, and Codex hook events through the CLI adapter and the single `engine.invoke` execution path.
- Add atomic file persistence, concurrency and idempotency coverage, hook configuration examples, and adoption documentation.
- Harden recovery with owner-aware locks, fixed-length storage keys, bounded resume context, occurrence-safe event identity, and complete neutral Claude Code hook coverage.

## Why

Agent work can stop when a harness reaches a usage limit or loses its session. This example keeps portable execution state outside any one harness so another supported harness can resume from the last durable checkpoint.

## Impact

This is additive under `examples/` and does not change the v0.1 framework API. Users can adopt the example store and hook configurations while retaining direct, CLI, and MCP access through the same engine.

Hook capture remains bounded by the events each harness exposes; documented non-neutral or unsupported events are intentionally excluded.

## Review fixes

The follow-up commit addresses five root causes found during review:

- elapsed lock age could steal ownership from a live writer;
- individually valid fields could exceed the aggregate resume-context limit after persistence;
- byte-identical lifecycle events without native occurrence IDs could collapse into one event;
- the Claude Code example and its test covered only a subset of neutral events;
- percent-encoded valid session IDs could exceed filesystem filename limits.

## Validation

- `yarn run check`
- 71 test files passed
- 1,321 tests passed
