### PR TITLE
feat(examples): add task readiness review engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Then follow the [getting-started guide](./docs/getting-started.md) or inspect:
   that run before authorization;
 - [`spec-engine`](./examples/spec-engine/) for a spec-driven development
   workflow whose ordering, state, and per-step authorization live in the domain
-  rather than in a workflow engine.
+  rather than in a workflow engine;
+- [`review-engine`](./examples/review-engine/) for a fail-closed code review,
+  acceptance-eval, and adversarial-review gate that tells an agent whether a
+  task is ready to be declared complete.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ conflicts with a contract or ADR, the normative source takes precedence.
 - [`support-harness`: private MCP consumer](../examples/support-harness/)
 - [`crawl-engine`: outbound provider integration with Firecrawl](../examples/crawl-engine/)
 - [`spec-engine`: spec-driven development workflow as domain rules](../examples/spec-engine/)
+- [`review-engine`: fail-closed task completion review](../examples/review-engine/)
 - [`community-capabilities`: atomic and library capability publication fixture](../examples/community-capabilities/)
 - [`composed-engine`: local, atomic, and library capability composition](../examples/composed-engine/)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,9 +11,11 @@ For complete, runnable compositions, see
 onboarding path. The support example demonstrates injected ports and a domain
 authorization rule. Two further examples apply the same contracts to harder
 cases: [`crawl-engine`](../examples/crawl-engine/) integrates an external
-provider (Firecrawl) behind a port, and [`spec-engine`](../examples/spec-engine/)
+provider (Firecrawl) behind a port, [`spec-engine`](../examples/spec-engine/)
 runs a multi-step, spec-driven workflow using domain stage rules instead of a
-workflow engine.
+workflow engine, and [`review-engine`](../examples/review-engine/) applies
+code-review, acceptance-eval, and adversarial-review rules before an agent may
+declare a task complete.
 
 ## Prerequisites
 

--- a/examples/review-engine/README.md
+++ b/examples/review-engine/README.md
@@ -1,0 +1,156 @@
+# Review engine example
+
+This example publishes `review.assess-task-readiness`, a fail-closed completion
+gate for coding agents. The agent submits the task, acceptance criteria, changed
+files, patch, and verification evidence. The capability runs three independent
+reviews and returns `readyToComplete: true` only when every gate passes.
+
+The same capability is available through direct invocation, the CLI, MCP stdio,
+and stateless MCP HTTP. Every channel executes the capability through
+`engine.invoke`; no adapter duplicates the review rules.
+
+## Standard agent workflow
+
+1. Turn the task requirements into binary, observable acceptance criteria with
+   stable IDs.
+2. Implement the change and collect evidence. Every evidence record names the
+   criteria it supports and records whether the check passed.
+3. Submit the current changed-file list and patch to
+   `review.assess-task-readiness`.
+4. Address every returned blocker, update the patch and evidence, and run the
+   assessment again.
+5. Declare the task complete only when `readyToComplete` is `true`, `blockers` is
+   empty, and `nextAction` is `declare-complete`.
+
+An assessment is stateless and describes one review attempt. Rerunning after a
+change creates a fresh decision from the new candidate; the framework does not
+provide a workflow engine, review session, queue, or release gate.
+
+## Review policy
+
+The versioned policy lives in `src/domain/policy.ts`. Review adapters receive the
+applicable rule set and independent snapshots of the candidate, so one reviewer
+cannot mutate another reviewer's input or anchor it with a prior verdict.
+
+### Code review
+
+| Rule | Required review behavior |
+| --- | --- |
+| `CR-01` | Find correctness defects and regressions relative to the task and acceptance criteria. |
+| `CR-02` | Check public contracts, compatibility, architecture boundaries, and repository instructions. |
+| `CR-03` | Require focused verification and reject known failing checks. |
+| `CR-04` | Inspect relevant security, authorization, data handling, cancellation, concurrency, and resource limits. |
+| `CR-05` | Reject unrelated scope, unresolved bypasses, speculative abstractions, and maintainability regressions. |
+
+A `blocker` or `major` finding fails the code-review gate. A `minor` finding is
+reported but does not prevent completion. Duplicate finding IDs and findings
+that cite an unknown rule fail closed.
+
+### Acceptance judges and evals
+
+| Rule | Required evaluation behavior |
+| --- | --- |
+| `EV-01` | Return exactly one binary verdict for every criterion and none for unknown criteria. |
+| `EV-02` | A pass cites unique, passed evidence mapped to that same criterion. |
+| `EV-03` | Judge observable outcomes instead of implementation details or confidence claims. |
+| `EV-04` | Missing, conflicting, ambiguous, or unreproducible evidence fails closed. |
+
+The engine, rather than the judge, enforces criterion coverage and evidence
+cross-references. A persuasive but structurally incomplete judge response can
+never produce a passing completion decision.
+
+### Adversarial review
+
+| Rule | Required adversarial behavior |
+| --- | --- |
+| `AR-01` | Attempt at least one concrete counterexample for every criterion. |
+| `AR-02` | Probe applicable invalid inputs, boundaries, failures, authorization, cancellation, and concurrency. |
+| `AR-03` | Challenge the candidate independently of prior review and eval claims. |
+| `AR-04` | Every exposed gap or missing criterion challenge blocks completion. |
+
+An adversarial attempt reports either `survived` or `exposed-gap`. An unknown
+criterion, duplicate attempt ID, exposed gap, or criterion without an attempt
+fails the adversarial gate.
+
+## Deterministic demonstration adapter
+
+`src/infrastructure/deterministic-reviewers.ts` keeps the example runnable with
+no model provider. It checks structured evidence, requires at least one passing
+automated test, requires passing `adversarial-test` evidence for every criterion,
+rejects reported failing checks, and flags added `TODO`, `FIXME`, `@ts-ignore`,
+or `biome-ignore` markers.
+
+Those checks demonstrate the contract and workflow; they are not a production
+code reviewer, LLM judge, security scanner, or quality guarantee. Replace the
+three ports in `src/application/ports.ts` with model-, tool-, or service-backed
+adapters that apply the supplied rules, bound provider responses, and honor the
+received `AbortSignal`. The readiness calculation and public capability contract
+do not change.
+
+## Contract and limits
+
+- An authenticated principal is required and comes from the invocation boundary,
+  never from the task payload.
+- Each request contains 1–50 unique criteria, 1–200 evidence records, and 1–200
+  changed files.
+- The patch is limited to 200,000 characters. Identifiers are limited to 96
+  characters; summaries, commands, file names, and rule outputs also have
+  explicit schema limits.
+- Evidence IDs are unique and may reference only criteria declared by the same
+  request.
+- Reviewer reports are bounded before readiness is calculated: 200 code
+  findings, 100 eval results, and 200 adversarial attempts.
+- The capability timeout is 120 seconds. Cancellation is propagated to all
+  three reviewer ports.
+- Invalid input fails as `INPUT_INVALID`; unauthorized calls fail before any
+  reviewer runs; reviewer failures are normalized by the engine pipeline.
+- The patch and evidence are business payloads and are not included in framework
+  events. Provider-backed adapters must apply their own data-handling policy,
+  and reviewer summaries and findings must not expose secrets because they are
+  returned to the caller.
+
+## Run the example
+
+From the repository root, build the framework and example:
+
+```sh
+yarn build
+```
+
+Run the bundled passing assessment:
+
+```sh
+node examples/review-engine/dist/direct.js
+```
+
+Use the CLI:
+
+```sh
+node examples/review-engine/dist/cli.js list
+node examples/review-engine/dist/cli.js describe review.assess-task-readiness
+node examples/review-engine/dist/cli.js run review.assess-task-readiness --input '{"taskId":"TASK-1","summary":"Verify completion","acceptanceCriteria":[{"id":"AC-1","statement":"The focused test passes."}],"change":{"summary":"Add the behavior","files":["src/change.ts","test/change.test.ts"],"patch":"+export const changed = true;"},"evidence":[{"id":"TEST-1","kind":"test","criterionIds":["AC-1"],"passed":true,"command":"vitest run change.test.ts","summary":"Focused test passed."},{"id":"ADV-1","kind":"adversarial-test","criterionIds":["AC-1"],"passed":true,"command":"vitest run change.adversarial.test.ts","summary":"The negative case stayed blocked."}]}'
+```
+
+Start the MCP stdio adapter from an MCP host configuration:
+
+```sh
+node examples/review-engine/dist/mcp-stdio.js
+```
+
+Start stateless MCP HTTP on the loopback default:
+
+```sh
+REVIEW_ENGINE_BEARER_TOKEN=development-only-token \
+  node examples/review-engine/dist/mcp-http.js
+```
+
+The literal bearer-token comparison is a deterministic authentication-boundary
+demonstration, not production identity validation.
+
+## Verify the example
+
+```sh
+yarn workspace @ai-engine/example-review test
+yarn workspace @ai-engine/example-review typecheck
+yarn workspace @ai-engine/example-review build
+```

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ai-engine/example-review",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "typecheck": "tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false --noEmit",
+    "test": "vitest run test",
+    "direct": "node dist/direct.js",
+    "cli": "node dist/cli.js",
+    "mcp:stdio": "node dist/mcp-stdio.js",
+    "mcp:http": "node dist/mcp-http.js"
+  },
+  "dependencies": {
+    "@ai-engine/cli": "0.1.0",
+    "@ai-engine/core": "0.1.0",
+    "@ai-engine/mcp": "0.1.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  }
+}

