### PR TITLE
feat(examples): add observability incident context engine

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ conflicts with a contract or ADR, the normative source takes precedence.
 - [`support-engine`: dependency injection and authorization example](../examples/support-engine/)
 - [`support-harness`: private MCP consumer](../examples/support-harness/)
 - [`crawl-engine`: outbound provider integration with Firecrawl](../examples/crawl-engine/)
+- [`observability-engine`: Sentry, Datadog, and New Relic incident context](../examples/observability-engine/)
 - [`spec-engine`: spec-driven development workflow as domain rules](../examples/spec-engine/)
 - [`community-capabilities`: atomic and library capability publication fixture](../examples/community-capabilities/)
 - [`composed-engine`: local, atomic, and library capability composition](../examples/composed-engine/)

--- a/examples/observability-engine/README.md
+++ b/examples/observability-engine/README.md
@@ -1,0 +1,164 @@
+# Observability engine example
+
+This example publishes one incident-investigation capability backed by Sentry,
+Datadog, and New Relic through the direct API, CLI, MCP stdio, and stateless MCP
+HTTP:
+
+| Capability | Purpose |
+| --- | --- |
+| `observability.collect-incident-context` | Collect issues, logs, and service telemetry for one bounded time window |
+
+The capability is defined once; every adapter reaches it through
+`engine.invoke`. The public contract describes incident context rather than a
+provider API. Sentry, Datadog, and New Relic live behind custom-engine ports and
+can be replaced without changing the capability ID, schemas, or entrypoints.
+
+## Architecture
+
+```text
+direct / CLI / MCP stdio / MCP HTTP
+                |
+                v
+           engine.invoke
+                |
+                v
+ observability.collect-incident-context
+       |              |               |
+       v              v               v
+ IssueTracker      LogStore     TelemetryReader
+       |              |               |
+       v              v               v
+ Sentry issues   Datadog logs   New Relic NerdGraph
+```
+
+- `src/domain/incident-context.ts` owns the normalized request and result types.
+- `src/application/ports.ts` owns the three provider-independent ports.
+- `src/capabilities/collect-incident-context.ts` owns the stable Zod 4
+  contracts, limits, timeout, and handler.
+- `src/infrastructure/` is the only layer that knows the external HTTP
+  contracts.
+- `src/engine.ts` is the composition root; it reads credentials and account
+  configuration from the environment and injects the adapters.
+
+The Sentry adapter uses the organization issues endpoint and maps `service` to a
+Sentry project slug. The Datadog adapter searches v2 log events with a
+`service:<service>` filter. The New Relic adapter runs a fixed, read-only NRQL
+aggregate over `Transaction` data where `appName` matches the service. Consumers
+cannot submit arbitrary NRQL or provider credentials.
+
+## Configure
+
+```sh
+export SENTRY_AUTH_TOKEN='sntrys_...'
+export SENTRY_ORG='acme'
+export DD_API_KEY='...'
+export DD_APP_KEY='...'
+export NEW_RELIC_USER_KEY='NRAK-...'
+export NEW_RELIC_ACCOUNT_ID='1234567'
+```
+
+Optional endpoint overrides support another provider region, a compatible
+gateway, or a local test stub:
+
+```sh
+export SENTRY_BASE_URL='https://sentry.io'
+export DD_BASE_URL='https://api.datadoghq.com'
+export NEW_RELIC_GRAPHQL_URL='https://api.newrelic.com/graphql'
+```
+
+Use `https://api.eu.newrelic.com/graphql` for a New Relic account in the EU data
+center. Every entrypoint fails fast if any required provider setting is missing.
+Credentials are never part of the capability input, output, events, or public
+error details.
+
+## Run the example
+
+From the repository root, build the framework and example:
+
+```sh
+yarn build
+```
+
+Invoke the capability directly. The optional fourth argument is the per-provider
+result limit:
+
+```sh
+node examples/observability-engine/dist/direct.js \
+  checkout-api \
+  2026-07-28T12:00:00.000Z \
+  2026-07-28T13:00:00.000Z \
+  20
+```
+
+Use the CLI:
+
+```sh
+node examples/observability-engine/dist/cli.js list
+node examples/observability-engine/dist/cli.js describe observability.collect-incident-context
+node examples/observability-engine/dist/cli.js run observability.collect-incident-context --input '{"service":"checkout-api","from":"2026-07-28T12:00:00.000Z","to":"2026-07-28T13:00:00.000Z","limit":20}'
+```
+
+Start the MCP stdio adapter from an MCP host configuration:
+
+```sh
+node examples/observability-engine/dist/mcp-stdio.js
+```
+
+Start authenticated stateless MCP HTTP on the loopback default:
+
+```sh
+OBSERVABILITY_ENGINE_BEARER_TOKEN='development-only-token' \
+  node examples/observability-engine/dist/mcp-http.js
+```
+
+The literal bearer-token comparison is only a deterministic authentication-hook
+example. A real deployment replaces it with the organization's identity
+implementation. Authorization remains inside `engine.invoke`; the capability
+requires an authenticated principal.
+
+## Contract and operational limits
+
+| Concern | Behavior |
+| --- | --- |
+| Service | 1–128 characters: letters, digits, `_`, `.`, or `-` |
+| Time window | Explicit ISO 8601 offsets; start before end; maximum seven days |
+| Results | Default 20; range 1–100; enforced locally for issues and logs |
+| Provider calls | Sentry, Datadog, and New Relic start concurrently |
+| Completion | All-or-nothing; a provider failure aborts its sibling requests |
+| Timeout | 30 seconds for the capability invocation |
+| Cancellation | The invocation signal reaches all three outbound requests |
+| Access | Authenticated, read-only, idempotent, and open-world |
+
+Provider HTTP rejections become `EXECUTION_FAILED` with only `provider` and
+`status` in `publicDetails`. Response bodies and credentials remain internal.
+The tests use a local three-provider stub and never call public provider APIs.
+
+## Replace a provider
+
+Implement the corresponding custom-engine port and inject it into
+`createObservabilityEngine`. The replacement must honor the supplied
+`AbortSignal` and return the normalized domain type.
+
+```ts
+const engine = createObservabilityEngine({
+  issues: myIssueTracker,
+  logs: myLogStore,
+  telemetry: myTelemetryReader,
+});
+```
+
+No capability, schema, CLI command, or MCP tool changes.
+
+## Verify the example
+
+```sh
+yarn workspace @ai-engine/example-observability test
+yarn workspace @ai-engine/example-observability typecheck
+yarn workspace @ai-engine/example-observability build
+```
+
+Provider contract references:
+
+- [Sentry organization issues API](https://docs.sentry.io/api/events/list-an-organizations-issues/)
+- [Datadog v2 log search API](https://docs.datadoghq.com/api/latest/logs/search-logs-post/)
+- [New Relic NerdGraph NRQL tutorial](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/)

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ai-engine/example-observability",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "typecheck": "tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false --noEmit",
+    "test": "vitest run test",
+    "direct": "node dist/direct.js",
+    "cli": "node dist/cli.js",
+    "mcp:stdio": "node dist/mcp-stdio.js",
+    "mcp:http": "node dist/mcp-http.js"
+  },
+  "dependencies": {
+    "@ai-engine/cli": "0.1.0",
+    "@ai-engine/core": "0.1.0",
+    "@ai-engine/mcp": "0.1.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  }
+}

--- a/examples/observability-engine/src/application/ports.ts
+++ b/examples/observability-engine/src/application/ports.ts
@@ -1,0 +1,37 @@
+import type {
+  IncidentContextRequest,
+  IssueSummary,
+  LogSummary,
+  ServiceTelemetry,
+} from "../domain/incident-context.js";
+
+export interface ProviderCallOptions {
+  readonly signal: AbortSignal;
+}
+
+export interface IssueTracker {
+  searchServiceIssues(
+    request: IncidentContextRequest,
+    options: ProviderCallOptions,
+  ): Promise<ReadonlyArray<IssueSummary>>;
+}
+
+export interface LogStore {
+  searchServiceLogs(
+    request: IncidentContextRequest,
+    options: ProviderCallOptions,
+  ): Promise<ReadonlyArray<LogSummary>>;
+}
+
+export interface TelemetryReader {
+  summarizeService(
+    request: IncidentContextRequest,
+    options: ProviderCallOptions,
+  ): Promise<ServiceTelemetry>;
+}
+
+export interface ObservabilityDependencies {
+  readonly issues: IssueTracker;
+  readonly logs: LogStore;
+  readonly telemetry: TelemetryReader;
+}

--- a/examples/observability-engine/src/capabilities/collect-incident-context.ts
+++ b/examples/observability-engine/src/capabilities/collect-incident-context.ts
@@ -1,0 +1,117 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import type { ObservabilityDependencies } from "../application/ports.js";
+
+const maximumWindowMs = 7 * 24 * 60 * 60 * 1_000;
+
+const inputSchema = z
+  .object({
+    service: z
+      .string()
+      .trim()
+      .min(1)
+      .max(128)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9_.-]*$/u),
+    from: z.iso.datetime({ offset: true }),
+    to: z.iso.datetime({ offset: true }),
+    limit: z.number().int().min(1).max(100).default(20),
+  })
+  .superRefine(({ from, to }, context) => {
+    const fromMs = Date.parse(from);
+    const toMs = Date.parse(to);
+    if (fromMs >= toMs) {
+      context.addIssue({
+        code: "custom",
+        path: ["to"],
+        message: "The end of the window must be after its start.",
+      });
+      return;
+    }
+    if (toMs - fromMs > maximumWindowMs) {
+      context.addIssue({
+        code: "custom",
+        path: ["to"],
+        message: "The time window cannot exceed seven days.",
+      });
+    }
+  });
+
+const issueSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  status: z.string().min(1),
+  project: z.string().min(1),
+  lastSeen: z.iso.datetime({ offset: true }),
+  eventCount: z.number().int().nonnegative(),
+  url: z.string().url().nullable(),
+});
+
+const logSchema = z.object({
+  id: z.string().min(1),
+  timestamp: z.iso.datetime({ offset: true }),
+  service: z.string().min(1),
+  severity: z.string().min(1).nullable(),
+  message: z.string(),
+});
+
+const telemetrySchema = z.object({
+  transactionCount: z.number().int().nonnegative(),
+  errorRate: z.number().min(0).max(100),
+  averageDurationMs: z.number().nonnegative().nullable(),
+});
+
+const outputSchema = z.object({
+  service: z.string().min(1),
+  from: z.iso.datetime({ offset: true }),
+  to: z.iso.datetime({ offset: true }),
+  issues: z.array(issueSchema),
+  logs: z.array(logSchema),
+  telemetry: telemetrySchema,
+});
+
+export function createCollectIncidentContext({
+  issues,
+  logs,
+  telemetry,
+}: ObservabilityDependencies) {
+  return defineCapability({
+    title: "Collect incident context",
+    description:
+      "Collect bounded issue, log, and telemetry context for one service and time window.",
+    input: inputSchema,
+    output: outputSchema,
+    access: "authenticated",
+    timeoutMs: 30_000,
+    annotations: {
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+      openWorld: true,
+    },
+    async run({ input, context }): Promise<z.input<typeof outputSchema>> {
+      const siblingController = new AbortController();
+      const options = {
+        signal: AbortSignal.any([context.signal, siblingController.signal]),
+      };
+      try {
+        const [issueResults, logResults, telemetryResult] = await Promise.all([
+          issues.searchServiceIssues(input, options),
+          logs.searchServiceLogs(input, options),
+          telemetry.summarizeService(input, options),
+        ]);
+        return {
+          service: input.service,
+          from: input.from,
+          to: input.to,
+          issues: issueResults.slice(0, input.limit),
+          logs: logResults.slice(0, input.limit),
+          telemetry: telemetryResult,
+        };
+      } catch (cause) {
+        siblingController.abort(cause);
+        throw cause;
+      }
+    },
+  });
+}