--- a/examples/review-engine/src/application/ports.ts
+++ b/examples/review-engine/src/application/ports.ts
@@ -1,0 +1,41 @@
+import type {
+  AcceptanceEvaluationReport,
+  AdversarialReviewReport,
+  CodeReviewReport,
+  ReviewCandidate,
+} from "../domain/review.js";
+import type { ReviewRule } from "../domain/policy.js";
+
+export interface ReviewerOptions {
+  readonly signal: AbortSignal;
+}
+
+export interface CodeReviewer {
+  review(
+    candidate: ReviewCandidate,
+    rules: ReadonlyArray<ReviewRule>,
+    options: ReviewerOptions,
+  ): Promise<CodeReviewReport>;
+}
+
+export interface AcceptanceJudge {
+  evaluate(
+    candidate: ReviewCandidate,
+    rules: ReadonlyArray<ReviewRule>,
+    options: ReviewerOptions,
+  ): Promise<AcceptanceEvaluationReport>;
+}
+
+export interface AdversarialReviewer {
+  challenge(
+    candidate: ReviewCandidate,
+    rules: ReadonlyArray<ReviewRule>,
+    options: ReviewerOptions,
+  ): Promise<AdversarialReviewReport>;
+}
+
+export interface ReviewDependencies {
+  readonly codeReviewer: CodeReviewer;
+  readonly acceptanceJudge: AcceptanceJudge;
+  readonly adversarialReviewer: AdversarialReviewer;
+}

--- a/examples/review-engine/src/capabilities/assess-task-readiness.ts
+++ b/examples/review-engine/src/capabilities/assess-task-readiness.ts
@@ -1,0 +1,204 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import type { ReviewDependencies } from "../application/ports.js";
+import { standardReviewPolicy } from "../domain/policy.js";
+import { assessReadiness } from "../domain/readiness.js";
+
+const identifier = z
+  .string()
+  .trim()
+  .min(1)
+  .max(96)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u);
+
+const criterionInput = z.object({
+  id: identifier,
+  statement: z.string().trim().min(1).max(1_000),
+});
+
+const evidenceInput = z.object({
+  id: identifier,
+  kind: z.enum([
+    "test",
+    "adversarial-test",
+    "typecheck",
+    "lint",
+    "build",
+    "manual-inspection",
+  ]),
+  criterionIds: z.array(identifier).min(1).max(50),
+  passed: z.boolean(),
+  command: z.string().trim().min(1).max(1_000).nullable(),
+  summary: z.string().trim().min(1).max(2_000),
+});
+
+const input = z
+  .object({
+    taskId: identifier,
+    summary: z.string().trim().min(1).max(2_000),
+    acceptanceCriteria: z.array(criterionInput).min(1).max(50),
+    change: z.object({
+      summary: z.string().trim().min(1).max(2_000),
+      files: z.array(z.string().trim().min(1).max(500)).min(1).max(200),
+      patch: z.string().min(1).max(200_000),
+    }),
+    evidence: z.array(evidenceInput).min(1).max(200),
+  })
+  .superRefine((candidate, context) => {
+    const criterionIds = new Set<string>();
+    for (const [index, criterion] of candidate.acceptanceCriteria.entries()) {
+      if (criterionIds.has(criterion.id)) {
+        context.addIssue({
+          code: "custom",
+          message: "Acceptance criterion IDs must be unique.",
+          path: ["acceptanceCriteria", index, "id"],
+        });
+      }
+      criterionIds.add(criterion.id);
+    }
+
+    const evidenceIds = new Set<string>();
+    for (const [index, evidence] of candidate.evidence.entries()) {
+      if (evidenceIds.has(evidence.id)) {
+        context.addIssue({
+          code: "custom",
+          message: "Evidence IDs must be unique.",
+          path: ["evidence", index, "id"],
+        });
+      }
+      evidenceIds.add(evidence.id);
+      for (const criterionId of evidence.criterionIds) {
+        if (!criterionIds.has(criterionId)) {
+          context.addIssue({
+            code: "custom",
+            message: "Evidence must reference a known acceptance criterion.",
+            path: ["evidence", index, "criterionIds"],
+          });
+        }
+      }
+    }
+  });
+
+const findingOutput = z.object({
+  id: identifier,
+  ruleId: identifier,
+  severity: z.enum(["blocker", "major", "minor"]),
+  message: z.string().min(1).max(2_000),
+  file: z.string().min(1).max(500).optional(),
+  line: z.number().int().positive().optional(),
+});
+
+const criterionDecisionOutput = z.object({
+  criterionId: identifier,
+  verdict: z.enum(["pass", "fail"]),
+  rationale: z.string().min(1).max(2_000),
+  evidenceIds: z.array(identifier).max(200),
+});
+
+const adversarialAttemptOutput = z.object({
+  id: identifier,
+  criterionId: identifier,
+  scenario: z.string().min(1).max(2_000),
+  outcome: z.enum(["survived", "exposed-gap"]),
+  rationale: z.string().min(1).max(2_000),
+});
+
+const blockerOutput = z.object({
+  gate: z.enum(["code-review", "acceptance-evals", "adversarial-review"]),
+  id: identifier,
+  message: z.string().min(1).max(2_000),
+});
+
+const codeReviewReport = z.object({
+  summary: z.string().min(1).max(4_000),
+  findings: z.array(findingOutput).max(200),
+});
+
+const acceptanceEvaluationReport = z.object({
+  summary: z.string().min(1).max(4_000),
+  results: z.array(criterionDecisionOutput).max(100),
+});
+
+const adversarialReviewReport = z.object({
+  summary: z.string().min(1).max(4_000),
+  attempts: z.array(adversarialAttemptOutput).max(200),
+});
+
+export function createAssessTaskReadiness({
+  codeReviewer,
+  acceptanceJudge,
+  adversarialReviewer,
+}: ReviewDependencies) {
+  return defineCapability({
+    title: "Assess task readiness",
+    description:
+      "Run independent code review, acceptance evaluations, and adversarial review before a task may be declared complete.",
+    input,
+    output: z.object({
+      taskId: identifier,
+      policyVersion: z.string().min(1),
+      readyToComplete: z.boolean(),
+      decision: z.enum(["pass", "changes-required"]),
+      gates: z.object({
+        codeReview: z.object({
+          verdict: z.enum(["pass", "fail"]),
+          summary: z.string().min(1).max(4_000),
+          findings: z.array(findingOutput).max(200),
+        }),
+        acceptanceEvals: z.object({
+          verdict: z.enum(["pass", "fail"]),
+          summary: z.string().min(1).max(4_000),
+          criteria: z.array(criterionDecisionOutput).min(1).max(50),
+        }),
+        adversarialReview: z.object({
+          verdict: z.enum(["pass", "fail"]),
+          summary: z.string().min(1).max(4_000),
+          attempts: z.array(adversarialAttemptOutput).max(200),
+        }),
+      }),
+      blockers: z.array(blockerOutput).max(1_500),
+      nextAction: z.enum(["declare-complete", "address-blockers-and-rerun"]),
+    }),
+    access: "authenticated",
+    timeoutMs: 120_000,
+    annotations: {
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+      openWorld: false,
+    },
+    async run({ input: candidate, context }) {
+      const [unparsedCodeReview, unparsedAcceptanceEvals, unparsedAdversarial] =
+        await Promise.all([
+          codeReviewer.review(
+            structuredClone(candidate),
+            standardReviewPolicy.codeReview,
+            { signal: context.signal },
+          ),
+          acceptanceJudge.evaluate(
+            structuredClone(candidate),
+            standardReviewPolicy.acceptanceEvals,
+            { signal: context.signal },
+          ),
+          adversarialReviewer.challenge(
+            structuredClone(candidate),
+            standardReviewPolicy.adversarialReview,
+            { signal: context.signal },
+          ),
+        ]);
+      const codeReview = codeReviewReport.parse(unparsedCodeReview);
+      const acceptanceEvals = acceptanceEvaluationReport.parse(
+        unparsedAcceptanceEvals,
+      );
+      const adversarialReview =
+        adversarialReviewReport.parse(unparsedAdversarial);
+
+      return assessReadiness(candidate, standardReviewPolicy, {
+        codeReview,
+        acceptanceEvals,
+        adversarialReview,
+      });
+    },
+  });
+}