--- a/examples/observability-engine/src/cli.ts
+++ b/examples/observability-engine/src/cli.ts
@@ -1,0 +1,25 @@
+import { pathToFileURL } from "node:url";
+
+import { runCli } from "@ai-engine/cli";
+
+import { createProviderBackedObservabilityEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<number> {
+  return runCli(createProviderBackedObservabilityEngine(), {
+    principal: localPrincipal,
+  });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  process.exitCode = await main().catch(() => {
+    process.stderr.write(
+      '{"error":{"code":"EXECUTION_FAILED","message":"Observability engine CLI startup failed."}}\n',
+    );
+    return 1;
+  });
+}

--- a/examples/observability-engine/src/direct.ts
+++ b/examples/observability-engine/src/direct.ts
@@ -1,0 +1,37 @@
+import { pathToFileURL } from "node:url";
+
+import { createProviderBackedObservabilityEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+const defaultService = "checkout-api";
+const defaultFrom = "2026-07-28T12:00:00.000Z";
+const defaultTo = "2026-07-28T13:00:00.000Z";
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+): Promise<void> {
+  const configuredLimit = args[3];
+  const limit = configuredLimit === undefined ? 20 : Number(configuredLimit);
+  const result = await createProviderBackedObservabilityEngine().invoke(
+    "observability.collect-incident-context",
+    {
+      service: args[0] ?? defaultService,
+      from: args[1] ?? defaultFrom,
+      to: args[2] ?? defaultTo,
+      limit,
+    },
+    { source: "direct", principal: localPrincipal },
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Observability engine direct invocation failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/observability-engine/src/domain/incident-context.ts
+++ b/examples/observability-engine/src/domain/incident-context.ts
@@ -1,0 +1,30 @@
+export interface IncidentContextRequest {
+  readonly service: string;
+  readonly from: string;
+  readonly to: string;
+  readonly limit: number;
+}
+
+export interface IssueSummary {
+  readonly id: string;
+  readonly title: string;
+  readonly status: string;
+  readonly project: string;
+  readonly lastSeen: string;
+  readonly eventCount: number;
+  readonly url: string | null;
+}
+
+export interface LogSummary {
+  readonly id: string;
+  readonly timestamp: string;
+  readonly service: string;
+  readonly severity: string | null;
+  readonly message: string;
+}
+
+export interface ServiceTelemetry {
+  readonly transactionCount: number;
+  readonly errorRate: number;
+  readonly averageDurationMs: number | null;
+}

--- a/examples/observability-engine/src/engine.ts
+++ b/examples/observability-engine/src/engine.ts
@@ -1,0 +1,85 @@
+import { createEngine } from "@ai-engine/core";
+
+import type { ObservabilityDependencies } from "./application/ports.js";
+import { createCollectIncidentContext } from "./capabilities/collect-incident-context.js";
+import { createDatadogLogStore } from "./infrastructure/datadog-log-store.js";
+import { createNewRelicTelemetryReader } from "./infrastructure/new-relic-telemetry-reader.js";
+import { createSentryIssueTracker } from "./infrastructure/sentry-issue-tracker.js";
+
+export function createObservabilityEngine(
+  dependencies: ObservabilityDependencies,
+) {
+  return createEngine({
+    name: "observability-engine",
+    version: "0.1.0",
+    capabilities: {
+      "observability.collect-incident-context":
+        createCollectIncidentContext(dependencies),
+    },
+  });
+}
+
+export interface ObservabilityEnvironment {
+  readonly SENTRY_AUTH_TOKEN?: string | undefined;
+  readonly SENTRY_ORG?: string | undefined;
+  readonly SENTRY_BASE_URL?: string | undefined;
+  readonly DD_API_KEY?: string | undefined;
+  readonly DD_APP_KEY?: string | undefined;
+  readonly DD_BASE_URL?: string | undefined;
+  readonly NEW_RELIC_USER_KEY?: string | undefined;
+  readonly NEW_RELIC_ACCOUNT_ID?: string | undefined;
+  readonly NEW_RELIC_GRAPHQL_URL?: string | undefined;
+}
+
+function requireEnvironment(
+  environment: ObservabilityEnvironment,
+  key: keyof ObservabilityEnvironment,
+): string {
+  const value = environment[key];
+  if (value === undefined || value === "") {
+    throw new Error(`${key} is required.`);
+  }
+  return value;
+}
+
+export function createProviderBackedObservabilityEngine(
+  environment: ObservabilityEnvironment = process.env,
+) {
+  const sentryAuthToken = requireEnvironment(environment, "SENTRY_AUTH_TOKEN");
+  const sentryOrganization = requireEnvironment(environment, "SENTRY_ORG");
+  const datadogApiKey = requireEnvironment(environment, "DD_API_KEY");
+  const datadogApplicationKey = requireEnvironment(environment, "DD_APP_KEY");
+  const newRelicUserKey = requireEnvironment(environment, "NEW_RELIC_USER_KEY");
+  const accountIdText = requireEnvironment(environment, "NEW_RELIC_ACCOUNT_ID");
+  const newRelicAccountId = Number(accountIdText);
+  if (!Number.isSafeInteger(newRelicAccountId) || newRelicAccountId <= 0) {
+    throw new Error("NEW_RELIC_ACCOUNT_ID must be a positive integer.");
+  }
+
+  return createObservabilityEngine({
+    issues: createSentryIssueTracker({
+      authToken: sentryAuthToken,
+      organization: sentryOrganization,
+      ...(environment.SENTRY_BASE_URL === undefined ||
+      environment.SENTRY_BASE_URL === ""
+        ? {}
+        : { baseUrl: environment.SENTRY_BASE_URL }),
+    }),
+    logs: createDatadogLogStore({
+      apiKey: datadogApiKey,
+      applicationKey: datadogApplicationKey,
+      ...(environment.DD_BASE_URL === undefined ||
+      environment.DD_BASE_URL === ""
+        ? {}
+        : { baseUrl: environment.DD_BASE_URL }),
+    }),
+    telemetry: createNewRelicTelemetryReader({
+      userKey: newRelicUserKey,
+      accountId: newRelicAccountId,
+      ...(environment.NEW_RELIC_GRAPHQL_URL === undefined ||
+      environment.NEW_RELIC_GRAPHQL_URL === ""
+        ? {}
+        : { graphqlUrl: environment.NEW_RELIC_GRAPHQL_URL }),
+    }),
+  });
+}

--- a/examples/observability-engine/src/infrastructure/datadog-log-store.ts
+++ b/examples/observability-engine/src/infrastructure/datadog-log-store.ts
@@ -1,0 +1,87 @@
+import type { LogStore } from "../application/ports.js";
+import type { LogSummary } from "../domain/incident-context.js";
+import {
+  asRecord,
+  providerFailure,
+  readOptionalString,
+  readRequiredString,
+  requestProviderJson,
+} from "./provider-http.js";
+
+export interface DatadogLogStoreOptions {
+  readonly apiKey: string;
+  readonly applicationKey: string;
+  readonly baseUrl?: string;
+}
+
+const defaultBaseUrl = "https://api.datadoghq.com";
+
+function toLog(value: unknown, fallbackService: string): LogSummary | null {
+  const log = asRecord(value);
+  const attributes = log === null ? null : asRecord(log.attributes);
+  if (log === null || attributes === null) return null;
+  const id = readRequiredString(log, "id");
+  const timestamp = readRequiredString(attributes, "timestamp");
+  const message = readRequiredString(attributes, "message");
+  if (id === null || timestamp === null || message === null) return null;
+  return {
+    id,
+    timestamp,
+    service: readOptionalString(attributes, "service") ?? fallbackService,
+    severity: readOptionalString(attributes, "status"),
+    message,
+  };
+}
+
+export function createDatadogLogStore(
+  options: DatadogLogStoreOptions,
+): LogStore {
+  if (options.apiKey === "") {
+    throw new TypeError("A Datadog API key is required.");
+  }
+  if (options.applicationKey === "") {
+    throw new TypeError("A Datadog application key is required.");
+  }
+  const baseUrl = new URL(options.baseUrl ?? defaultBaseUrl);
+
+  return {
+    async searchServiceLogs(request, { signal }) {
+      const payload = await requestProviderJson(
+        "datadog",
+        new URL("/api/v2/logs/events/search", baseUrl),
+        {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            "dd-api-key": options.apiKey,
+            "dd-application-key": options.applicationKey,
+          },
+          body: JSON.stringify({
+            filter: {
+              query: `service:${request.service}`,
+              from: request.from,
+              to: request.to,
+            },
+            page: { limit: request.limit },
+            sort: "-timestamp",
+          }),
+        },
+        signal,
+      );
+      const response = asRecord(payload);
+      const data = response?.data;
+      if (!Array.isArray(data)) {
+        throw providerFailure(
+          "datadog",
+          "Datadog returned an unexpected payload.",
+        );
+      }
+      const logs = data.map((item) => toLog(item, request.service));
+      if (logs.some((log) => log === null)) {
+        throw providerFailure("datadog", "Datadog returned an unexpected log.");
+      }
+      return logs as LogSummary[];
+    },
+  };
+}

--- a/examples/observability-engine/src/infrastructure/new-relic-telemetry-reader.ts
+++ b/examples/observability-engine/src/infrastructure/new-relic-telemetry-reader.ts
@@ -1,0 +1,124 @@
+import type { TelemetryReader } from "../application/ports.js";
+import type { ServiceTelemetry } from "../domain/incident-context.js";
+import {
+  asRecord,
+  providerFailure,
+  requestProviderJson,
+} from "./provider-http.js";
+
+export interface NewRelicTelemetryReaderOptions {
+  readonly userKey: string;
+  readonly accountId: number;
+  readonly graphqlUrl?: string;
+}
+
+const defaultGraphqlUrl = "https://api.newrelic.com/graphql";
+
+function readFiniteNumber(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): number | null {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function toTelemetry(value: unknown): ServiceTelemetry | null {
+  const row = asRecord(value);
+  if (row === null) return null;
+  const transactionCount = readFiniteNumber(row, "transactionCount");
+  const rawErrorRate = row.errorRate;
+  const errorRate =
+    rawErrorRate === null ? 0 : readFiniteNumber(row, "errorRate");
+  const rawAverageDuration = row.averageDurationMs;
+  const averageDurationMs =
+    rawAverageDuration === null
+      ? null
+      : readFiniteNumber(row, "averageDurationMs");
+  if (
+    transactionCount === null ||
+    !Number.isSafeInteger(transactionCount) ||
+    transactionCount < 0 ||
+    errorRate === null ||
+    errorRate < 0 ||
+    errorRate > 100 ||
+    (averageDurationMs !== null && averageDurationMs < 0)
+  ) {
+    return null;
+  }
+  return { transactionCount, errorRate, averageDurationMs };
+}
+
+function createNrql(service: string, from: string, to: string): string {
+  return [
+    "SELECT count(*) AS 'transactionCount',",
+    "percentage(count(*), WHERE error IS true) AS 'errorRate',",
+    "average(duration) * 1000 AS 'averageDurationMs'",
+    "FROM Transaction",
+    `WHERE appName = '${service}'`,
+    `SINCE ${String(Date.parse(from))} UNTIL ${String(Date.parse(to))}`,
+  ].join(" ");
+}
+
+export function createNewRelicTelemetryReader(
+  options: NewRelicTelemetryReaderOptions,
+): TelemetryReader {
+  if (options.userKey === "") {
+    throw new TypeError("A New Relic user key is required.");
+  }
+  if (!Number.isSafeInteger(options.accountId) || options.accountId <= 0) {
+    throw new TypeError("A positive New Relic account ID is required.");
+  }
+  const graphqlUrl = new URL(options.graphqlUrl ?? defaultGraphqlUrl);
+
+  return {
+    async summarizeService(request, { signal }) {
+      const nrql = createNrql(request.service, request.from, request.to);
+      const graphQl = [
+        "query {",
+        "actor {",
+        `account(id: ${String(options.accountId)}) {`,
+        `nrql(query: ${JSON.stringify(nrql)}) { results }`,
+        "}",
+        "}",
+        "}",
+      ].join(" ");
+      const payload = await requestProviderJson(
+        "new-relic",
+        graphqlUrl,
+        {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            "api-key": options.userKey,
+          },
+          body: JSON.stringify({ query: graphQl }),
+        },
+        signal,
+      );
+      const response = asRecord(payload);
+      if (Array.isArray(response?.errors) && response.errors.length > 0) {
+        throw providerFailure(
+          "new-relic",
+          "New Relic returned an unsuccessful result.",
+        );
+      }
+      const data = response === null ? null : asRecord(response.data);
+      const actor = data === null ? null : asRecord(data.actor);
+      const account = actor === null ? null : asRecord(actor.account);
+      const nrqlResult = account === null ? null : asRecord(account.nrql);
+      const results = nrqlResult?.results;
+      const telemetry =
+        Array.isArray(results) && results.length === 1
+          ? toTelemetry(results[0])
+          : null;
+      if (telemetry === null) {
+        throw providerFailure(
+          "new-relic",
+          "New Relic returned an unexpected payload.",
+        );
+      }
+      return telemetry;
+    },
+  };
+}

--- a/examples/observability-engine/src/infrastructure/provider-http.ts
+++ b/examples/observability-engine/src/infrastructure/provider-http.ts
@@ -1,0 +1,89 @@
+import { EngineError } from "@ai-engine/core";
+
+export type ProviderName = "sentry" | "datadog" | "new-relic";
+
+const maximumCauseLength = 512;
+
+export function providerFailure(
+  provider: ProviderName,
+  message: string,
+  status?: number,
+  cause?: unknown,
+): EngineError {
+  return new EngineError({
+    code: "EXECUTION_FAILED",
+    message,
+    publicDetails: {
+      provider,
+      ...(status === undefined ? {} : { status }),
+    },
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+export function asRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : null;
+}
+
+export function readRequiredString(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+export function readOptionalString(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+export async function requestProviderJson(
+  provider: ProviderName,
+  url: URL,
+  init: RequestInit,
+  signal: AbortSignal,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, signal });
+  } catch (cause) {
+    if (signal.aborted) throw cause;
+    throw providerFailure(
+      provider,
+      `The ${provider} request could not be completed.`,
+      undefined,
+      cause,
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw providerFailure(
+      provider,
+      `${provider} rejected the request.`,
+      response.status,
+      new Error(
+        `${provider} responded with status ${String(response.status)}: ${detail.slice(0, maximumCauseLength)}`,
+      ),
+    );
+  }
+
+  try {
+    return await response.json();
+  } catch (cause) {
+    throw providerFailure(
+      provider,
+      `${provider} returned an unreadable payload.`,
+      undefined,
+      cause,
+    );
+  }
+}

--- a/examples/observability-engine/src/infrastructure/sentry-issue-tracker.ts
+++ b/examples/observability-engine/src/infrastructure/sentry-issue-tracker.ts
@@ -1,0 +1,102 @@
+import type { IssueTracker } from "../application/ports.js";
+import type { IssueSummary } from "../domain/incident-context.js";
+import {
+  asRecord,
+  providerFailure,
+  readOptionalString,
+  readRequiredString,
+  requestProviderJson,
+} from "./provider-http.js";
+
+export interface SentryIssueTrackerOptions {
+  readonly authToken: string;
+  readonly organization: string;
+  readonly baseUrl?: string;
+}
+
+const defaultBaseUrl = "https://sentry.io";
+
+function toIssue(value: unknown): IssueSummary | null {
+  const issue = asRecord(value);
+  if (issue === null) return null;
+  const project = asRecord(issue.project);
+  const id = readRequiredString(issue, "id");
+  const title = readRequiredString(issue, "title");
+  const status = readRequiredString(issue, "status");
+  const projectSlug =
+    project === null ? null : readRequiredString(project, "slug");
+  const lastSeen = readRequiredString(issue, "lastSeen");
+  const count = readRequiredString(issue, "count");
+  if (
+    id === null ||
+    title === null ||
+    status === null ||
+    projectSlug === null ||
+    lastSeen === null ||
+    count === null ||
+    !/^(?:0|[1-9][0-9]*)$/u.test(count)
+  ) {
+    return null;
+  }
+  const eventCount = Number(count);
+  if (!Number.isSafeInteger(eventCount)) return null;
+  return {
+    id,
+    title,
+    status,
+    project: projectSlug,
+    lastSeen,
+    eventCount,
+    url: readOptionalString(issue, "permalink"),
+  };
+}
+
+export function createSentryIssueTracker(
+  options: SentryIssueTrackerOptions,
+): IssueTracker {
+  if (options.authToken === "") {
+    throw new TypeError("A Sentry auth token is required.");
+  }
+  if (options.organization === "") {
+    throw new TypeError("A Sentry organization is required.");
+  }
+  const baseUrl = new URL(options.baseUrl ?? defaultBaseUrl);
+
+  return {
+    async searchServiceIssues(request, { signal }) {
+      const url = new URL(
+        `/api/0/organizations/${encodeURIComponent(options.organization)}/issues/`,
+        baseUrl,
+      );
+      url.searchParams.set("project", request.service);
+      url.searchParams.set("query", "is:unresolved");
+      url.searchParams.set("start", request.from);
+      url.searchParams.set("end", request.to);
+      url.searchParams.set("sort", "date");
+      url.searchParams.set("limit", String(request.limit));
+      const payload = await requestProviderJson(
+        "sentry",
+        url,
+        {
+          method: "GET",
+          headers: {
+            accept: "application/json",
+            authorization: `Bearer ${options.authToken}`,
+          },
+        },
+        signal,
+      );
+      if (!Array.isArray(payload)) {
+        throw providerFailure(
+          "sentry",
+          "Sentry returned an unexpected payload.",
+        );
+      }
+      const issues = payload.map(toIssue);
+      if (issues.some((issue) => issue === null)) {
+        throw providerFailure("sentry", "Sentry returned an unexpected issue.");
+      }
+      return issues as IssueSummary[];
+    },
+  };
+}

--- a/examples/observability-engine/src/local-principal.ts
+++ b/examples/observability-engine/src/local-principal.ts
@@ -1,0 +1,6 @@
+import type { Principal } from "@ai-engine/core";
+
+/** Trusted identity supplied by local direct, CLI, and MCP stdio hosts. */
+export const localPrincipal: Principal = Object.freeze({
+  id: "local:observability-operator",
+});

--- a/examples/observability-engine/src/mcp-http.ts
+++ b/examples/observability-engine/src/mcp-http.ts
@@ -1,0 +1,63 @@
+import { pathToFileURL } from "node:url";
+
+import { type McpHttpServerHandle, serveMcpHttp } from "@ai-engine/mcp";
+
+import { createProviderBackedObservabilityEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export interface ObservabilityMcpHttpOptions {
+  readonly expectedBearerToken: string;
+  readonly host?: string;
+  readonly port?: number;
+}
+
+export async function startObservabilityMcpHttp(
+  options: ObservabilityMcpHttpOptions,
+): Promise<McpHttpServerHandle> {
+  return serveMcpHttp(createProviderBackedObservabilityEngine(), {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.port === undefined ? {} : { port: options.port }),
+    auth: {
+      mode: "required",
+      authenticate(request) {
+        return request.headers.get("authorization") ===
+          `Bearer ${options.expectedBearerToken}`
+          ? localPrincipal
+          : null;
+      },
+    },
+  });
+}
+
+export async function main(): Promise<McpHttpServerHandle> {
+  const expectedBearerToken = process.env.OBSERVABILITY_ENGINE_BEARER_TOKEN;
+  if (expectedBearerToken === undefined || expectedBearerToken === "") {
+    throw new Error("OBSERVABILITY_ENGINE_BEARER_TOKEN is required.");
+  }
+  const configuredPort = process.env.PORT;
+  const port = configuredPort === undefined ? 3000 : Number(configuredPort);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error("PORT must be an integer between 0 and 65535.");
+  }
+  return startObservabilityMcpHttp({ expectedBearerToken, port });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main()
+    .then((server) => {
+      const address = server.address();
+      process.stderr.write(
+        `Observability engine MCP HTTP adapter listening on host ${address.host}, port ${String(address.port)}\n`,
+      );
+    })
+    .catch(() => {
+      process.stderr.write(
+        "Observability engine MCP HTTP adapter failed to start.\n",
+      );
+      process.exitCode = 1;
+    });
+}

--- a/examples/observability-engine/src/mcp-stdio.ts
+++ b/examples/observability-engine/src/mcp-stdio.ts
@@ -1,0 +1,23 @@
+import { pathToFileURL } from "node:url";
+
+import { serveMcpStdio } from "@ai-engine/mcp";
+
+import { createProviderBackedObservabilityEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<void> {
+  await serveMcpStdio(createProviderBackedObservabilityEngine(), {
+    principal: localPrincipal,
+  });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Observability engine MCP stdio adapter failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/observability-engine/test/entrypoints.test.ts
+++ b/examples/observability-engine/test/entrypoints.test.ts
@@ -1,0 +1,277 @@
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  type ObservabilityStub,
+  startObservabilityStub,
+} from "./observability-stub.js";
+
+const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
+const capabilityId = "observability.collect-incident-context";
+const input = {
+  service: "checkout-api",
+  from: "2026-07-28T12:00:00.000Z",
+  to: "2026-07-28T13:00:00.000Z",
+  limit: 2,
+} as const;
+
+let stub: ObservabilityStub;
+
+beforeAll(() => {
+  const build = spawnSync(
+    process.execPath,
+    ["../../node_modules/typescript/bin/tsc", "-b", "--pretty", "false"],
+    { cwd: exampleRoot, encoding: "utf8" },
+  );
+  if (build.status !== 0) {
+    throw new Error(`Example build failed:\n${build.stdout}${build.stderr}`);
+  }
+});
+
+beforeEach(async () => {
+  stub = await startObservabilityStub();
+});
+
+afterEach(async () => {
+  await stub.close();
+});
+
+function providerEnvironment(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    SENTRY_AUTH_TOKEN: "test-sentry-token",
+    SENTRY_ORG: "acme",
+    SENTRY_BASE_URL: stub.baseUrl,
+    DD_API_KEY: "test-datadog-api-key",
+    DD_APP_KEY: "test-datadog-application-key",
+    DD_BASE_URL: stub.baseUrl,
+    NEW_RELIC_USER_KEY: "test-new-relic-user-key",
+    NEW_RELIC_ACCOUNT_ID: "123456",
+    NEW_RELIC_GRAPHQL_URL: `${stub.baseUrl}/graphql`,
+  };
+}
+
+interface CommandResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+async function run(
+  entrypoint: string,
+  args: readonly string[] = [],
+  environment: NodeJS.ProcessEnv = providerEnvironment(),
+): Promise<CommandResult> {
+  const child = spawn(process.execPath, [`dist/${entrypoint}.js`, ...args], {
+    cwd: exampleRoot,
+    env: environment,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: Buffer | string) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer | string) => {
+    stderr += chunk.toString();
+  });
+  const [status] = (await once(child, "exit")) as [number | null];
+  return { status, stdout, stderr };
+}
+
+async function stopProcess(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) return;
+  const exited = once(child, "exit");
+  child.kill();
+  await exited;
+}
+
+function expectedContext() {
+  return {
+    service: input.service,
+    from: input.from,
+    to: input.to,
+    issues: [
+      {
+        id: "SENTRY-1",
+        title: "Payment confirmation failed",
+        status: "unresolved",
+        project: "checkout-api",
+        lastSeen: "2026-07-28T12:45:00.000Z",
+        eventCount: 42,
+        url: "https://sentry.example/issues/SENTRY-1",
+      },
+    ],
+    logs: [
+      {
+        id: "DD-1",
+        timestamp: "2026-07-28T12:40:00.000Z",
+        service: "checkout-api",
+        severity: "error",
+        message: "Payment confirmation failed",
+      },
+    ],
+    telemetry: {
+      transactionCount: 125,
+      errorRate: 2.5,
+      averageDurationMs: 420,
+    },
+  };
+}
+
+describe("observability engine entrypoints", () => {
+  it("collects incident context through the direct entrypoint with result-only stdout", async () => {
+    const result = await run("direct", [input.service, input.from, input.to]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual(expectedContext());
+  });
+
+  it("publishes and runs the same capability through the CLI", async () => {
+    const listed = await run("cli", ["list"]);
+    expect(listed.status).toBe(0);
+    expect(listed.stderr).toBe("");
+    expect(JSON.parse(listed.stdout)).toMatchObject([{ id: capabilityId }]);
+
+    const invoked = await run("cli", [
+      "run",
+      capabilityId,
+      "--input",
+      JSON.stringify(input),
+    ]);
+    expect(invoked.status).toBe(0);
+    expect(invoked.stderr).toBe("");
+    expect(JSON.parse(invoked.stdout)).toEqual(expectedContext());
+  });
+
+  it("fails startup without all provider credentials", async () => {
+    const result = await run("cli", ["list"], {
+      ...providerEnvironment(),
+      DD_APP_KEY: "",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toMatchObject({
+      error: { code: "EXECUTION_FAILED" },
+    });
+  });
+
+  it("serves the capability over protocol-only MCP stdio", async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["dist/mcp-stdio.js"],
+      cwd: exampleRoot,
+      env: providerEnvironment() as Record<string, string>,
+      stderr: "pipe",
+    });
+    let stderr = "";
+    transport.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    const client = new Client(
+      { name: "observability-stdio-test", version: "0.0.0-test" },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: capabilityId }],
+      });
+      await expect(
+        client.callTool({ name: capabilityId, arguments: input }),
+      ).resolves.toMatchObject({ structuredContent: expectedContext() });
+    } finally {
+      await client.close();
+    }
+
+    expect(stderr).toBe("");
+  });
+
+  it("serves authenticated stateless MCP HTTP without exposing credentials", async () => {
+    const token = "test-only-observability-token";
+    const child = spawn(process.execPath, ["dist/mcp-http.js"], {
+      cwd: exampleRoot,
+      env: {
+        ...providerEnvironment(),
+        OBSERVABILITY_ENGINE_BEARER_TOKEN: token,
+        PORT: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    let client: Client | undefined;
+
+    try {
+      const port = await vi.waitFor(
+        () => {
+          const match = stderr.match(/host 127\.0\.0\.1, port (\d+)/u);
+          expect(match?.[1]).toBeDefined();
+          return Number(match?.[1]);
+        },
+        { timeout: 5_000 },
+      );
+      const url = new URL(`http://127.0.0.1:${String(port)}/mcp`);
+      const unauthenticated = await fetch(url, {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "auth-boundary",
+          method: "tools/call",
+          params: { name: capabilityId, arguments: input },
+        }),
+      });
+      expect(unauthenticated.status).toBe(401);
+      await unauthenticated.arrayBuffer();
+
+      const transport = new StreamableHTTPClientTransport(url, {
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+      });
+      client = new Client(
+        { name: "observability-http-test", version: "0.0.0-test" },
+        { capabilities: {} },
+      );
+      await client.connect(transport as unknown as Transport);
+      await expect(
+        client.callTool({ name: capabilityId, arguments: input }),
+      ).resolves.toMatchObject({ structuredContent: expectedContext() });
+    } finally {
+      await client?.close().catch(() => undefined);
+      await stopProcess(child);
+    }
+
+    expect(stdout).toBe("");
+    expect(stderr).not.toContain(token);
+    expect(stderr).not.toContain("test-sentry-token");
+    expect(stderr).not.toContain("test-datadog-api-key");
+    expect(stderr).not.toContain("test-new-relic-user-key");
+  });
+});

--- a/examples/observability-engine/test/observability-engine.test.ts
+++ b/examples/observability-engine/test/observability-engine.test.ts
@@ -1,0 +1,333 @@
+import { EngineError, type Principal } from "@ai-engine/core";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import type {
+  IssueTracker,
+  LogStore,
+  ObservabilityDependencies,
+  TelemetryReader,
+} from "../src/application/ports.js";
+import { createObservabilityEngine } from "../src/engine.js";
+
+const principal: Principal = { id: "operator:local" };
+const input = {
+  service: "checkout-api",
+  from: "2026-07-28T12:00:00.000Z",
+  to: "2026-07-28T13:00:00.000Z",
+  limit: 2,
+} as const;
+
+function createDependencies(): ObservabilityDependencies {
+  const issues: IssueTracker = {
+    searchServiceIssues: vi.fn(async () => [
+      {
+        id: "SENTRY-1",
+        title: "Payment confirmation failed",
+        status: "unresolved",
+        project: "checkout-api",
+        lastSeen: "2026-07-28T12:45:00.000Z",
+        eventCount: 42,
+        url: "https://sentry.example/issues/SENTRY-1",
+      },
+    ]),
+  };
+  const logs: LogStore = {
+    searchServiceLogs: vi.fn(async () => [
+      {
+        id: "DD-1",
+        timestamp: "2026-07-28T12:40:00.000Z",
+        service: "checkout-api",
+        severity: "error",
+        message: "Payment confirmation failed",
+      },
+    ]),
+  };
+  const telemetry: TelemetryReader = {
+    summarizeService: vi.fn(async () => ({
+      transactionCount: 125,
+      errorRate: 2.5,
+      averageDurationMs: 420,
+    })),
+  };
+  return { issues, logs, telemetry };
+}
+
+describe("the observability engine example", () => {
+  it("collects one normalized incident context through injected provider ports", async () => {
+    const dependencies = createDependencies();
+    const engine = createObservabilityEngine(dependencies);
+
+    const result = await engine.invoke(
+      "observability.collect-incident-context",
+      input,
+      { source: "direct", principal },
+    );
+
+    expectTypeOf(result).toEqualTypeOf<{
+      service: string;
+      from: string;
+      to: string;
+      issues: Array<{
+        id: string;
+        title: string;
+        status: string;
+        project: string;
+        lastSeen: string;
+        eventCount: number;
+        url: string | null;
+      }>;
+      logs: Array<{
+        id: string;
+        timestamp: string;
+        service: string;
+        severity: string | null;
+        message: string;
+      }>;
+      telemetry: {
+        transactionCount: number;
+        errorRate: number;
+        averageDurationMs: number | null;
+      };
+    }>();
+    expect(result).toEqual({
+      service: input.service,
+      from: input.from,
+      to: input.to,
+      issues: [
+        {
+          id: "SENTRY-1",
+          title: "Payment confirmation failed",
+          status: "unresolved",
+          project: "checkout-api",
+          lastSeen: "2026-07-28T12:45:00.000Z",
+          eventCount: 42,
+          url: "https://sentry.example/issues/SENTRY-1",
+        },
+      ],
+      logs: [
+        {
+          id: "DD-1",
+          timestamp: "2026-07-28T12:40:00.000Z",
+          service: "checkout-api",
+          severity: "error",
+          message: "Payment confirmation failed",
+        },
+      ],
+      telemetry: {
+        transactionCount: 125,
+        errorRate: 2.5,
+        averageDurationMs: 420,
+      },
+    });
+    const expectedRequest = input;
+    expect(dependencies.issues.searchServiceIssues).toHaveBeenCalledWith(
+      expectedRequest,
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(dependencies.logs.searchServiceLogs).toHaveBeenCalledWith(
+      expectedRequest,
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(dependencies.telemetry.summarizeService).toHaveBeenCalledWith(
+      expectedRequest,
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("applies the default provider result limit", async () => {
+    const dependencies = createDependencies();
+    const engine = createObservabilityEngine(dependencies);
+
+    await engine.invoke(
+      "observability.collect-incident-context",
+      {
+        service: input.service,
+        from: input.from,
+        to: input.to,
+      },
+      { source: "direct", principal },
+    );
+
+    expect(dependencies.issues.searchServiceIssues).toHaveBeenCalledWith(
+      { ...input, limit: 20 },
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("enforces the requested result limit when a provider returns too many items", async () => {
+    const dependencies = createDependencies();
+    const issue = await dependencies.issues.searchServiceIssues(input, {
+      signal: new AbortController().signal,
+    });
+    const log = await dependencies.logs.searchServiceLogs(input, {
+      signal: new AbortController().signal,
+    });
+    dependencies.issues.searchServiceIssues = vi.fn(async () => [
+      ...issue,
+      ...issue,
+    ]);
+    dependencies.logs.searchServiceLogs = vi.fn(async () => [...log, ...log]);
+    const engine = createObservabilityEngine(dependencies);
+
+    const result = await engine.invoke(
+      "observability.collect-incident-context",
+      { ...input, limit: 1 },
+      { source: "direct", principal },
+    );
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.logs).toHaveLength(1);
+  });
+
+  it.each([
+    ["an empty service", { ...input, service: "" }],
+    ["an unsafe service identifier", { ...input, service: "checkout api" }],
+    ["an inverted time range", { ...input, from: input.to, to: input.from }],
+    [
+      "a time range longer than seven days",
+      { ...input, from: "2026-07-20T12:00:00.000Z" },
+    ],
+    ["a provider limit above 100", { ...input, limit: 101 }],
+  ])("rejects %s before any provider request", async (_description, value) => {
+    const dependencies = createDependencies();
+    const engine = createObservabilityEngine(dependencies);
+
+    await expect(
+      engine.invoke("observability.collect-incident-context", value, {
+        source: "direct",
+        principal,
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+    expect(dependencies.issues.searchServiceIssues).not.toHaveBeenCalled();
+    expect(dependencies.logs.searchServiceLogs).not.toHaveBeenCalled();
+    expect(dependencies.telemetry.summarizeService).not.toHaveBeenCalled();
+  });
+
+  it("requires an authenticated principal before provider access", async () => {
+    const dependencies = createDependencies();
+    const engine = createObservabilityEngine(dependencies);
+
+    await expect(
+      engine.invoke("observability.collect-incident-context", input, {
+        source: "direct",
+        principal: null,
+      }),
+    ).rejects.toMatchObject({ code: "UNAUTHENTICATED" });
+    expect(dependencies.issues.searchServiceIssues).not.toHaveBeenCalled();
+    expect(dependencies.logs.searchServiceLogs).not.toHaveBeenCalled();
+    expect(dependencies.telemetry.summarizeService).not.toHaveBeenCalled();
+  });
+
+  it("propagates caller cancellation to every provider port", async () => {
+    const dependencies = createDependencies();
+    const providerSignals: AbortSignal[] = [];
+    const waitForCancellation = async (
+      _request: unknown,
+      { signal }: { readonly signal: AbortSignal },
+    ): Promise<never> => {
+      providerSignals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      });
+    };
+    dependencies.issues.searchServiceIssues = vi.fn(waitForCancellation);
+    dependencies.logs.searchServiceLogs = vi.fn(waitForCancellation);
+    dependencies.telemetry.summarizeService = vi.fn(waitForCancellation);
+    const engine = createObservabilityEngine(dependencies);
+    const controller = new AbortController();
+
+    const invocation = engine.invoke(
+      "observability.collect-incident-context",
+      input,
+      { source: "direct", principal, signal: controller.signal },
+    );
+    await vi.waitFor(() => expect(providerSignals).toHaveLength(3));
+    controller.abort(new Error("Incident investigation stopped."));
+
+    await expect(invocation).rejects.toMatchObject({ code: "CANCELLED" });
+    expect(providerSignals.every(({ aborted }) => aborted)).toBe(true);
+  });
+
+  it("aborts sibling provider work when one provider fails", async () => {
+    const dependencies = createDependencies();
+    const siblingSignals: AbortSignal[] = [];
+    dependencies.issues.searchServiceIssues = vi.fn(async () => {
+      throw new EngineError({
+        code: "EXECUTION_FAILED",
+        message: "Sentry rejected the request.",
+        publicDetails: { provider: "sentry", status: 503 },
+      });
+    });
+    const waitForSiblingAbort = async (
+      _request: unknown,
+      { signal }: { readonly signal: AbortSignal },
+    ): Promise<never> => {
+      siblingSignals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      });
+    };
+    dependencies.logs.searchServiceLogs = vi.fn(waitForSiblingAbort);
+    dependencies.telemetry.summarizeService = vi.fn(waitForSiblingAbort);
+    const engine = createObservabilityEngine(dependencies);
+
+    await expect(
+      engine.invoke("observability.collect-incident-context", input, {
+        source: "direct",
+        principal,
+      }),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      publicDetails: { provider: "sentry", status: 503 },
+    });
+    expect(siblingSignals).toHaveLength(2);
+    expect(siblingSignals.every(({ aborted }) => aborted)).toBe(true);
+  });
+
+  it("rejects provider data that breaks the normalized output contract", async () => {
+    const dependencies = createDependencies();
+    dependencies.telemetry.summarizeService = vi.fn(async () => ({
+      transactionCount: 1,
+      errorRate: 101,
+      averageDurationMs: 10,
+    }));
+    const engine = createObservabilityEngine(dependencies);
+
+    await expect(
+      engine.invoke("observability.collect-incident-context", input, {
+        source: "direct",
+        principal,
+      }),
+    ).rejects.toMatchObject({ code: "OUTPUT_INVALID" });
+  });
+
+  it("publishes one bounded read-only open-world capability", () => {
+    const engine = createObservabilityEngine(createDependencies());
+
+    expect(engine.list().map(({ id }) => id)).toEqual([
+      "observability.collect-incident-context",
+    ]);
+    expect(
+      engine.describe("observability.collect-incident-context"),
+    ).toMatchObject({
+      id: "observability.collect-incident-context",
+      title: "Collect incident context",
+      timeoutMs: 30_000,
+      annotations: {
+        readOnly: true,
+        destructive: false,
+        idempotent: true,
+        openWorld: true,
+      },
+      inputSchema: {
+        type: "object",
+        required: ["service", "from", "to"],
+      },
+      outputSchema: { type: "object" },
+    });
+  });
+});

--- a/examples/observability-engine/test/observability-stub.ts
+++ b/examples/observability-engine/test/observability-stub.ts
@@ -1,0 +1,186 @@
+import { once } from "node:events";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface ObservabilityStubRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query: Readonly<Record<string, string>>;
+  readonly authorization: string | null;
+  readonly datadogApiKey: string | null;
+  readonly datadogApplicationKey: string | null;
+  readonly newRelicUserKey: string | null;
+  readonly body: unknown;
+}
+
+export interface ObservabilityStubOptions {
+  readonly sentryStatus?: number;
+  readonly datadogStatus?: number;
+  readonly newRelicStatus?: number;
+  readonly newRelicGraphqlError?: boolean;
+}
+
+export interface ObservabilityStub {
+  readonly baseUrl: string;
+  readonly requests: ReadonlyArray<ObservabilityStubRequest>;
+  close(): Promise<void>;
+}
+
+function send(
+  response: ServerResponse,
+  status: number,
+  payload: unknown,
+): void {
+  const body = JSON.stringify(payload);
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": String(Buffer.byteLength(body)),
+  });
+  response.end(body);
+}
+
+async function readBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(chunk as Buffer);
+  if (chunks.length === 0) return undefined;
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function queryRecord(url: URL): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    [...url.searchParams.entries()].sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+}
+
+export async function startObservabilityStub(
+  options: ObservabilityStubOptions = {},
+): Promise<ObservabilityStub> {
+  const requests: ObservabilityStubRequest[] = [];
+  const server = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      const body = await readBody(request);
+      requests.push({
+        method: request.method ?? "GET",
+        path: url.pathname,
+        query: queryRecord(url),
+        authorization: request.headers.authorization ?? null,
+        datadogApiKey:
+          typeof request.headers["dd-api-key"] === "string"
+            ? request.headers["dd-api-key"]
+            : null,
+        datadogApplicationKey:
+          typeof request.headers["dd-application-key"] === "string"
+            ? request.headers["dd-application-key"]
+            : null,
+        newRelicUserKey:
+          typeof request.headers["api-key"] === "string"
+            ? request.headers["api-key"]
+            : null,
+        body,
+      });
+
+      if (url.pathname.startsWith("/api/0/organizations/")) {
+        const status = options.sentryStatus ?? 200;
+        if (status !== 200) {
+          send(response, status, { detail: "Sentry stub rejected a secret." });
+          return;
+        }
+        send(response, 200, [
+          {
+            id: "SENTRY-1",
+            title: "Payment confirmation failed",
+            status: "unresolved",
+            project: { slug: "checkout-api" },
+            lastSeen: "2026-07-28T12:45:00.000Z",
+            count: "42",
+            permalink: "https://sentry.example/issues/SENTRY-1",
+          },
+        ]);
+        return;
+      }
+
+      if (url.pathname === "/api/v2/logs/events/search") {
+        const status = options.datadogStatus ?? 200;
+        if (status !== 200) {
+          send(response, status, {
+            errors: ["Datadog stub rejected a secret."],
+          });
+          return;
+        }
+        send(response, 200, {
+          data: [
+            {
+              id: "DD-1",
+              attributes: {
+                timestamp: "2026-07-28T12:40:00.000Z",
+                service: "checkout-api",
+                status: "error",
+                message: "Payment confirmation failed",
+              },
+            },
+          ],
+        });
+        return;
+      }
+
+      if (url.pathname === "/graphql") {
+        const status = options.newRelicStatus ?? 200;
+        if (status !== 200) {
+          send(response, status, {
+            errors: [{ message: "Rejected a secret." }],
+          });
+          return;
+        }
+        if (options.newRelicGraphqlError === true) {
+          send(response, 200, { errors: [{ message: "Access denied." }] });
+          return;
+        }
+        send(response, 200, {
+          data: {
+            actor: {
+              account: {
+                nrql: {
+                  results: [
+                    {
+                      transactionCount: 125,
+                      errorRate: 2.5,
+                      averageDurationMs: 420,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+        return;
+      }
+
+      send(response, 404, { error: "Not found" });
+    })();
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${String(address.port)}`,
+    requests,
+    async close() {
+      server.closeAllConnections();
+      server.close();
+      await once(server, "close");
+    },
+  };
+}

--- a/examples/observability-engine/test/provider-adapters.test.ts
+++ b/examples/observability-engine/test/provider-adapters.test.ts
@@ -1,0 +1,230 @@
+import type { EngineError } from "@ai-engine/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createDatadogLogStore } from "../src/infrastructure/datadog-log-store.js";
+import { createNewRelicTelemetryReader } from "../src/infrastructure/new-relic-telemetry-reader.js";
+import { createSentryIssueTracker } from "../src/infrastructure/sentry-issue-tracker.js";
+import {
+  type ObservabilityStub,
+  type ObservabilityStubOptions,
+  startObservabilityStub,
+} from "./observability-stub.js";
+
+const request = {
+  service: "checkout-api",
+  from: "2026-07-28T12:00:00.000Z",
+  to: "2026-07-28T13:00:00.000Z",
+  limit: 2,
+} as const;
+const sentryToken = "test-sentry-token";
+const datadogApiKey = "test-datadog-api-key";
+const datadogApplicationKey = "test-datadog-application-key";
+const newRelicUserKey = "test-new-relic-user-key";
+
+let stub: ObservabilityStub | undefined;
+
+async function startStub(
+  options: ObservabilityStubOptions = {},
+): Promise<ObservabilityStub> {
+  stub = await startObservabilityStub(options);
+  return stub;
+}
+
+afterEach(async () => {
+  await stub?.close();
+  stub = undefined;
+});
+
+describe("the Sentry issue tracker adapter", () => {
+  it("queries organization issues with a bearer credential and maps the response", async () => {
+    const server = await startStub();
+
+    const issues = await createSentryIssueTracker({
+      authToken: sentryToken,
+      organization: "acme",
+      baseUrl: server.baseUrl,
+    }).searchServiceIssues(request, {
+      signal: new AbortController().signal,
+    });
+
+    expect(issues).toEqual([
+      {
+        id: "SENTRY-1",
+        title: "Payment confirmation failed",
+        status: "unresolved",
+        project: "checkout-api",
+        lastSeen: "2026-07-28T12:45:00.000Z",
+        eventCount: 42,
+        url: "https://sentry.example/issues/SENTRY-1",
+      },
+    ]);
+    expect(server.requests[0]).toMatchObject({
+      method: "GET",
+      path: "/api/0/organizations/acme/issues/",
+      authorization: `Bearer ${sentryToken}`,
+    });
+    expect(server.requests[0]?.query).toEqual({
+      end: request.to,
+      limit: "2",
+      project: request.service,
+      query: "is:unresolved",
+      sort: "date",
+      start: request.from,
+    });
+  });
+});
+
+describe("the Datadog log store adapter", () => {
+  it("searches bounded service logs with both Datadog credentials", async () => {
+    const server = await startStub();
+
+    const logs = await createDatadogLogStore({
+      apiKey: datadogApiKey,
+      applicationKey: datadogApplicationKey,
+      baseUrl: server.baseUrl,
+    }).searchServiceLogs(request, {
+      signal: new AbortController().signal,
+    });
+
+    expect(logs).toEqual([
+      {
+        id: "DD-1",
+        timestamp: "2026-07-28T12:40:00.000Z",
+        service: "checkout-api",
+        severity: "error",
+        message: "Payment confirmation failed",
+      },
+    ]);
+    expect(server.requests[0]).toMatchObject({
+      method: "POST",
+      path: "/api/v2/logs/events/search",
+      datadogApiKey,
+      datadogApplicationKey,
+      body: {
+        filter: {
+          query: "service:checkout-api",
+          from: request.from,
+          to: request.to,
+        },
+        page: { limit: 2 },
+        sort: "-timestamp",
+      },
+    });
+  });
+});
+
+describe("the New Relic telemetry reader adapter", () => {
+  it("runs a bounded NRQL aggregate through NerdGraph and maps its row", async () => {
+    const server = await startStub();
+
+    const summary = await createNewRelicTelemetryReader({
+      userKey: newRelicUserKey,
+      accountId: 123_456,
+      graphqlUrl: `${server.baseUrl}/graphql`,
+    }).summarizeService(request, {
+      signal: new AbortController().signal,
+    });
+
+    expect(summary).toEqual({
+      transactionCount: 125,
+      errorRate: 2.5,
+      averageDurationMs: 420,
+    });
+    expect(server.requests[0]).toMatchObject({
+      method: "POST",
+      path: "/graphql",
+      newRelicUserKey,
+    });
+    const body = server.requests[0]?.body as { readonly query?: unknown };
+    expect(body.query).toBeTypeOf("string");
+    expect(body.query).toContain("account(id: 123456)");
+    expect(body.query).toContain("WHERE appName = 'checkout-api'");
+    expect(body.query).toContain(
+      `SINCE ${String(Date.parse(request.from))} UNTIL ${String(Date.parse(request.to))}`,
+    );
+  });
+});
+
+describe("provider failure boundaries", () => {
+  it.each([
+    ["sentry", { sentryStatus: 401 }],
+    ["datadog", { datadogStatus: 429 }],
+    ["new-relic", { newRelicStatus: 503 }],
+  ] as const)(
+    "sanitizes a %s HTTP rejection without exposing credentials",
+    async (provider, options) => {
+      const server = await startStub(options);
+      const controller = new AbortController();
+      const operation =
+        provider === "sentry"
+          ? createSentryIssueTracker({
+              authToken: sentryToken,
+              organization: "acme",
+              baseUrl: server.baseUrl,
+            }).searchServiceIssues(request, { signal: controller.signal })
+          : provider === "datadog"
+            ? createDatadogLogStore({
+                apiKey: datadogApiKey,
+                applicationKey: datadogApplicationKey,
+                baseUrl: server.baseUrl,
+              }).searchServiceLogs(request, { signal: controller.signal })
+            : createNewRelicTelemetryReader({
+                userKey: newRelicUserKey,
+                accountId: 123_456,
+                graphqlUrl: `${server.baseUrl}/graphql`,
+              }).summarizeService(request, { signal: controller.signal });
+
+      const failure = await operation.then(
+        () => undefined,
+        (error: unknown) => error as EngineError,
+      );
+
+      expect(failure).toMatchObject({
+        code: "EXECUTION_FAILED",
+        publicDetails: {
+          provider,
+          status:
+            provider === "sentry" ? 401 : provider === "datadog" ? 429 : 503,
+        },
+      });
+      const publicFailure = JSON.stringify({
+        message: failure?.message,
+        publicDetails: failure?.publicDetails,
+      });
+      expect(publicFailure).not.toContain(sentryToken);
+      expect(publicFailure).not.toContain(datadogApiKey);
+      expect(publicFailure).not.toContain(datadogApplicationKey);
+      expect(publicFailure).not.toContain(newRelicUserKey);
+    },
+  );
+
+  it("treats NerdGraph errors in a successful HTTP response as a provider failure", async () => {
+    const server = await startStub({ newRelicGraphqlError: true });
+
+    await expect(
+      createNewRelicTelemetryReader({
+        userKey: newRelicUserKey,
+        accountId: 123_456,
+        graphqlUrl: `${server.baseUrl}/graphql`,
+      }).summarizeService(request, {
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "New Relic returned an unsuccessful result.",
+      publicDetails: { provider: "new-relic" },
+    });
+  });
+
+  it("fails fast on missing provider configuration", () => {
+    expect(() =>
+      createSentryIssueTracker({ authToken: "", organization: "acme" }),
+    ).toThrow("A Sentry auth token is required.");
+    expect(() =>
+      createDatadogLogStore({ apiKey: "", applicationKey: "app-key" }),
+    ).toThrow("A Datadog API key is required.");
+    expect(() =>
+      createNewRelicTelemetryReader({ userKey: "key", accountId: 0 }),
+    ).toThrow("A positive New Relic account ID is required.");
+  });
+});

--- a/examples/observability-engine/tsconfig.json
+++ b/examples/observability-engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/example-observability.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/cli" },
+    { "path": "../../packages/mcp" }
+  ]
+}

--- a/examples/observability-engine/tsconfig.test.json
+++ b/examples/observability-engine/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "./examples/composed-engine" },
     { "path": "./examples/crawl-engine" },
     { "path": "./examples/hello-engine" },
+    { "path": "./examples/observability-engine" },
     { "path": "./examples/spec-engine" },
     { "path": "./examples/support-engine" },
     { "path": "./examples/support-harness" }


### PR DESCRIPTION
## Summary

- add an `observability-engine` example with the domain capability `observability.collect-incident-context`
- query Sentry issues, Datadog logs, and New Relic telemetry through injected engine-owned ports
- expose the same capability through direct invocation, CLI, MCP stdio, and authenticated stateless MCP HTTP
- document configuration, provider mapping, operational limits, replacement points, and local verification
- add local provider stubs and contract, adapter, cancellation, failure-boundary, and entrypoint tests

## Why

The repository needs a concrete multi-provider engine example that preserves the domain-first contract and the single `engine.invoke` execution path. Provider credentials and HTTP contracts stay behind the custom engine's ports, so they do not enter capability inputs, outputs, events, or public error details.

## Developer impact

The example demonstrates bounded concurrent provider access with a seven-day time window, per-provider result limits, a 30-second invocation timeout, caller cancellation propagation, and sibling request cancellation after a provider failure. Real accounts only require environment configuration; the automated tests never call public provider APIs.

## Validation

- `yarn run check`
  - TypeScript build and test typecheck passed
  - Biome lint and format checks passed
  - 71 test files passed
  - 1,330 tests passed
  - final build passed
- `git diff --check main...HEAD` passed