--- a/examples/review-engine/src/cli.ts
+++ b/examples/review-engine/src/cli.ts
@@ -1,0 +1,18 @@
+import { pathToFileURL } from "node:url";
+
+import { runCli } from "@ai-engine/cli";
+
+import { engine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<number> {
+  return runCli(engine, { principal: localPrincipal });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  process.exitCode = await main();
+}

--- a/examples/review-engine/src/direct.ts
+++ b/examples/review-engine/src/direct.ts
@@ -1,0 +1,25 @@
+import { pathToFileURL } from "node:url";
+
+import { engine } from "./engine.js";
+import { exampleCandidate } from "./example-candidate.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<void> {
+  const result = await engine.invoke(
+    "review.assess-task-readiness",
+    exampleCandidate,
+    { source: "direct", principal: localPrincipal },
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Review engine direct invocation failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/review-engine/src/domain/policy.ts
+++ b/examples/review-engine/src/domain/policy.ts
@@ -1,0 +1,85 @@
+export interface ReviewRule {
+  readonly id: string;
+  readonly description: string;
+}
+
+function frozenRules(
+  rules: ReadonlyArray<ReviewRule>,
+): ReadonlyArray<ReviewRule> {
+  return Object.freeze(rules.map((rule) => Object.freeze({ ...rule })));
+}
+
+export const standardReviewPolicy = Object.freeze({
+  version: "2026-07-28",
+  codeReview: frozenRules([
+    {
+      id: "CR-01",
+      description:
+        "Find correctness defects and regressions relative to the task and its acceptance criteria.",
+    },
+    {
+      id: "CR-02",
+      description:
+        "Check public contracts, compatibility, architecture boundaries, and repository instructions.",
+    },
+    {
+      id: "CR-03",
+      description:
+        "Require focused verification for changed behavior and reject known failing checks.",
+    },
+    {
+      id: "CR-04",
+      description:
+        "Inspect relevant security, authorization, data handling, cancellation, concurrency, and resource limits.",
+    },
+    {
+      id: "CR-05",
+      description:
+        "Reject unrelated scope, unresolved bypasses, speculative abstractions, and maintainability regressions.",
+    },
+  ]),
+  acceptanceEvals: frozenRules([
+    {
+      id: "EV-01",
+      description:
+        "Return exactly one binary verdict for every acceptance criterion and no verdict for an unknown criterion.",
+    },
+    {
+      id: "EV-02",
+      description:
+        "A passing verdict must cite passed evidence that is explicitly mapped to the same criterion.",
+    },
+    {
+      id: "EV-03",
+      description:
+        "Judge observable acceptance outcomes instead of implementation-only claims or confidence statements.",
+    },
+    {
+      id: "EV-04",
+      description:
+        "Fail closed when evidence is missing, conflicting, ambiguous, or cannot be reproduced.",
+    },
+  ]),
+  adversarialReview: frozenRules([
+    {
+      id: "AR-01",
+      description:
+        "Attempt at least one concrete counterexample against every acceptance criterion.",
+    },
+    {
+      id: "AR-02",
+      description:
+        "Probe relevant invalid inputs, boundaries, failures, authorization, cancellation, and concurrency.",
+    },
+    {
+      id: "AR-03",
+      description:
+        "Challenge the candidate independently instead of trusting prior review or evaluation claims.",
+    },
+    {
+      id: "AR-04",
+      description:
+        "Treat every exposed gap or missing criterion challenge as completion-blocking.",
+    },
+  ]),
+});

--- a/examples/review-engine/src/domain/readiness.ts
+++ b/examples/review-engine/src/domain/readiness.ts
@@ -1,0 +1,302 @@
+import type {
+  AcceptanceEvaluation,
+  AcceptanceEvaluationReport,
+  AdversarialAttempt,
+  AdversarialReviewReport,
+  CodeReviewFinding,
+  CodeReviewReport,
+  ReviewCandidate,
+} from "./review.js";
+import type { ReviewRule } from "./policy.js";
+
+export type ReviewGate =
+  | "code-review"
+  | "acceptance-evals"
+  | "adversarial-review";
+
+export interface CompletionBlocker {
+  readonly gate: ReviewGate;
+  readonly id: string;
+  readonly message: string;
+}
+
+export interface CriterionDecision {
+  readonly criterionId: string;
+  readonly verdict: "pass" | "fail";
+  readonly rationale: string;
+  readonly evidenceIds: string[];
+}
+
+export interface ReadinessAssessment {
+  readonly taskId: string;
+  readonly policyVersion: string;
+  readonly readyToComplete: boolean;
+  readonly decision: "pass" | "changes-required";
+  readonly gates: {
+    readonly codeReview: {
+      readonly verdict: "pass" | "fail";
+      readonly summary: string;
+      readonly findings: CodeReviewFinding[];
+    };
+    readonly acceptanceEvals: {
+      readonly verdict: "pass" | "fail";
+      readonly summary: string;
+      readonly criteria: CriterionDecision[];
+    };
+    readonly adversarialReview: {
+      readonly verdict: "pass" | "fail";
+      readonly summary: string;
+      readonly attempts: AdversarialAttempt[];
+    };
+  };
+  readonly blockers: CompletionBlocker[];
+  readonly nextAction: "declare-complete" | "address-blockers-and-rerun";
+}
+
+interface ReviewPolicy {
+  readonly version: string;
+  readonly codeReview: ReadonlyArray<ReviewRule>;
+}
+
+function evidenceIds(results: ReadonlyArray<AcceptanceEvaluation>): string[] {
+  return [...new Set(results.flatMap((result) => result.evidenceIds))].slice(
+    0,
+    200,
+  );
+}
+
+function criterionDecision(
+  candidate: ReviewCandidate,
+  criterionId: string,
+  results: ReadonlyArray<AcceptanceEvaluation>,
+): {
+  readonly decision: CriterionDecision;
+  readonly blocker?: CompletionBlocker;
+} {
+  if (results.length !== 1) {
+    const rationale =
+      results.length === 0
+        ? "The acceptance judge did not return a verdict for this criterion."
+        : "The acceptance judge returned more than one verdict for this criterion.";
+    return {
+      decision: {
+        criterionId,
+        verdict: "fail",
+        rationale,
+        evidenceIds: evidenceIds(results),
+      },
+      blocker: {
+        gate: "acceptance-evals",
+        id: criterionId,
+        message: rationale,
+      },
+    };
+  }
+
+  const [result] = results;
+  if (result === undefined) {
+    throw new Error("The acceptance result count changed unexpectedly.");
+  }
+  if (result.verdict === "fail") {
+    return {
+      decision: { ...result, evidenceIds: result.evidenceIds.slice() },
+      blocker: {
+        gate: "acceptance-evals",
+        id: criterionId,
+        message: result.rationale,
+      },
+    };
+  }
+
+  const mappedEvidence = candidate.evidence.filter((evidence) =>
+    evidence.criterionIds.includes(criterionId),
+  );
+  const citedEvidence = result.evidenceIds.map((id) =>
+    candidate.evidence.find((evidence) => evidence.id === id),
+  );
+  const invalidEvidence =
+    result.evidenceIds.length === 0 ||
+    new Set(result.evidenceIds).size !== result.evidenceIds.length ||
+    citedEvidence.some(
+      (evidence) =>
+        evidence === undefined ||
+        !evidence.passed ||
+        !evidence.criterionIds.includes(criterionId),
+    ) ||
+    mappedEvidence.some((evidence) => !evidence.passed);
+
+  if (invalidEvidence) {
+    const rationale =
+      "The passing verdict is not supported by unique, passed evidence mapped to this criterion.";
+    return {
+      decision: {
+        criterionId,
+        verdict: "fail",
+        rationale,
+        evidenceIds: result.evidenceIds.slice(),
+      },
+      blocker: {
+        gate: "acceptance-evals",
+        id: criterionId,
+        message: rationale,
+      },
+    };
+  }
+
+  return {
+    decision: { ...result, evidenceIds: result.evidenceIds.slice() },
+  };
+}
+
+export function assessReadiness(
+  candidate: ReviewCandidate,
+  policy: ReviewPolicy,
+  reports: {
+    readonly codeReview: CodeReviewReport;
+    readonly acceptanceEvals: AcceptanceEvaluationReport;
+    readonly adversarialReview: AdversarialReviewReport;
+  },
+): ReadinessAssessment {
+  const blockers: CompletionBlocker[] = [];
+  const codeRuleIds = new Set(policy.codeReview.map(({ id }) => id));
+  const codeFindingIds = new Set<string>();
+
+  for (const finding of reports.codeReview.findings) {
+    if (codeFindingIds.has(finding.id)) {
+      blockers.push({
+        gate: "code-review",
+        id: finding.id,
+        message: "The code reviewer returned a duplicate finding ID.",
+      });
+    }
+    codeFindingIds.add(finding.id);
+    if (!codeRuleIds.has(finding.ruleId)) {
+      blockers.push({
+        gate: "code-review",
+        id: finding.id,
+        message: "The code review finding references an unknown policy rule.",
+      });
+    }
+    if (finding.severity !== "minor") {
+      blockers.push({
+        gate: "code-review",
+        id: finding.id,
+        message: finding.message,
+      });
+    }
+  }
+
+  const criteria = candidate.acceptanceCriteria.map((criterion) =>
+    criterionDecision(
+      candidate,
+      criterion.id,
+      reports.acceptanceEvals.results.filter(
+        (result) => result.criterionId === criterion.id,
+      ),
+    ),
+  );
+  for (const result of criteria) {
+    if (result.blocker !== undefined) blockers.push(result.blocker);
+  }
+
+  const knownCriterionIds = new Set(
+    candidate.acceptanceCriteria.map(({ id }) => id),
+  );
+  for (const result of reports.acceptanceEvals.results) {
+    if (!knownCriterionIds.has(result.criterionId)) {
+      blockers.push({
+        gate: "acceptance-evals",
+        id: result.criterionId,
+        message:
+          "The acceptance judge returned a verdict for an unknown criterion.",
+      });
+    }
+  }
+
+  const attemptIds = new Set<string>();
+  for (const attempt of reports.adversarialReview.attempts) {
+    if (attemptIds.has(attempt.id)) {
+      blockers.push({
+        gate: "adversarial-review",
+        id: attempt.id,
+        message: "The adversarial reviewer returned a duplicate attempt ID.",
+      });
+    }
+    attemptIds.add(attempt.id);
+    if (!knownCriterionIds.has(attempt.criterionId)) {
+      blockers.push({
+        gate: "adversarial-review",
+        id: attempt.id,
+        message:
+          "The adversarial reviewer challenged an unknown acceptance criterion.",
+      });
+    }
+    if (attempt.outcome === "exposed-gap") {
+      blockers.push({
+        gate: "adversarial-review",
+        id: attempt.id,
+        message: attempt.rationale,
+      });
+    }
+  }
+  for (const criterion of candidate.acceptanceCriteria) {
+    if (
+      !reports.adversarialReview.attempts.some(
+        (attempt) => attempt.criterionId === criterion.id,
+      )
+    ) {
+      blockers.push({
+        gate: "adversarial-review",
+        id: criterion.id,
+        message:
+          "No adversarial counterexample was attempted for this criterion.",
+      });
+    }
+  }
+
+  const codeReviewFailed = blockers.some(({ gate }) => gate === "code-review");
+  const acceptanceEvalsFailed = blockers.some(
+    ({ gate }) => gate === "acceptance-evals",
+  );
+  const adversarialReviewFailed = blockers.some(
+    ({ gate }) => gate === "adversarial-review",
+  );
+  const readyToComplete = blockers.length === 0;
+
+  return {
+    taskId: candidate.taskId,
+    policyVersion: policy.version,
+    readyToComplete,
+    decision: readyToComplete ? "pass" : "changes-required",
+    gates: {
+      codeReview: {
+        verdict: codeReviewFailed ? "fail" : "pass",
+        summary: reports.codeReview.summary,
+        findings: reports.codeReview.findings.map((finding) => ({
+          id: finding.id,
+          ruleId: finding.ruleId,
+          severity: finding.severity,
+          message: finding.message,
+          ...(finding.file === undefined ? {} : { file: finding.file }),
+          ...(finding.line === undefined ? {} : { line: finding.line }),
+        })),
+      },
+      acceptanceEvals: {
+        verdict: acceptanceEvalsFailed ? "fail" : "pass",
+        summary: reports.acceptanceEvals.summary,
+        criteria: criteria.map(({ decision }) => decision),
+      },
+      adversarialReview: {
+        verdict: adversarialReviewFailed ? "fail" : "pass",
+        summary: reports.adversarialReview.summary,
+        attempts: reports.adversarialReview.attempts.map((attempt) => ({
+          ...attempt,
+        })),
+      },
+    },
+    blockers,
+    nextAction: readyToComplete
+      ? "declare-complete"
+      : "address-blockers-and-rerun",
+  };
+}

--- a/examples/review-engine/src/domain/review.ts
+++ b/examples/review-engine/src/domain/review.ts
@@ -1,0 +1,74 @@
+export type EvidenceKind =
+  | "test"
+  | "adversarial-test"
+  | "typecheck"
+  | "lint"
+  | "build"
+  | "manual-inspection";
+
+export interface AcceptanceCriterion {
+  readonly id: string;
+  readonly statement: string;
+}
+
+export interface ReviewEvidence {
+  readonly id: string;
+  readonly kind: EvidenceKind;
+  readonly criterionIds: string[];
+  readonly passed: boolean;
+  readonly command: string | null;
+  readonly summary: string;
+}
+
+export interface ReviewCandidate {
+  readonly taskId: string;
+  readonly summary: string;
+  readonly acceptanceCriteria: AcceptanceCriterion[];
+  readonly change: {
+    readonly summary: string;
+    readonly files: string[];
+    readonly patch: string;
+  };
+  readonly evidence: ReviewEvidence[];
+}
+
+export type FindingSeverity = "blocker" | "major" | "minor";
+
+export interface CodeReviewFinding {
+  readonly id: string;
+  readonly ruleId: string;
+  readonly severity: FindingSeverity;
+  readonly message: string;
+  readonly file?: string | undefined;
+  readonly line?: number | undefined;
+}
+
+export interface CodeReviewReport {
+  readonly summary: string;
+  readonly findings: ReadonlyArray<CodeReviewFinding>;
+}
+
+export interface AcceptanceEvaluation {
+  readonly criterionId: string;
+  readonly verdict: "pass" | "fail";
+  readonly rationale: string;
+  readonly evidenceIds: ReadonlyArray<string>;
+}
+
+export interface AcceptanceEvaluationReport {
+  readonly summary: string;
+  readonly results: ReadonlyArray<AcceptanceEvaluation>;
+}
+
+export interface AdversarialAttempt {
+  readonly id: string;
+  readonly criterionId: string;
+  readonly scenario: string;
+  readonly outcome: "survived" | "exposed-gap";
+  readonly rationale: string;
+}
+
+export interface AdversarialReviewReport {
+  readonly summary: string;
+  readonly attempts: ReadonlyArray<AdversarialAttempt>;
+}

--- a/examples/review-engine/src/engine.ts
+++ b/examples/review-engine/src/engine.ts
@@ -1,0 +1,21 @@
+import { createEngine } from "@ai-engine/core";
+
+import type { ReviewDependencies } from "./application/ports.js";
+import { createAssessTaskReadiness } from "./capabilities/assess-task-readiness.js";
+import { createDeterministicReviewers } from "./infrastructure/deterministic-reviewers.js";
+
+export function createReviewEngine(dependencies: ReviewDependencies) {
+  return createEngine({
+    name: "review-engine",
+    version: "0.1.0",
+    capabilities: {
+      "review.assess-task-readiness": createAssessTaskReadiness(dependencies),
+    },
+  });
+}
+
+export function createDefaultReviewEngine() {
+  return createReviewEngine(createDeterministicReviewers());
+}
+
+export const engine = createDefaultReviewEngine();

--- a/examples/review-engine/src/example-candidate.ts
+++ b/examples/review-engine/src/example-candidate.ts
@@ -1,0 +1,57 @@
+import type { ReviewCandidate } from "./domain/review.js";
+
+export const exampleCandidate: ReviewCandidate = {
+  taskId: "TASK-DEMO",
+  summary:
+    "Prevent an agent from declaring completion before review gates pass.",
+  acceptanceCriteria: [
+    {
+      id: "AC-1",
+      statement: "Blocking code review findings prevent completion.",
+    },
+    {
+      id: "AC-2",
+      statement: "Every acceptance criterion requires passing evidence.",
+    },
+  ],
+  change: {
+    summary: "Add a fail-closed readiness decision.",
+    files: ["src/readiness.ts", "test/readiness.test.ts"],
+    patch: "+export const ready = blockers.length === 0;\n",
+  },
+  evidence: [
+    {
+      id: "TEST-1",
+      kind: "test",
+      criterionIds: ["AC-1"],
+      passed: true,
+      command: "vitest run readiness.test.ts",
+      summary: "A blocking finding kept readiness false.",
+    },
+    {
+      id: "TEST-2",
+      kind: "test",
+      criterionIds: ["AC-2"],
+      passed: true,
+      command: "vitest run readiness.test.ts",
+      summary: "Missing criterion evidence kept readiness false.",
+    },
+    {
+      id: "ADV-TEST-1",
+      kind: "adversarial-test",
+      criterionIds: ["AC-1"],
+      passed: true,
+      command: "vitest run readiness.adversarial.test.ts",
+      summary: "A major finding was injected and completion remained blocked.",
+    },
+    {
+      id: "ADV-TEST-2",
+      kind: "adversarial-test",
+      criterionIds: ["AC-2"],
+      passed: true,
+      command: "vitest run readiness.adversarial.test.ts",
+      summary:
+        "Criterion evidence was removed and completion remained blocked.",
+    },
+  ],
+};

--- a/examples/review-engine/src/infrastructure/deterministic-reviewers.ts
+++ b/examples/review-engine/src/infrastructure/deterministic-reviewers.ts
@@ -1,0 +1,139 @@
+import type { ReviewDependencies } from "../application/ports.js";
+import type { ReviewRule } from "../domain/policy.js";
+
+function requireRule(rules: ReadonlyArray<ReviewRule>, ruleId: string): string {
+  const rule = rules.find(({ id }) => id === ruleId);
+  if (rule === undefined) {
+    throw new Error(`Required review rule ${ruleId} is missing.`);
+  }
+  return rule.id;
+}
+
+/**
+ * A deterministic local fixture for exercising the engine without a model
+ * provider. It checks structured evidence and a few explicit patch markers; it
+ * is not a substitute for a production code-review or judge implementation.
+ */
+export function createDeterministicReviewers(): ReviewDependencies {
+  return {
+    codeReviewer: {
+      async review(candidate, rules, { signal }) {
+        signal.throwIfAborted();
+        const verificationRule = requireRule(rules, "CR-03");
+        const maintainabilityRule = requireRule(rules, "CR-05");
+        const findings = candidate.evidence
+          .filter(({ passed }) => !passed)
+          .map((evidence, index) => ({
+            id: `FAILED-${String(index + 1)}`,
+            ruleId: verificationRule,
+            severity: "major" as const,
+            message: `Verification evidence ${evidence.id} is reported as failing.`,
+          }));
+
+        if (
+          !candidate.evidence.some(
+            ({ kind, passed }) => kind === "test" && passed,
+          )
+        ) {
+          findings.push({
+            id: "MISSING-AUTOMATED-TEST",
+            ruleId: verificationRule,
+            severity: "major",
+            message: "No passing automated test evidence was supplied.",
+          });
+        }
+
+        const addedPatchLines = candidate.change.patch
+          .split("\n")
+          .filter((line) => line.startsWith("+") && !line.startsWith("+++"));
+        if (
+          addedPatchLines.some((line) =>
+            /(?:TODO|FIXME|@ts-ignore|biome-ignore)/u.test(line),
+          )
+        ) {
+          findings.push({
+            id: "UNRESOLVED-BYPASS",
+            ruleId: maintainabilityRule,
+            severity: "major",
+            message:
+              "The patch adds an unresolved TODO, FIXME, or validation bypass marker.",
+          });
+        }
+
+        return {
+          summary:
+            findings.length === 0
+              ? "The deterministic checks found no blocking verification or bypass issue."
+              : "The deterministic checks found completion-blocking issues.",
+          findings,
+        };
+      },
+    },
+
+    acceptanceJudge: {
+      async evaluate(candidate, rules, { signal }) {
+        signal.throwIfAborted();
+        requireRule(rules, "EV-01");
+        requireRule(rules, "EV-02");
+        requireRule(rules, "EV-04");
+        const results = candidate.acceptanceCriteria.map((criterion) => {
+          const evidence = candidate.evidence.filter((item) =>
+            item.criterionIds.includes(criterion.id),
+          );
+          const passed =
+            evidence.length > 0 && evidence.every((item) => item.passed);
+          return {
+            criterionId: criterion.id,
+            verdict: passed ? ("pass" as const) : ("fail" as const),
+            rationale: passed
+              ? "All evidence mapped to this criterion is passing."
+              : "Evidence is missing or at least one mapped check is failing.",
+            evidenceIds: evidence.map(({ id }) => id),
+          };
+        });
+        return {
+          summary: results.every(({ verdict }) => verdict === "pass")
+            ? "Every acceptance criterion has passing mapped evidence."
+            : "At least one acceptance criterion lacks passing mapped evidence.",
+          results,
+        };
+      },
+    },
+
+    adversarialReviewer: {
+      async challenge(candidate, rules, { signal }) {
+        signal.throwIfAborted();
+        requireRule(rules, "AR-01");
+        requireRule(rules, "AR-04");
+        const attempts = candidate.acceptanceCriteria.map(
+          (criterion, index) => {
+            const evidence = candidate.evidence.filter(
+              (item) =>
+                item.kind === "adversarial-test" &&
+                item.criterionIds.includes(criterion.id),
+            );
+            const survived =
+              evidence.length > 0 && evidence.every((item) => item.passed);
+            return {
+              id: `ADV-${String(index + 1)}`,
+              criterionId: criterion.id,
+              scenario: `Attempt to falsify: ${criterion.statement}`,
+              outcome: survived
+                ? ("survived" as const)
+                : ("exposed-gap" as const),
+              rationale: survived
+                ? "Passing adversarial-test evidence is mapped to this criterion."
+                : "No passing adversarial-test evidence is mapped to this criterion.",
+            };
+          },
+        );
+        return {
+          summary: attempts.every(({ outcome }) => outcome === "survived")
+            ? "Every acceptance criterion survived a recorded counterexample."
+            : "At least one acceptance criterion has no passing adversarial challenge.",
+          attempts,
+        };
+      },
+    },
+  };
+}

--- a/examples/review-engine/src/local-principal.ts
+++ b/examples/review-engine/src/local-principal.ts
@@ -1,0 +1,5 @@
+import type { Principal } from "@ai-engine/core";
+
+export const localPrincipal: Principal = Object.freeze({
+  id: "local:delivery-reviewer",
+});

--- a/examples/review-engine/src/mcp-http.ts
+++ b/examples/review-engine/src/mcp-http.ts
@@ -1,0 +1,61 @@
+import { pathToFileURL } from "node:url";
+
+import { type McpHttpServerHandle, serveMcpHttp } from "@ai-engine/mcp";
+
+import { engine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export interface ReviewMcpHttpOptions {
+  readonly expectedBearerToken: string;
+  readonly host?: string;
+  readonly port?: number;
+}
+
+export async function startReviewMcpHttp(
+  options: ReviewMcpHttpOptions,
+): Promise<McpHttpServerHandle> {
+  return serveMcpHttp(engine, {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.port === undefined ? {} : { port: options.port }),
+    auth: {
+      mode: "required",
+      authenticate(request) {
+        return request.headers.get("authorization") ===
+          `Bearer ${options.expectedBearerToken}`
+          ? localPrincipal
+          : null;
+      },
+    },
+  });
+}
+
+export async function main(): Promise<McpHttpServerHandle> {
+  const expectedBearerToken = process.env.REVIEW_ENGINE_BEARER_TOKEN;
+  if (expectedBearerToken === undefined || expectedBearerToken === "") {
+    throw new Error("REVIEW_ENGINE_BEARER_TOKEN is required.");
+  }
+  const configuredPort = process.env.PORT;
+  const port = configuredPort === undefined ? 3000 : Number(configuredPort);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error("PORT must be an integer between 0 and 65535.");
+  }
+  return startReviewMcpHttp({ expectedBearerToken, port });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main()
+    .then((server) => {
+      const address = server.address();
+      process.stderr.write(
+        `Review engine MCP HTTP adapter listening on host ${address.host}, port ${address.port}\n`,
+      );
+    })
+    .catch(() => {
+      process.stderr.write("Review engine MCP HTTP adapter failed to start.\n");
+      process.exitCode = 1;
+    });
+}

--- a/examples/review-engine/src/mcp-stdio.ts
+++ b/examples/review-engine/src/mcp-stdio.ts
@@ -1,0 +1,21 @@
+import { pathToFileURL } from "node:url";
+
+import { serveMcpStdio } from "@ai-engine/mcp";
+
+import { engine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<void> {
+  await serveMcpStdio(engine, { principal: localPrincipal });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Review engine MCP stdio adapter failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/review-engine/test/entrypoints.test.ts
+++ b/examples/review-engine/test/entrypoints.test.ts
@@ -1,0 +1,200 @@
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { exampleCandidate } from "../src/example-candidate.js";
+
+const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
+
+beforeAll(() => {
+  const build = spawnSync(
+    process.execPath,
+    ["../../node_modules/typescript/bin/tsc", "-b", "--pretty", "false"],
+    { cwd: exampleRoot, encoding: "utf8" },
+  );
+  if (build.status !== 0) {
+    throw new Error(`Example build failed:\n${build.stdout}${build.stderr}`);
+  }
+});
+
+function run(entrypoint: string, args: readonly string[] = []) {
+  return spawnSync(process.execPath, [`dist/${entrypoint}.js`, ...args], {
+    cwd: exampleRoot,
+    encoding: "utf8",
+  });
+}
+
+async function stopProcess(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) return;
+  const exited = once(child, "exit");
+  child.kill();
+  await exited;
+}
+
+function structuredContent(result: unknown): Record<string, unknown> {
+  const content = (result as { readonly structuredContent?: unknown })
+    .structuredContent;
+  if (typeof content !== "object" || content === null) {
+    throw new Error("Expected MCP structured content.");
+  }
+  return content as Record<string, unknown>;
+}
+
+describe("review engine entrypoints", () => {
+  it("assesses a ready candidate through the direct entrypoint", () => {
+    const result = run("direct");
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      taskId: "TASK-DEMO",
+      policyVersion: "2026-07-28",
+      readyToComplete: true,
+      decision: "pass",
+      blockers: [],
+      nextAction: "declare-complete",
+    });
+  });
+
+  it("publishes and invokes the same capability through the CLI", () => {
+    const listed = run("cli", ["list"]);
+    expect(listed.status).toBe(0);
+    expect(JSON.parse(listed.stdout)).toMatchObject([
+      { id: "review.assess-task-readiness" },
+    ]);
+
+    const assessed = run("cli", [
+      "run",
+      "review.assess-task-readiness",
+      "--input",
+      JSON.stringify(exampleCandidate),
+    ]);
+    expect(assessed.status).toBe(0);
+    expect(assessed.stderr).toBe("");
+    expect(JSON.parse(assessed.stdout)).toMatchObject({
+      readyToComplete: true,
+      nextAction: "declare-complete",
+    });
+  });
+
+  it("returns a fail-closed decision through MCP stdio", async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["dist/mcp-stdio.js"],
+      cwd: exampleRoot,
+      stderr: "pipe",
+    });
+    let stderr = "";
+    transport.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    const client = new Client(
+      { name: "review-stdio-entrypoint-test", version: "0.0.0-test" },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: "review.assess-task-readiness" }],
+      });
+      const result = await client.callTool({
+        name: "review.assess-task-readiness",
+        arguments: {
+          ...exampleCandidate,
+          evidence: exampleCandidate.evidence.filter(
+            ({ id }) => id !== "ADV-TEST-2",
+          ),
+        },
+      });
+      expect(structuredContent(result)).toMatchObject({
+        readyToComplete: false,
+        gates: { adversarialReview: { verdict: "fail" } },
+        nextAction: "address-blockers-and-rerun",
+      });
+    } finally {
+      await client.close();
+    }
+
+    expect(stderr).toBe("");
+  });
+
+  it("serves authenticated stateless HTTP without exposing the token", async () => {
+    const token = "test-only-review-token";
+    const child = spawn(process.execPath, ["dist/mcp-http.js"], {
+      cwd: exampleRoot,
+      env: { ...process.env, REVIEW_ENGINE_BEARER_TOKEN: token, PORT: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    let client: Client | undefined;
+
+    try {
+      const port = await vi.waitFor(
+        () => {
+          const match = stderr.match(/host 127\.0\.0\.1, port (\d+)/u);
+          expect(match?.[1]).toBeDefined();
+          return Number(match?.[1]);
+        },
+        { timeout: 5_000 },
+      );
+      const url = new URL(`http://127.0.0.1:${String(port)}/mcp`);
+
+      const unauthenticated = await fetch(url, {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "auth-boundary",
+          method: "tools/call",
+          params: {
+            name: "review.assess-task-readiness",
+            arguments: exampleCandidate,
+          },
+        }),
+      });
+      expect(unauthenticated.status).toBe(401);
+      await unauthenticated.arrayBuffer();
+
+      const transport = new StreamableHTTPClientTransport(url, {
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+      });
+      client = new Client(
+        { name: "review-http-entrypoint-test", version: "0.0.0-test" },
+        { capabilities: {} },
+      );
+      await client.connect(transport as unknown as Transport);
+
+      const result = await client.callTool({
+        name: "review.assess-task-readiness",
+        arguments: exampleCandidate as unknown as Record<string, unknown>,
+      });
+      expect(structuredContent(result)).toMatchObject({
+        readyToComplete: true,
+        nextAction: "declare-complete",
+      });
+    } finally {
+      await client?.close().catch(() => undefined);
+      await stopProcess(child);
+    }
+
+    expect(stdout).toBe("");
+    expect(stderr).not.toContain(token);
+  });
+});

--- a/examples/review-engine/test/review-engine.test.ts
+++ b/examples/review-engine/test/review-engine.test.ts
@@ -1,0 +1,674 @@
+import type { EngineError, Principal } from "@ai-engine/core";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import type {
+  AcceptanceJudge,
+  AdversarialReviewer,
+  CodeReviewer,
+  ReviewDependencies,
+} from "../src/application/ports.js";
+import type {
+  AcceptanceEvaluationReport,
+  AdversarialReviewReport,
+  CodeReviewReport,
+  ReviewCandidate,
+} from "../src/domain/review.js";
+import { createReviewEngine } from "../src/engine.js";
+import { createDeterministicReviewers } from "../src/infrastructure/deterministic-reviewers.js";
+
+const principal: Principal = { id: "agent:delivery-reviewer" };
+const invocation = { source: "direct", principal } as const;
+
+const candidate: ReviewCandidate = {
+  taskId: "TASK-42",
+  summary: "Reject task completion until every review gate passes.",
+  acceptanceCriteria: [
+    {
+      id: "AC-1",
+      statement: "A blocking code review finding prevents completion.",
+    },
+    {
+      id: "AC-2",
+      statement: "Every acceptance criterion has passing evidence.",
+    },
+  ],
+  change: {
+    summary: "Add a fail-closed readiness decision.",
+    files: ["src/readiness.ts", "test/readiness.test.ts"],
+    patch: "+export const ready = blockers.length === 0;\n",
+  },
+  evidence: [
+    {
+      id: "E-AC1",
+      kind: "test",
+      criterionIds: ["AC-1"],
+      passed: true,
+      command: "vitest run readiness.test.ts",
+      summary: "The blocking-finding test passed.",
+    },
+    {
+      id: "E-AC2",
+      kind: "test",
+      criterionIds: ["AC-2"],
+      passed: true,
+      command: "vitest run readiness.test.ts",
+      summary: "The criterion coverage test passed.",
+    },
+    {
+      id: "E-ADV1",
+      kind: "adversarial-test",
+      criterionIds: ["AC-1"],
+      passed: true,
+      command: "vitest run readiness.adversarial.test.ts",
+      summary: "A major finding was injected and blocked completion.",
+    },
+    {
+      id: "E-ADV2",
+      kind: "adversarial-test",
+      criterionIds: ["AC-2"],
+      passed: true,
+      command: "vitest run readiness.adversarial.test.ts",
+      summary: "Missing evidence was injected and blocked completion.",
+    },
+  ],
+};
+
+const passingCodeReview: CodeReviewReport = {
+  summary: "No blocking or major findings.",
+  findings: [],
+};
+
+const passingAcceptanceEvals: AcceptanceEvaluationReport = {
+  summary: "Every criterion passed with mapped evidence.",
+  results: [
+    {
+      criterionId: "AC-1",
+      verdict: "pass",
+      rationale: "The blocking behavior is covered.",
+      evidenceIds: ["E-AC1"],
+    },
+    {
+      criterionId: "AC-2",
+      verdict: "pass",
+      rationale: "The coverage behavior is covered.",
+      evidenceIds: ["E-AC2"],
+    },
+  ],
+};
+
+const passingAdversarialReview: AdversarialReviewReport = {
+  summary: "Both criteria survived a counterexample.",
+  attempts: [
+    {
+      id: "ADV-1",
+      criterionId: "AC-1",
+      scenario: "Inject a major code review finding.",
+      outcome: "survived",
+      rationale: "Completion remained blocked.",
+    },
+    {
+      id: "ADV-2",
+      criterionId: "AC-2",
+      scenario: "Remove all evidence for one criterion.",
+      outcome: "survived",
+      rationale: "Completion remained blocked.",
+    },
+  ],
+};
+
+function requiredItem<T>(items: ReadonlyArray<T>, index: number): T {
+  const item = items[index];
+  if (item === undefined)
+    throw new Error("Required test fixture item is missing.");
+  return item;
+}
+
+function createDependencies(
+  overrides: {
+    readonly codeReview?: CodeReviewReport;
+    readonly acceptanceEvals?: AcceptanceEvaluationReport;
+    readonly adversarialReview?: AdversarialReviewReport;
+  } = {},
+): ReviewDependencies {
+  return {
+    codeReviewer: {
+      review: vi.fn(async () => overrides.codeReview ?? passingCodeReview),
+    },
+    acceptanceJudge: {
+      evaluate: vi.fn(
+        async () => overrides.acceptanceEvals ?? passingAcceptanceEvals,
+      ),
+    },
+    adversarialReviewer: {
+      challenge: vi.fn(
+        async () => overrides.adversarialReview ?? passingAdversarialReview,
+      ),
+    },
+  };
+}
+
+describe("the review engine example", () => {
+  it("allows completion only after all three independent gates pass", async () => {
+    const dependencies = createDependencies();
+    const engine = createReviewEngine(dependencies);
+
+    const result = await engine.invoke(
+      "review.assess-task-readiness",
+      candidate,
+      invocation,
+    );
+
+    expectTypeOf(result.readyToComplete).toEqualTypeOf<boolean>();
+    expect(result).toMatchObject({
+      taskId: "TASK-42",
+      policyVersion: "2026-07-28",
+      readyToComplete: true,
+      decision: "pass",
+      gates: {
+        codeReview: { verdict: "pass" },
+        acceptanceEvals: { verdict: "pass" },
+        adversarialReview: { verdict: "pass" },
+      },
+      blockers: [],
+      nextAction: "declare-complete",
+    });
+
+    expect(dependencies.codeReviewer.review).toHaveBeenCalledOnce();
+    expect(dependencies.acceptanceJudge.evaluate).toHaveBeenCalledOnce();
+    expect(dependencies.adversarialReviewer.challenge).toHaveBeenCalledOnce();
+    expect(
+      vi
+        .mocked(dependencies.codeReviewer.review)
+        .mock.calls[0]?.[1].map(({ id }) => id),
+    ).toEqual(["CR-01", "CR-02", "CR-03", "CR-04", "CR-05"]);
+    expect(
+      vi
+        .mocked(dependencies.acceptanceJudge.evaluate)
+        .mock.calls[0]?.[1].map(({ id }) => id),
+    ).toEqual(["EV-01", "EV-02", "EV-03", "EV-04"]);
+    expect(
+      vi
+        .mocked(dependencies.adversarialReviewer.challenge)
+        .mock.calls[0]?.[1].map(({ id }) => id),
+    ).toEqual(["AR-01", "AR-02", "AR-03", "AR-04"]);
+  });
+
+  it("blocks completion for blocker and major code findings but not minor findings", async () => {
+    const major = createReviewEngine(
+      createDependencies({
+        codeReview: {
+          summary: "A regression was found.",
+          findings: [
+            {
+              id: "F-1",
+              ruleId: "CR-01",
+              severity: "major",
+              message: "The error path returns success.",
+              file: "src/readiness.ts",
+              line: 8,
+            },
+          ],
+        },
+      }),
+    );
+
+    await expect(
+      major.invoke("review.assess-task-readiness", candidate, invocation),
+    ).resolves.toMatchObject({
+      readyToComplete: false,
+      decision: "changes-required",
+      gates: { codeReview: { verdict: "fail" } },
+      blockers: [
+        {
+          gate: "code-review",
+          id: "F-1",
+          message: "The error path returns success.",
+        },
+      ],
+      nextAction: "address-blockers-and-rerun",
+    });
+
+    const minor = createReviewEngine(
+      createDependencies({
+        codeReview: {
+          summary: "Only a non-blocking naming suggestion remains.",
+          findings: [
+            {
+              id: "F-2",
+              ruleId: "CR-05",
+              severity: "minor",
+              message: "Consider a more precise local variable name.",
+            },
+          ],
+        },
+      }),
+    );
+    await expect(
+      minor.invoke("review.assess-task-readiness", candidate, invocation),
+    ).resolves.toMatchObject({
+      readyToComplete: true,
+      gates: { codeReview: { verdict: "pass" } },
+    });
+  });
+
+  it("fails closed when an acceptance verdict is missing or duplicated", async () => {
+    const engine = createReviewEngine(
+      createDependencies({
+        acceptanceEvals: {
+          summary: "The judge returned incomplete and duplicated coverage.",
+          results: [
+            requiredItem(passingAcceptanceEvals.results, 0),
+            { ...requiredItem(passingAcceptanceEvals.results, 0) },
+          ],
+        },
+      }),
+    );
+
+    const result = await engine.invoke(
+      "review.assess-task-readiness",
+      candidate,
+      invocation,
+    );
+
+    expect(result).toMatchObject({
+      readyToComplete: false,
+      gates: {
+        acceptanceEvals: {
+          verdict: "fail",
+          criteria: [
+            { criterionId: "AC-1", verdict: "fail" },
+            { criterionId: "AC-2", verdict: "fail" },
+          ],
+        },
+      },
+    });
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          gate: "acceptance-evals",
+          id: "AC-1",
+        }),
+        expect.objectContaining({
+          gate: "acceptance-evals",
+          id: "AC-2",
+        }),
+      ]),
+    );
+  });
+
+  it("bounds evidence echoed from a maximally duplicated judge response", async () => {
+    const duplicatedResults = Array.from({ length: 100 }, (_, resultIndex) => ({
+      criterionId: "AC-1",
+      verdict: "pass" as const,
+      rationale: "A duplicated verdict must fail closed.",
+      evidenceIds: Array.from(
+        { length: 200 },
+        (_, evidenceIndex) =>
+          `E-${String(resultIndex)}-${String(evidenceIndex)}`,
+      ),
+    }));
+    const engine = createReviewEngine(
+      createDependencies({
+        acceptanceEvals: {
+          summary:
+            "The judge returned the maximum number of duplicate verdicts.",
+          results: duplicatedResults,
+        },
+      }),
+    );
+
+    const result = await engine.invoke(
+      "review.assess-task-readiness",
+      candidate,
+      invocation,
+    );
+
+    expect(result).toMatchObject({
+      readyToComplete: false,
+      gates: { acceptanceEvals: { verdict: "fail" } },
+      nextAction: "address-blockers-and-rerun",
+    });
+    expect(result.gates.acceptanceEvals.criteria[0]?.evidenceIds).toHaveLength(
+      200,
+    );
+  });
+
+  it("rejects a passing acceptance verdict that cites invalid evidence", async () => {
+    const engine = createReviewEngine(
+      createDependencies({
+        acceptanceEvals: {
+          summary: "One verdict cites evidence for a different criterion.",
+          results: [
+            {
+              ...requiredItem(passingAcceptanceEvals.results, 0),
+              evidenceIds: ["E-AC2"],
+            },
+            requiredItem(passingAcceptanceEvals.results, 1),
+          ],
+        },
+      }),
+    );
+
+    const result = await engine.invoke(
+      "review.assess-task-readiness",
+      candidate,
+      invocation,
+    );
+    expect(result).toMatchObject({
+      readyToComplete: false,
+      gates: {
+        acceptanceEvals: {
+          verdict: "fail",
+        },
+      },
+      blockers: [
+        expect.objectContaining({
+          gate: "acceptance-evals",
+          id: "AC-1",
+        }),
+      ],
+    });
+    expect(result.gates.acceptanceEvals.criteria).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ criterionId: "AC-1", verdict: "fail" }),
+      ]),
+    );
+  });
+
+  it("blocks exposed gaps, missing challenges, and challenges for unknown criteria", async () => {
+    const engine = createReviewEngine(
+      createDependencies({
+        adversarialReview: {
+          summary: "The adversarial reviewer exposed incomplete coverage.",
+          attempts: [
+            {
+              id: "ADV-GAP",
+              criterionId: "AC-1",
+              scenario: "Return success after a major finding.",
+              outcome: "exposed-gap",
+              rationale: "The candidate incorrectly allowed completion.",
+            },
+            {
+              id: "ADV-UNKNOWN",
+              criterionId: "AC-404",
+              scenario: "Challenge a criterion that does not exist.",
+              outcome: "survived",
+              rationale: "The attempt cannot establish required coverage.",
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await engine.invoke(
+      "review.assess-task-readiness",
+      candidate,
+      invocation,
+    );
+    expect(result).toMatchObject({
+      readyToComplete: false,
+      gates: { adversarialReview: { verdict: "fail" } },
+    });
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        {
+          gate: "adversarial-review",
+          id: "ADV-GAP",
+          message: "The candidate incorrectly allowed completion.",
+        },
+        expect.objectContaining({
+          gate: "adversarial-review",
+          id: "AC-2",
+        }),
+        expect.objectContaining({
+          gate: "adversarial-review",
+          id: "ADV-UNKNOWN",
+        }),
+      ]),
+    );
+  });
+
+  it("gives each reviewer an independent candidate snapshot and the invocation signal", async () => {
+    const candidates: ReviewCandidate[] = [];
+    const signals: AbortSignal[] = [];
+    const codeReviewer: CodeReviewer = {
+      async review(received, _rules, options) {
+        candidates.push(received);
+        signals.push(options.signal);
+        (received.change.files as string[]).push("mutated-by-code-review.ts");
+        return passingCodeReview;
+      },
+    };
+    const acceptanceJudge: AcceptanceJudge = {
+      async evaluate(received, _rules, options) {
+        candidates.push(received);
+        signals.push(options.signal);
+        return passingAcceptanceEvals;
+      },
+    };
+    const adversarialReviewer: AdversarialReviewer = {
+      async challenge(received, _rules, options) {
+        candidates.push(received);
+        signals.push(options.signal);
+        return passingAdversarialReview;
+      },
+    };
+    const controller = new AbortController();
+    const engine = createReviewEngine({
+      codeReviewer,
+      acceptanceJudge,
+      adversarialReviewer,
+    });
+
+    await engine.invoke("review.assess-task-readiness", candidate, {
+      ...invocation,
+      signal: controller.signal,
+    });
+
+    expect(candidates).toHaveLength(3);
+    expect(new Set(candidates).size).toBe(3);
+    expect(candidates[1]?.change.files).toEqual(candidate.change.files);
+    expect(candidates[2]?.change.files).toEqual(candidate.change.files);
+    expect(signals).toHaveLength(3);
+    expect(new Set(signals).size).toBe(1);
+  });
+
+  it("propagates cancellation to reviewers and returns no readiness decision", async () => {
+    let reviewerSignal: AbortSignal | undefined;
+    const dependencies = createDependencies();
+    dependencies.codeReviewer.review = vi.fn(
+      async (_candidate, _rules, { signal }) => {
+        reviewerSignal = signal;
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        });
+        return passingCodeReview;
+      },
+    );
+    const controller = new AbortController();
+    const engine = createReviewEngine(dependencies);
+    const invoked = engine.invoke("review.assess-task-readiness", candidate, {
+      ...invocation,
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(reviewerSignal).toBeDefined());
+    controller.abort(new Error("The agent stopped the review."));
+
+    await expect(invoked).rejects.toMatchObject({ code: "CANCELLED" });
+  });
+
+  it("validates identifiers, cross-references, and payload limits before review", async () => {
+    const dependencies = createDependencies();
+    const engine = createReviewEngine(dependencies);
+
+    await expect(
+      engine.invoke(
+        "review.assess-task-readiness",
+        {
+          ...candidate,
+          acceptanceCriteria: [
+            requiredItem(candidate.acceptanceCriteria, 0),
+            { ...requiredItem(candidate.acceptanceCriteria, 0) },
+          ],
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+
+    await expect(
+      engine.invoke(
+        "review.assess-task-readiness",
+        {
+          ...candidate,
+          evidence: [
+            {
+              ...requiredItem(candidate.evidence, 0),
+              criterionIds: ["AC-404"],
+            },
+          ],
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+
+    await expect(
+      engine.invoke(
+        "review.assess-task-readiness",
+        {
+          ...candidate,
+          change: { ...candidate.change, patch: "x".repeat(200_001) },
+        },
+        invocation,
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+    expect(dependencies.codeReviewer.review).not.toHaveBeenCalled();
+  });
+
+  it("requires an authenticated principal before any reviewer runs", async () => {
+    const dependencies = createDependencies();
+    const engine = createReviewEngine(dependencies);
+
+    await expect(
+      engine.invoke("review.assess-task-readiness", candidate, {
+        source: "direct",
+        principal: null,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<EngineError>>({
+        code: "UNAUTHENTICATED",
+      }),
+    );
+    expect(dependencies.codeReviewer.review).not.toHaveBeenCalled();
+    expect(dependencies.acceptanceJudge.evaluate).not.toHaveBeenCalled();
+    expect(dependencies.adversarialReviewer.challenge).not.toHaveBeenCalled();
+  });
+
+  it("ships deterministic reviewers that require passing verification and adversarial evidence", async () => {
+    const engine = createReviewEngine(createDeterministicReviewers());
+
+    await expect(
+      engine.invoke("review.assess-task-readiness", candidate, invocation),
+    ).resolves.toMatchObject({
+      readyToComplete: true,
+      decision: "pass",
+    });
+
+    const withoutSecondChallenge = {
+      ...candidate,
+      evidence: candidate.evidence.filter(({ id }) => id !== "E-ADV2"),
+    };
+    await expect(
+      engine.invoke(
+        "review.assess-task-readiness",
+        withoutSecondChallenge,
+        invocation,
+      ),
+    ).resolves.toMatchObject({
+      readyToComplete: false,
+      gates: {
+        codeReview: { verdict: "pass" },
+        acceptanceEvals: { verdict: "pass" },
+        adversarialReview: { verdict: "fail" },
+      },
+      blockers: [
+        expect.objectContaining({
+          gate: "adversarial-review",
+          id: "ADV-2",
+        }),
+      ],
+    });
+
+    const failedVerification = {
+      ...candidate,
+      evidence: candidate.evidence.map((evidence) =>
+        evidence.id === "E-AC1" ? { ...evidence, passed: false } : evidence,
+      ),
+    };
+    await expect(
+      engine.invoke(
+        "review.assess-task-readiness",
+        failedVerification,
+        invocation,
+      ),
+    ).resolves.toMatchObject({
+      readyToComplete: false,
+      gates: {
+        codeReview: { verdict: "fail" },
+        acceptanceEvals: { verdict: "fail" },
+      },
+    });
+
+    await expect(
+      engine.invoke(
+        "review.assess-task-readiness",
+        {
+          ...candidate,
+          change: {
+            ...candidate.change,
+            patch: "+// TODO: bypass this check before release\n",
+          },
+        },
+        invocation,
+      ),
+    ).resolves.toMatchObject({
+      readyToComplete: false,
+      gates: { codeReview: { verdict: "fail" } },
+      blockers: [
+        expect.objectContaining({
+          gate: "code-review",
+          id: "UNRESOLVED-BYPASS",
+        }),
+      ],
+    });
+  });
+
+  it("publishes one bounded, read-only readiness capability", () => {
+    const engine = createReviewEngine(createDependencies());
+
+    expect(engine.list().map(({ id }) => id)).toEqual([
+      "review.assess-task-readiness",
+    ]);
+    expect(engine.describe("review.assess-task-readiness")).toMatchObject({
+      title: "Assess task readiness",
+      timeoutMs: 120_000,
+      annotations: {
+        readOnly: true,
+        destructive: false,
+        idempotent: true,
+        openWorld: false,
+      },
+      inputSchema: {
+        type: "object",
+        required: [
+          "taskId",
+          "summary",
+          "acceptanceCriteria",
+          "change",
+          "evidence",
+        ],
+      },
+    });
+  });
+});

--- a/examples/review-engine/tsconfig.json
+++ b/examples/review-engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/example-review.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/cli" },
+    { "path": "../../packages/mcp" }
+  ]
+}

--- a/examples/review-engine/tsconfig.test.json
+++ b/examples/review-engine/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "./examples/composed-engine" },
     { "path": "./examples/crawl-engine" },
     { "path": "./examples/hello-engine" },
+    { "path": "./examples/review-engine" },
     { "path": "./examples/spec-engine" },
     { "path": "./examples/support-engine" },
     { "path": "./examples/support-harness" }


### PR DESCRIPTION
## Summary

- add a private `review-engine` example with the `review.assess-task-readiness` capability
- enforce fail-closed code-review, acceptance-eval, and adversarial-review gates
- inject independent reviewer ports and include a deterministic local demonstration adapter
- expose the same capability through direct invocation, CLI, MCP stdio, and stateless MCP HTTP
- document the standard agent workflow, versioned policy, operational limits, and production-adapter boundary

## Why

Coding agents need an observable, repeatable way to determine whether every acceptance criterion has passed before they declare a task complete. This example keeps that policy inside a custom engine, without expanding the framework API or adding a framework-level eval runner.

## Impact

This is an additive private example. It does not change public framework contracts. Production consumers can replace the three reviewer ports with model-, tool-, or service-backed adapters without changing the capability contract or readiness calculation.

## Validation

- `yarn run check`
- 70 test files passed
- 1,320 tests passed
- typecheck, lint, format check, full test suite, and build passed