### PR TITLE
feat(examples): add multi-provider image engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Then follow the [getting-started guide](./docs/getting-started.md) or inspect:
 - [`crawl-engine`](./examples/crawl-engine/) for an outbound provider
   integration, crawling the web with Firecrawl behind a port, with target rules
   that run before authorization;
+- [`image-engine`](./examples/image-engine/) for outcome-based routing across
+  GPT Image 2, Seedream 5.0, and Nano Banana 2 behind replaceable domain ports;
 - [`spec-engine`](./examples/spec-engine/) for a spec-driven development
   workflow whose ordering, state, and per-step authorization live in the domain
   rather than in a workflow engine.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ conflicts with a contract or ADR, the normative source takes precedence.
 - [`support-engine`: dependency injection and authorization example](../examples/support-engine/)
 - [`support-harness`: private MCP consumer](../examples/support-harness/)
 - [`crawl-engine`: outbound provider integration with Firecrawl](../examples/crawl-engine/)
+- [`image-engine`: multi-provider image production by use case](../examples/image-engine/)
 - [`spec-engine`: spec-driven development workflow as domain rules](../examples/spec-engine/)
 - [`community-capabilities`: atomic and library capability publication fixture](../examples/community-capabilities/)
 - [`composed-engine`: local, atomic, and library capability composition](../examples/composed-engine/)

--- a/examples/image-engine/README.md
+++ b/examples/image-engine/README.md
@@ -1,0 +1,199 @@
+# Multi-provider image engine example
+
+This example publishes four image-production capabilities through the direct
+API, CLI, MCP stdio, and stateless MCP HTTP. Each capability chooses an image
+provider behind a domain port; consumers request an outcome and never select a
+model or send a provider credential.
+
+| Capability | Production use case | Default provider |
+| --- | --- | --- |
+| `image.edit-asset` | Edit one existing asset while preserving supplied details | OpenAI GPT Image 2 |
+| `image.render-text-asset` | Produce posters, covers, and social assets where copy fidelity is the primary concern | OpenAI GPT Image 2 |
+| `image.generate-campaign-series` | Generate two to four high-resolution images with coherent art direction | BytePlus Seedream 5.0 Lite |
+| `image.compose-reference-asset` | Create a new composition that keeps products, subjects, or brand cues consistent across multiple references | Google Nano Banana 2 |
+
+The defaults reflect the providers' documented strengths as of July 2026:
+
+- [`gpt-image-2`](https://developers.openai.com/api/docs/models/gpt-image-2)
+  supports image generation and editing, flexible sizes, and high-fidelity
+  image inputs. The example uses the Image Edits endpoint for edits and the
+  Image Generations endpoint for copy-heavy assets.
+- [`seedream-5-0-260128`](https://docs.byteplus.com/api/docs/ModelArk/1824121)
+  supports 2K/3K/4K output and sequential image generation. The example uses it
+  for bounded campaign series where cross-image coherence is the primary need.
+- [`gemini-3.1-flash-image`](https://ai.google.dev/gemini-api/docs/image-generation),
+  currently named Nano Banana 2, is Google's general-purpose native image model
+  with multi-reference processing and consistency. The example uses it to
+  create a new asset from two to four references, not to edit an existing asset.
+
+Model aliases and recommendations evolve. The composition root therefore allows
+every model ID to be overridden without changing a capability contract.
+
+## Architecture
+
+```text
+direct / CLI / MCP stdio / MCP HTTP
+                |
+                v
+           engine.invoke
+                |
+     +----------+-----------+----------------+
+     |          |           |                |
+     v          v           v                v
+ edit asset  render copy  campaign series  reference composition
+     |          |           |                |
+     +----> GPT Image 2   Seedream 5.0    Nano Banana 2
+```
+
+- `src/application/ports.ts` defines outcome-oriented ports. It contains no
+  provider SDK or transport type.
+- `src/capabilities/` owns the stable Zod 4 contracts, defaults, access rules,
+  timeouts, and handlers.
+- `src/infrastructure/` is the only layer that knows the three outbound HTTP
+  contracts.
+- `src/engine.ts` is the composition root. It reads credentials and optional
+  model/base-URL overrides, constructs the adapters, and injects them.
+- CLI and MCP adapters receive the engine and can execute a capability only
+  through `engine.invoke`.
+
+The example uses built-in `fetch`, `FormData`, and `Blob`, so it adds no provider
+SDK dependencies. A production engine may use official SDKs behind the same
+ports without changing a capability or consumer.
+
+## Configure
+
+All three credentials are required at startup because the four capabilities are
+published together:
+
+```sh
+export OPENAI_API_KEY='sk-...'
+export ARK_API_KEY='...'
+export GEMINI_API_KEY='...'
+```
+
+The following optional settings support regional endpoints, compatible local
+stubs, gateways, and deliberate model upgrades:
+
+| Environment variable | Default |
+| --- | --- |
+| `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
+| `OPENAI_IMAGE_MODEL` | `gpt-image-2` |
+| `BYTEPLUS_ARK_BASE_URL` | `https://ark.ap-southeast.bytepluses.com/api/v3` |
+| `SEEDREAM_IMAGE_MODEL` | `seedream-5-0-260128` |
+| `GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta` |
+| `NANO_BANANA_IMAGE_MODEL` | `gemini-3.1-flash-image` |
+
+Base URLs must use HTTP(S) and cannot contain credentials. Provider keys are
+sent only in outbound headers. They never appear in capability inputs, outputs,
+events, logs, or public error details.
+
+## Run the example
+
+From the repository root:
+
+```sh
+yarn build
+```
+
+The direct entrypoint demonstrates the text-fidelity workflow:
+
+```sh
+node examples/image-engine/dist/direct.js \
+  'A restrained product launch poster with generous whitespace.' \
+  'SHIP THE RIGHT THING'
+```
+
+List and describe the same capabilities through the CLI:
+
+```sh
+node examples/image-engine/dist/cli.js list
+node examples/image-engine/dist/cli.js describe image.generate-campaign-series
+```
+
+Generate a bounded Seedream campaign series:
+
+```sh
+node examples/image-engine/dist/cli.js run image.generate-campaign-series \
+  --input '{"prompt":"A connected editorial launch campaign.","count":3,"aspectRatio":"16:9","resolution":"4K"}'
+```
+
+Reference images use a JSON-safe object with a MIME type and base64 data. For
+example, an image edit input has this shape:
+
+```json
+{
+  "prompt": "Replace the background with a quiet studio.",
+  "referenceImages": [
+    {
+      "mimeType": "image/png",
+      "base64Data": "<BASE64_IMAGE_DATA>"
+    }
+  ],
+  "aspectRatio": "3:2"
+}
+```
+
+Start the MCP stdio adapter from a trusted local MCP host:
+
+```sh
+node examples/image-engine/dist/mcp-stdio.js
+```
+
+Start authenticated stateless MCP HTTP on loopback:
+
+```sh
+IMAGE_ENGINE_BEARER_TOKEN='development-only-token' \
+  node examples/image-engine/dist/mcp-http.js
+```
+
+The literal bearer-token comparison is only a deterministic authentication
+example. A real deployment should inject its identity provider at the MCP HTTP
+boundary.
+
+## Contracts and operational limits
+
+| Concern | Contract |
+| --- | --- |
+| Access | All capabilities require a trusted `Principal` |
+| Prompt | Trimmed, 1–4,000 characters |
+| Required rendered copy | Trimmed, 1–500 characters |
+| Reference formats | PNG, JPEG, or WebP |
+| Reference size | At most 10 MiB decoded per image |
+| Edit references | 1–4 images |
+| Composition references | 2–4 images |
+| Campaign count | 2–4 images, exactly the requested count |
+| Campaign resolution | 2K or 4K; default 2K |
+| Generated image size | At most 32 MiB decoded per image |
+| Provider response | At most 64 MiB before JSON parsing |
+| GPT Image timeout | 150 seconds |
+| Seedream campaign timeout | 180 seconds |
+| Nano Banana timeout | 150 seconds |
+
+Aspect ratio defaults to `1:1` and accepts `1:1`, `3:2`, `2:3`, `16:9`, or
+`9:16`. Every adapter propagates the invocation's `AbortSignal` to `fetch`.
+
+The engine performs one provider request per invocation and implements no retry,
+fallback, cache, queue, or concurrency policy. Provider rejection, malformed
+payload, incomplete campaign output, and oversized response become
+`EXECUTION_FAILED`. Public details contain only the provider name and, when
+available, HTTP status or image counts; provider response bodies remain internal.
+
+Generated images are returned inline as base64 so direct, CLI, and MCP consumers
+observe the same output contract. Hosts should account for that bounded payload
+when selecting their own transport and process memory limits.
+
+Provider choice expresses the best-fit production path, not a deterministic
+visual-quality guarantee. This example validates schemas, counts, formats, and
+sizes, but it does not run OCR or perceptual evaluations. A production workflow
+that requires provably exact copy, brand identity, or cross-image consistency
+should add an eval and human-approval step after this capability returns.
+
+## Verify the example
+
+The tests use local provider stubs and never call OpenAI, BytePlus, or Google:
+
+```sh
+yarn workspace @ai-engine/example-image test
+yarn workspace @ai-engine/example-image typecheck
+yarn workspace @ai-engine/example-image build
+```

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ai-engine/example-image",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "typecheck": "tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false --noEmit",
+    "test": "vitest run test",
+    "direct": "node dist/direct.js",
+    "cli": "node dist/cli.js",
+    "mcp:stdio": "node dist/mcp-stdio.js",
+    "mcp:http": "node dist/mcp-http.js"
+  },
+  "dependencies": {
+    "@ai-engine/cli": "0.1.0",
+    "@ai-engine/core": "0.1.0",
+    "@ai-engine/mcp": "0.1.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  }
+}

--- a/examples/image-engine/src/application/ports.ts
+++ b/examples/image-engine/src/application/ports.ts
@@ -1,0 +1,69 @@
+import type {
+  AspectRatio,
+  ImageMimeType,
+  ImageResolution,
+} from "../domain/image.js";
+
+export interface ImageAsset {
+  readonly mimeType: ImageMimeType;
+  readonly base64Data: string;
+}
+
+export type ReferenceImage = ImageAsset;
+
+export interface ImageProviderCallOptions {
+  readonly signal: AbortSignal;
+}
+
+export interface ImageEditor {
+  edit(
+    request: {
+      readonly prompt: string;
+      readonly referenceImages: ReadonlyArray<ReferenceImage>;
+      readonly aspectRatio: AspectRatio;
+    },
+    options: ImageProviderCallOptions,
+  ): Promise<ImageAsset>;
+}
+
+export interface TextImageRenderer {
+  render(
+    request: {
+      readonly prompt: string;
+      readonly requiredText: string;
+      readonly aspectRatio: AspectRatio;
+    },
+    options: ImageProviderCallOptions,
+  ): Promise<ImageAsset>;
+}
+
+export interface CampaignImageGenerator {
+  generateSeries(
+    request: {
+      readonly prompt: string;
+      readonly count: number;
+      readonly aspectRatio: AspectRatio;
+      readonly resolution: ImageResolution;
+    },
+    options: ImageProviderCallOptions,
+  ): Promise<ReadonlyArray<ImageAsset>>;
+}
+
+export interface ReferenceImageComposer {
+  compose(
+    request: {
+      readonly prompt: string;
+      readonly referenceImages: ReadonlyArray<ReferenceImage>;
+      readonly aspectRatio: AspectRatio;
+      readonly resolution: ImageResolution;
+    },
+    options: ImageProviderCallOptions,
+  ): Promise<ImageAsset>;
+}
+
+export interface ImageEngineDependencies {
+  readonly editor: ImageEditor;
+  readonly textRenderer: TextImageRenderer;
+  readonly campaignGenerator: CampaignImageGenerator;
+  readonly referenceComposer: ReferenceImageComposer;
+}

--- a/examples/image-engine/src/capabilities/compose-reference-asset.ts
+++ b/examples/image-engine/src/capabilities/compose-reference-asset.ts
@@ -1,0 +1,35 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import type { ReferenceImageComposer } from "../application/ports.js";
+import {
+  aspectRatioSchema,
+  generativeAnnotations,
+  promptSchema,
+  referenceImageSchema,
+  resolutionSchema,
+  singleImageOutputSchema,
+} from "./image-contracts.js";
+
+export function createComposeReferenceAsset(composer: ReferenceImageComposer) {
+  return defineCapability({
+    title: "Compose reference image asset",
+    description:
+      "Create a new visual composition while preserving subjects from multiple references.",
+    input: z.object({
+      prompt: promptSchema,
+      referenceImages: z.array(referenceImageSchema).min(2).max(4),
+      aspectRatio: aspectRatioSchema,
+      resolution: resolutionSchema,
+    }),
+    output: singleImageOutputSchema,
+    access: "authenticated",
+    timeoutMs: 150_000,
+    annotations: generativeAnnotations,
+    async run({ input, context }) {
+      return {
+        image: await composer.compose(input, { signal: context.signal }),
+      };
+    },
+  });
+}

--- a/examples/image-engine/src/capabilities/edit-asset.ts
+++ b/examples/image-engine/src/capabilities/edit-asset.ts
@@ -1,0 +1,33 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import type { ImageEditor } from "../application/ports.js";
+import {
+  aspectRatioSchema,
+  generativeAnnotations,
+  promptSchema,
+  referenceImageSchema,
+  singleImageOutputSchema,
+} from "./image-contracts.js";
+
+export function createEditAsset(editor: ImageEditor) {
+  return defineCapability({
+    title: "Edit image asset",
+    description:
+      "Edit an existing visual while preserving the supplied image details.",
+    input: z.object({
+      prompt: promptSchema,
+      referenceImages: z.array(referenceImageSchema).min(1).max(4),
+      aspectRatio: aspectRatioSchema,
+    }),
+    output: singleImageOutputSchema,
+    access: "authenticated",
+    timeoutMs: 150_000,
+    annotations: generativeAnnotations,
+    async run({ input, context }) {
+      return {
+        image: await editor.edit(input, { signal: context.signal }),
+      };
+    },
+  });
+}

--- a/examples/image-engine/src/capabilities/generate-campaign-series.ts
+++ b/examples/image-engine/src/capabilities/generate-campaign-series.ts
@@ -1,0 +1,48 @@
+import { EngineError, defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import type { CampaignImageGenerator } from "../application/ports.js";
+import {
+  aspectRatioSchema,
+  generativeAnnotations,
+  imageAssetSchema,
+  promptSchema,
+  resolutionSchema,
+} from "./image-contracts.js";
+
+export function createGenerateCampaignSeries(
+  generator: CampaignImageGenerator,
+) {
+  return defineCapability({
+    title: "Generate campaign image series",
+    description:
+      "Create two to four visually coherent campaign images with shared art direction.",
+    input: z.object({
+      prompt: promptSchema,
+      count: z.number().int().min(2).max(4),
+      aspectRatio: aspectRatioSchema,
+      resolution: resolutionSchema,
+    }),
+    output: z.object({ images: z.array(imageAssetSchema).min(2).max(4) }),
+    access: "authenticated",
+    timeoutMs: 180_000,
+    annotations: generativeAnnotations,
+    async run({ input, context }) {
+      const images = await generator.generateSeries(input, {
+        signal: context.signal,
+      });
+      if (images.length !== input.count) {
+        throw new EngineError({
+          code: "EXECUTION_FAILED",
+          message: "The campaign generator returned an incomplete series.",
+        });
+      }
+      return {
+        images: images.map(({ mimeType, base64Data }) => ({
+          mimeType,
+          base64Data,
+        })),
+      };
+    },
+  });
+}

--- a/examples/image-engine/src/capabilities/image-contracts.ts
+++ b/examples/image-engine/src/capabilities/image-contracts.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+import {
+  aspectRatios,
+  imageMimeTypes,
+  imageResolutions,
+  isBoundedBase64,
+  maximumGeneratedImageBytes,
+  maximumReferenceImageBytes,
+} from "../domain/image.js";
+
+const maximumPromptCharacters = 4_000;
+const maximumRequiredTextCharacters = 500;
+
+export const promptSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(maximumPromptCharacters);
+export const aspectRatioSchema = z.enum(aspectRatios).default("1:1");
+export const resolutionSchema = z.enum(imageResolutions).default("2K");
+
+function boundedBase64Schema(maximumBytes: number) {
+  return z
+    .string()
+    .max(Math.ceil(maximumBytes / 3) * 4)
+    .refine((value) => isBoundedBase64(value, maximumBytes), {
+      message: "Image data must be valid bounded base64.",
+    });
+}
+
+export const referenceImageSchema = z.object({
+  mimeType: z.enum(imageMimeTypes),
+  base64Data: boundedBase64Schema(maximumReferenceImageBytes),
+});
+
+export const imageAssetSchema = z.object({
+  mimeType: z.enum(imageMimeTypes),
+  base64Data: boundedBase64Schema(maximumGeneratedImageBytes),
+});
+
+export const singleImageOutputSchema = z.object({ image: imageAssetSchema });
+
+export const requiredTextSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(maximumRequiredTextCharacters);
+
+export const generativeAnnotations = Object.freeze({
+  readOnly: true,
+  destructive: false,
+  idempotent: false,
+  openWorld: true,
+});

--- a/examples/image-engine/src/capabilities/render-text-asset.ts
+++ b/examples/image-engine/src/capabilities/render-text-asset.ts
@@ -1,0 +1,33 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import type { TextImageRenderer } from "../application/ports.js";
+import {
+  aspectRatioSchema,
+  generativeAnnotations,
+  promptSchema,
+  requiredTextSchema,
+  singleImageOutputSchema,
+} from "./image-contracts.js";
+
+export function createRenderTextAsset(renderer: TextImageRenderer) {
+  return defineCapability({
+    title: "Render text image asset",
+    description:
+      "Create a visual that prioritizes faithful rendering of supplied marketing copy.",
+    input: z.object({
+      prompt: promptSchema,
+      requiredText: requiredTextSchema,
+      aspectRatio: aspectRatioSchema,
+    }),
+    output: singleImageOutputSchema,
+    access: "authenticated",
+    timeoutMs: 150_000,
+    annotations: generativeAnnotations,
+    async run({ input, context }) {
+      return {
+        image: await renderer.render(input, { signal: context.signal }),
+      };
+    },
+  });
+}

--- a/examples/image-engine/src/cli.ts
+++ b/examples/image-engine/src/cli.ts
@@ -1,0 +1,23 @@
+import { pathToFileURL } from "node:url";
+
+import { runCli } from "@ai-engine/cli";
+
+import { createConfiguredImageEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<number> {
+  return runCli(createConfiguredImageEngine(), { principal: localPrincipal });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  process.exitCode = await main().catch(() => {
+    process.stderr.write(
+      '{"error":{"code":"EXECUTION_FAILED","message":"Image engine CLI startup failed."}}\n',
+    );
+    return 1;
+  });
+}

--- a/examples/image-engine/src/direct.ts
+++ b/examples/image-engine/src/direct.ts
@@ -1,0 +1,34 @@
+import { pathToFileURL } from "node:url";
+
+import { createConfiguredImageEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+const defaultPrompt =
+  "A restrained product launch poster with generous whitespace.";
+const defaultText = "SHIP THE RIGHT THING";
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+): Promise<void> {
+  const engine = createConfiguredImageEngine();
+  const result = await engine.invoke(
+    "image.render-text-asset",
+    {
+      prompt: args[0] ?? defaultPrompt,
+      requiredText: args[1] ?? defaultText,
+    },
+    { source: "direct", principal: localPrincipal },
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Image engine direct invocation failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/image-engine/src/domain/image.ts
+++ b/examples/image-engine/src/domain/image.ts
@@ -1,0 +1,39 @@
+export const imageMimeTypes = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+
+export type ImageMimeType = (typeof imageMimeTypes)[number];
+
+export const aspectRatios = ["1:1", "3:2", "2:3", "16:9", "9:16"] as const;
+
+export type AspectRatio = (typeof aspectRatios)[number];
+
+export const imageResolutions = ["2K", "4K"] as const;
+
+export type ImageResolution = (typeof imageResolutions)[number];
+
+export const maximumReferenceImageBytes = 10 * 1024 * 1024;
+export const maximumGeneratedImageBytes = 32 * 1024 * 1024;
+
+const base64Pattern =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
+
+export function isBoundedBase64(value: string, maximumBytes: number): boolean {
+  if (value === "" || !base64Pattern.test(value)) return false;
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  const decodedBytes = (value.length / 4) * 3 - padding;
+  return decodedBytes <= maximumBytes;
+}
+
+export function imageFileExtension(mimeType: ImageMimeType): string {
+  switch (mimeType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+  }
+}

--- a/examples/image-engine/src/engine.ts
+++ b/examples/image-engine/src/engine.ts
@@ -1,0 +1,90 @@
+import { createEngine } from "@ai-engine/core";
+
+import type { ImageEngineDependencies } from "./application/ports.js";
+import { createComposeReferenceAsset } from "./capabilities/compose-reference-asset.js";
+import { createEditAsset } from "./capabilities/edit-asset.js";
+import { createGenerateCampaignSeries } from "./capabilities/generate-campaign-series.js";
+import { createRenderTextAsset } from "./capabilities/render-text-asset.js";
+import { createNanoBananaReferenceComposer } from "./infrastructure/nano-banana-reference-composer.js";
+import { createOpenAiImageProvider } from "./infrastructure/openai-image-provider.js";
+import { createSeedreamCampaignGenerator } from "./infrastructure/seedream-campaign-generator.js";
+
+export function createImageEngine(dependencies: ImageEngineDependencies) {
+  return createEngine({
+    name: "multi-provider-image-engine",
+    version: "0.1.0",
+    capabilities: {
+      "image.edit-asset": createEditAsset(dependencies.editor),
+      "image.render-text-asset": createRenderTextAsset(
+        dependencies.textRenderer,
+      ),
+      "image.generate-campaign-series": createGenerateCampaignSeries(
+        dependencies.campaignGenerator,
+      ),
+      "image.compose-reference-asset": createComposeReferenceAsset(
+        dependencies.referenceComposer,
+      ),
+    },
+  });
+}
+
+export interface ImageEngineEnvironment {
+  readonly OPENAI_API_KEY?: string | undefined;
+  readonly OPENAI_BASE_URL?: string | undefined;
+  readonly OPENAI_IMAGE_MODEL?: string | undefined;
+  readonly ARK_API_KEY?: string | undefined;
+  readonly BYTEPLUS_ARK_BASE_URL?: string | undefined;
+  readonly SEEDREAM_IMAGE_MODEL?: string | undefined;
+  readonly GEMINI_API_KEY?: string | undefined;
+  readonly GEMINI_BASE_URL?: string | undefined;
+  readonly NANO_BANANA_IMAGE_MODEL?: string | undefined;
+}
+
+function requiredCredential(
+  environment: ImageEngineEnvironment,
+  name: "OPENAI_API_KEY" | "ARK_API_KEY" | "GEMINI_API_KEY",
+): string {
+  const value = environment[name];
+  if (value === undefined || value === "") {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function optionalValue(value: string | undefined): string | undefined {
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/**
+ * Composition root for the three outbound providers. Credentials and model IDs
+ * never enter a capability input or result.
+ */
+export function createConfiguredImageEngine(
+  environment: ImageEngineEnvironment = process.env,
+) {
+  const openAiBaseUrl = optionalValue(environment.OPENAI_BASE_URL);
+  const openAiModel = optionalValue(environment.OPENAI_IMAGE_MODEL);
+  const seedreamBaseUrl = optionalValue(environment.BYTEPLUS_ARK_BASE_URL);
+  const seedreamModel = optionalValue(environment.SEEDREAM_IMAGE_MODEL);
+  const geminiBaseUrl = optionalValue(environment.GEMINI_BASE_URL);
+  const nanoBananaModel = optionalValue(environment.NANO_BANANA_IMAGE_MODEL);
+  const openAi = createOpenAiImageProvider({
+    apiKey: requiredCredential(environment, "OPENAI_API_KEY"),
+    ...(openAiBaseUrl === undefined ? {} : { baseUrl: openAiBaseUrl }),
+    ...(openAiModel === undefined ? {} : { model: openAiModel }),
+  });
+  return createImageEngine({
+    editor: openAi,
+    textRenderer: openAi,
+    campaignGenerator: createSeedreamCampaignGenerator({
+      apiKey: requiredCredential(environment, "ARK_API_KEY"),
+      ...(seedreamBaseUrl === undefined ? {} : { baseUrl: seedreamBaseUrl }),
+      ...(seedreamModel === undefined ? {} : { model: seedreamModel }),
+    }),
+    referenceComposer: createNanoBananaReferenceComposer({
+      apiKey: requiredCredential(environment, "GEMINI_API_KEY"),
+      ...(geminiBaseUrl === undefined ? {} : { baseUrl: geminiBaseUrl }),
+      ...(nanoBananaModel === undefined ? {} : { model: nanoBananaModel }),
+    }),
+  });
+}

--- a/examples/image-engine/src/infrastructure/nano-banana-reference-composer.ts
+++ b/examples/image-engine/src/infrastructure/nano-banana-reference-composer.ts
@@ -1,0 +1,122 @@
+import type {
+  ImageAsset,
+  ReferenceImageComposer,
+} from "../application/ports.js";
+import type { ImageMimeType } from "../domain/image.js";
+import {
+  imageMimeTypes,
+  isBoundedBase64,
+  maximumGeneratedImageBytes,
+} from "../domain/image.js";
+import {
+  asRecord,
+  providerEndpoint,
+  providerFailure,
+  requestProviderJson,
+} from "./provider-http.js";
+
+export interface NanoBananaReferenceComposerOptions {
+  readonly apiKey: string;
+  readonly baseUrl?: string;
+  readonly model?: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+const defaultBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
+const defaultModel = "gemini-3.1-flash-image";
+
+function isImageMimeType(value: unknown): value is ImageMimeType {
+  return (
+    typeof value === "string" &&
+    imageMimeTypes.some((mimeType) => mimeType === value)
+  );
+}
+
+function readLastImage(payload: unknown): ImageAsset | null {
+  const steps = asRecord(payload)?.steps;
+  if (!Array.isArray(steps)) return null;
+  let result: ImageAsset | null = null;
+  for (const step of steps) {
+    const content = asRecord(step)?.content;
+    if (!Array.isArray(content)) continue;
+    for (const item of content) {
+      const record = asRecord(item);
+      const base64Data = record?.data;
+      const mimeType = record?.mime_type;
+      if (
+        record?.type === "image" &&
+        isImageMimeType(mimeType) &&
+        typeof base64Data === "string" &&
+        isBoundedBase64(base64Data, maximumGeneratedImageBytes)
+      ) {
+        result = { mimeType, base64Data };
+      }
+    }
+  }
+  return result;
+}
+
+export function createNanoBananaReferenceComposer(
+  options: NanoBananaReferenceComposerOptions,
+): ReferenceImageComposer {
+  const apiKey = options.apiKey;
+  const model = options.model ?? defaultModel;
+  if (apiKey === "") throw new TypeError("A Gemini API key is required.");
+  if (model === "")
+    throw new TypeError("A Nano Banana image model is required.");
+  const endpoint = providerEndpoint(
+    options.baseUrl ?? defaultBaseUrl,
+    "interactions",
+  );
+  const fetchImplementation = options.fetch ?? globalThis.fetch;
+
+  return {
+    async compose(
+      { prompt, referenceImages, aspectRatio, resolution },
+      { signal },
+    ) {
+      const payload = await requestProviderJson({
+        provider: "google",
+        providerLabel: "Nano Banana",
+        url: endpoint,
+        init: {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-goog-api-key": apiKey,
+          },
+          body: JSON.stringify({
+            model,
+            input: [
+              { type: "text", text: prompt },
+              ...referenceImages.map((reference) => ({
+                type: "image",
+                mime_type: reference.mimeType,
+                data: reference.base64Data,
+              })),
+            ],
+            response_format: {
+              type: "image",
+              mime_type: "image/png",
+              aspect_ratio: aspectRatio,
+              image_size: resolution,
+              delivery: "inline",
+            },
+          }),
+        },
+        fetch: fetchImplementation,
+        signal,
+        requestFailureMessage:
+          "The Nano Banana image request could not be completed.",
+        rejectionMessage: "Nano Banana rejected the image request.",
+      });
+      const image = readLastImage(payload);
+      if (image === null) {
+        throw providerFailure("Nano Banana returned no image.", {
+          provider: "google",
+        });
+      }
+      return image;
+    },
+  };
+}

--- a/examples/image-engine/src/infrastructure/openai-image-provider.ts
+++ b/examples/image-engine/src/infrastructure/openai-image-provider.ts
@@ -1,0 +1,138 @@
+import type {
+  ImageAsset,
+  ImageEditor,
+  ReferenceImage,
+  TextImageRenderer,
+} from "../application/ports.js";
+import type { AspectRatio } from "../domain/image.js";
+import {
+  imageFileExtension,
+  isBoundedBase64,
+  maximumGeneratedImageBytes,
+} from "../domain/image.js";
+import {
+  asRecord,
+  providerEndpoint,
+  providerFailure,
+  requestProviderJson,
+} from "./provider-http.js";
+
+export interface OpenAiImageProviderOptions {
+  readonly apiKey: string;
+  readonly baseUrl?: string;
+  readonly model?: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+export interface OpenAiImageProvider extends ImageEditor, TextImageRenderer {}
+
+const defaultBaseUrl = "https://api.openai.com/v1";
+const defaultModel = "gpt-image-2";
+
+const sizes: Readonly<Record<AspectRatio, string>> = {
+  "1:1": "1024x1024",
+  "3:2": "1536x1024",
+  "2:3": "1024x1536",
+  "16:9": "1792x1008",
+  "9:16": "1008x1792",
+};
+
+function readOpenAiImage(payload: unknown): ImageAsset {
+  const record = asRecord(payload);
+  const data = record?.data;
+  const first = Array.isArray(data) ? asRecord(data[0]) : null;
+  const base64Data = first?.b64_json;
+  if (
+    typeof base64Data !== "string" ||
+    !isBoundedBase64(base64Data, maximumGeneratedImageBytes)
+  ) {
+    throw providerFailure("OpenAI returned no image.", { provider: "openai" });
+  }
+  return { mimeType: "image/png", base64Data };
+}
+
+function toBlob(reference: ReferenceImage): Blob {
+  const bytes = Uint8Array.from(Buffer.from(reference.base64Data, "base64"));
+  return new Blob([bytes], { type: reference.mimeType });
+}
+
+export function createOpenAiImageProvider(
+  options: OpenAiImageProviderOptions,
+): OpenAiImageProvider {
+  const apiKey = options.apiKey;
+  const model = options.model ?? defaultModel;
+  if (apiKey === "") throw new TypeError("An OpenAI API key is required.");
+  if (model === "") throw new TypeError("An OpenAI image model is required.");
+  const baseUrl = options.baseUrl ?? defaultBaseUrl;
+  const generationsUrl = providerEndpoint(baseUrl, "images/generations");
+  const editsUrl = providerEndpoint(baseUrl, "images/edits");
+  const fetchImplementation = options.fetch ?? globalThis.fetch;
+
+  const request = async (
+    url: URL,
+    init: RequestInit,
+    signal: AbortSignal,
+  ): Promise<ImageAsset> =>
+    readOpenAiImage(
+      await requestProviderJson({
+        provider: "openai",
+        providerLabel: "OpenAI",
+        url,
+        init,
+        fetch: fetchImplementation,
+        signal,
+        requestFailureMessage:
+          "The OpenAI image request could not be completed.",
+        rejectionMessage: "OpenAI rejected the image request.",
+      }),
+    );
+
+  return {
+    async render({ prompt, requiredText, aspectRatio }, { signal }) {
+      return request(
+        generationsUrl,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model,
+            prompt: `${prompt}\n\nRender this text exactly as written, without adding or changing characters: "${requiredText}"`,
+            size: sizes[aspectRatio],
+            quality: "high",
+            output_format: "png",
+            n: 1,
+          }),
+        },
+        signal,
+      );
+    },
+
+    async edit({ prompt, referenceImages, aspectRatio }, { signal }) {
+      const form = new FormData();
+      form.set("model", model);
+      form.set("prompt", prompt);
+      form.set("size", sizes[aspectRatio]);
+      form.set("quality", "high");
+      form.set("output_format", "png");
+      referenceImages.forEach((reference, index) => {
+        form.append(
+          "image[]",
+          toBlob(reference),
+          `reference-${String(index + 1)}.${imageFileExtension(reference.mimeType)}`,
+        );
+      });
+      return request(
+        editsUrl,
+        {
+          method: "POST",
+          headers: { authorization: `Bearer ${apiKey}` },
+          body: form,
+        },
+        signal,
+      );
+    },
+  };
+}

--- a/examples/image-engine/src/infrastructure/provider-http.ts
+++ b/examples/image-engine/src/infrastructure/provider-http.ts
@@ -1,0 +1,144 @@
+import { EngineError } from "@ai-engine/core";
+
+const maximumProviderResponseBytes = 64 * 1024 * 1024;
+const maximumCauseCharacters = 512;
+
+export interface ProviderHttpRequest {
+  readonly provider: string;
+  readonly providerLabel: string;
+  readonly url: URL;
+  readonly init: RequestInit;
+  readonly fetch: typeof globalThis.fetch;
+  readonly signal: AbortSignal;
+  readonly requestFailureMessage: string;
+  readonly rejectionMessage: string;
+}
+
+export function providerFailure(
+  message: string,
+  publicDetails: Readonly<Record<string, unknown>>,
+  cause?: unknown,
+): EngineError {
+  return new EngineError({
+    code: "EXECUTION_FAILED",
+    message,
+    publicDetails,
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+export function providerEndpoint(baseUrl: string, path: string): URL {
+  const base = new URL(baseUrl);
+  if (
+    (base.protocol !== "https:" && base.protocol !== "http:") ||
+    base.username !== "" ||
+    base.password !== ""
+  ) {
+    throw new TypeError(
+      "Provider base URL must be a credential-free HTTP(S) URL.",
+    );
+  }
+  const normalizedPath = `${base.pathname.replace(/\/+$/u, "")}/`;
+  return new URL(path.replace(/^\/+/, ""), `${base.origin}${normalizedPath}`);
+}
+
+function responseLength(response: Response): number | null {
+  const raw = response.headers.get("content-length");
+  if (raw === null || !/^\d+$/u.test(raw)) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+async function readBoundedText(response: Response): Promise<string> {
+  const declaredLength = responseLength(response);
+  if (
+    declaredLength !== null &&
+    declaredLength > maximumProviderResponseBytes
+  ) {
+    throw new RangeError(
+      "Provider response exceeds the configured byte limit.",
+    );
+  }
+  if (response.body === null) return "";
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let totalBytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maximumProviderResponseBytes) {
+        await reader.cancel();
+        throw new RangeError(
+          "Provider response exceeds the configured byte limit.",
+        );
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export async function requestProviderJson(
+  request: ProviderHttpRequest,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await request.fetch(request.url, {
+      ...request.init,
+      signal: request.signal,
+    });
+  } catch (cause) {
+    if (request.signal.aborted) throw cause;
+    throw providerFailure(
+      request.requestFailureMessage,
+      { provider: request.provider },
+      cause,
+    );
+  }
+
+  if (!response.ok) {
+    const detail = await readBoundedText(response).catch(() => "");
+    throw providerFailure(
+      request.rejectionMessage,
+      { provider: request.provider, status: response.status },
+      new Error(
+        `${request.providerLabel} responded with status ${String(response.status)}: ${detail.slice(0, maximumCauseCharacters)}`,
+      ),
+    );
+  }
+
+  let text: string;
+  try {
+    text = await readBoundedText(response);
+  } catch (cause) {
+    throw providerFailure(
+      `${request.providerLabel} returned an unreadable response.`,
+      { provider: request.provider },
+      cause,
+    );
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (cause) {
+    throw providerFailure(
+      `${request.providerLabel} returned an unreadable response.`,
+      { provider: request.provider },
+      cause,
+    );
+  }
+}
+
+export function asRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : null;
+}

--- a/examples/image-engine/src/infrastructure/seedream-campaign-generator.ts
+++ b/examples/image-engine/src/infrastructure/seedream-campaign-generator.ts
@@ -1,0 +1,98 @@
+import type {
+  CampaignImageGenerator,
+  ImageAsset,
+} from "../application/ports.js";
+import {
+  isBoundedBase64,
+  maximumGeneratedImageBytes,
+} from "../domain/image.js";
+import {
+  asRecord,
+  providerEndpoint,
+  providerFailure,
+  requestProviderJson,
+} from "./provider-http.js";
+
+export interface SeedreamCampaignGeneratorOptions {
+  readonly apiKey: string;
+  readonly baseUrl?: string;
+  readonly model?: string;
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+const defaultBaseUrl = "https://ark.ap-southeast.bytepluses.com/api/v3";
+const defaultModel = "seedream-5-0-260128";
+
+function readImages(payload: unknown): ReadonlyArray<ImageAsset> {
+  const data = asRecord(payload)?.data;
+  if (!Array.isArray(data)) return [];
+  return data.flatMap((entry) => {
+    const base64Data = asRecord(entry)?.b64_json;
+    return typeof base64Data === "string" &&
+      isBoundedBase64(base64Data, maximumGeneratedImageBytes)
+      ? [{ mimeType: "image/png" as const, base64Data }]
+      : [];
+  });
+}
+
+export function createSeedreamCampaignGenerator(
+  options: SeedreamCampaignGeneratorOptions,
+): CampaignImageGenerator {
+  const apiKey = options.apiKey;
+  const model = options.model ?? defaultModel;
+  if (apiKey === "")
+    throw new TypeError("A BytePlus ModelArk API key is required.");
+  if (model === "") throw new TypeError("A Seedream image model is required.");
+  const endpoint = providerEndpoint(
+    options.baseUrl ?? defaultBaseUrl,
+    "images/generations",
+  );
+  const fetchImplementation = options.fetch ?? globalThis.fetch;
+
+  return {
+    async generateSeries(
+      { prompt, count, aspectRatio, resolution },
+      { signal },
+    ) {
+      const payload = await requestProviderJson({
+        provider: "seedream",
+        providerLabel: "Seedream",
+        url: endpoint,
+        init: {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model,
+            prompt: `${prompt}\n\nGenerate exactly ${String(count)} visually coherent campaign images at a ${aspectRatio} aspect ratio. Preserve the same art direction, subjects, products, and brand cues across the complete series.`,
+            size: resolution,
+            output_format: "png",
+            response_format: "b64_json",
+            watermark: false,
+            sequential_image_generation: "auto",
+            sequential_image_generation_options: { max_images: count },
+          }),
+        },
+        fetch: fetchImplementation,
+        signal,
+        requestFailureMessage:
+          "The Seedream image request could not be completed.",
+        rejectionMessage: "Seedream rejected the image request.",
+      });
+      const images = readImages(payload);
+      if (images.length !== count) {
+        throw providerFailure(
+          "Seedream returned an incomplete campaign series.",
+          {
+            provider: "seedream",
+            expectedImages: count,
+            receivedImages: images.length,
+          },
+        );
+      }
+      return images;
+    },
+  };
+}

--- a/examples/image-engine/src/local-principal.ts
+++ b/examples/image-engine/src/local-principal.ts
@@ -1,0 +1,6 @@
+import type { Principal } from "@ai-engine/core";
+
+/** Trusted identity supplied by the local CLI and MCP stdio hosts. */
+export const localPrincipal: Principal = Object.freeze({
+  id: "local:image-operator",
+});

--- a/examples/image-engine/src/mcp-http.ts
+++ b/examples/image-engine/src/mcp-http.ts
@@ -1,0 +1,65 @@
+import { pathToFileURL } from "node:url";
+
+import { type McpHttpServerHandle, serveMcpHttp } from "@ai-engine/mcp";
+
+import {
+  createConfiguredImageEngine,
+  type ImageEngineEnvironment,
+} from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export interface ImageMcpHttpOptions {
+  readonly expectedBearerToken: string;
+  readonly host?: string;
+  readonly port?: number;
+}
+
+export async function startImageMcpHttp(
+  options: ImageMcpHttpOptions,
+  environment: ImageEngineEnvironment = process.env,
+): Promise<McpHttpServerHandle> {
+  return serveMcpHttp(createConfiguredImageEngine(environment), {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.port === undefined ? {} : { port: options.port }),
+    auth: {
+      mode: "required",
+      authenticate(request) {
+        return request.headers.get("authorization") ===
+          `Bearer ${options.expectedBearerToken}`
+          ? localPrincipal
+          : null;
+      },
+    },
+  });
+}
+
+export async function main(): Promise<McpHttpServerHandle> {
+  const expectedBearerToken = process.env.IMAGE_ENGINE_BEARER_TOKEN;
+  if (expectedBearerToken === undefined || expectedBearerToken === "") {
+    throw new Error("IMAGE_ENGINE_BEARER_TOKEN is required.");
+  }
+  const configuredPort = process.env.PORT;
+  const port = configuredPort === undefined ? 3000 : Number(configuredPort);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error("PORT must be an integer between 0 and 65535.");
+  }
+  return startImageMcpHttp({ expectedBearerToken, port });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main()
+    .then((server) => {
+      const address = server.address();
+      process.stderr.write(
+        `Image engine MCP HTTP adapter listening on host ${address.host}, port ${String(address.port)}\n`,
+      );
+    })
+    .catch(() => {
+      process.stderr.write("Image engine MCP HTTP adapter failed to start.\n");
+      process.exitCode = 1;
+    });
+}

--- a/examples/image-engine/src/mcp-stdio.ts
+++ b/examples/image-engine/src/mcp-stdio.ts
@@ -1,0 +1,23 @@
+import { pathToFileURL } from "node:url";
+
+import { serveMcpStdio } from "@ai-engine/mcp";
+
+import { createConfiguredImageEngine } from "./engine.js";
+import { localPrincipal } from "./local-principal.js";
+
+export async function main(): Promise<void> {
+  await serveMcpStdio(createConfiguredImageEngine(), {
+    principal: localPrincipal,
+  });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Image engine MCP stdio adapter failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/image-engine/test/entrypoints.test.ts
+++ b/examples/image-engine/test/entrypoints.test.ts
@@ -1,0 +1,235 @@
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { startImageMcpHttp } from "../src/mcp-http.js";
+import { type ProviderStub, startProviderStub } from "./provider-stub.js";
+
+const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
+const referenceData = Buffer.from("reference png").toString("base64");
+const referenceImages = [
+  { mimeType: "image/png", base64Data: referenceData },
+  { mimeType: "image/png", base64Data: referenceData },
+];
+
+let stub: ProviderStub;
+
+beforeAll(() => {
+  const build = spawnSync(
+    process.execPath,
+    ["../../node_modules/typescript/bin/tsc", "-b", "--pretty", "false"],
+    { cwd: exampleRoot, encoding: "utf8" },
+  );
+  if (build.status !== 0) {
+    throw new Error(`Example build failed:\n${build.stdout}${build.stderr}`);
+  }
+});
+
+beforeEach(async () => {
+  stub = await startProviderStub();
+});
+
+afterEach(async () => {
+  await stub.close();
+});
+
+function providerEnvironment(): NodeJS.ProcessEnv & Record<string, string> {
+  return {
+    ...process.env,
+    OPENAI_API_KEY: "openai-stub-key",
+    OPENAI_BASE_URL: stub.openAiBaseUrl,
+    ARK_API_KEY: "seedream-stub-key",
+    BYTEPLUS_ARK_BASE_URL: stub.seedreamBaseUrl,
+    GEMINI_API_KEY: "gemini-stub-key",
+    GEMINI_BASE_URL: stub.geminiBaseUrl,
+  } as NodeJS.ProcessEnv & Record<string, string>;
+}
+
+interface CommandResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+async function run(
+  entrypoint: string,
+  args: readonly string[] = [],
+): Promise<CommandResult> {
+  const child = spawn(process.execPath, [`dist/${entrypoint}.js`, ...args], {
+    cwd: exampleRoot,
+    env: providerEnvironment(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: Buffer | string) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer | string) => {
+    stderr += chunk.toString();
+  });
+  const [status] = (await once(child, "exit")) as [number | null];
+  return { status, stdout, stderr };
+}
+
+describe("image engine entrypoints", () => {
+  it("renders text through the direct engine invocation", async () => {
+    const result = await run("direct", [
+      "A restrained product launch poster.",
+      "SHIP THE RIGHT THING",
+    ]);
+
+    expect(result).toMatchObject({ status: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toEqual({
+      image: { mimeType: "image/png", base64Data: stub.generatedData },
+    });
+    expect(stub.requests.at(-1)).toMatchObject({
+      path: "/openai/v1/images/generations",
+      authorization: "Bearer openai-stub-key",
+    });
+  });
+
+  it("publishes and invokes the same engine through the CLI", async () => {
+    const listed = await run("cli", ["list"]);
+    expect(listed.status).toBe(0);
+    expect(
+      (JSON.parse(listed.stdout) as ReadonlyArray<{ id: string }>).map(
+        ({ id }) => id,
+      ),
+    ).toEqual([
+      "image.edit-asset",
+      "image.render-text-asset",
+      "image.generate-campaign-series",
+      "image.compose-reference-asset",
+    ]);
+
+    const generated = await run("cli", [
+      "run",
+      "image.generate-campaign-series",
+      "--input",
+      JSON.stringify({ prompt: "A coherent launch series.", count: 2 }),
+    ]);
+    expect(generated.status).toBe(0);
+    expect(
+      (JSON.parse(generated.stdout) as { images: unknown[] }).images,
+    ).toHaveLength(2);
+    expect(stub.requests.at(-1)).toMatchObject({
+      path: "/ark/api/v3/images/generations",
+      authorization: "Bearer seedream-stub-key",
+    });
+  });
+
+  it("composes references through protocol-only MCP stdio", async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["dist/mcp-stdio.js"],
+      cwd: exampleRoot,
+      env: providerEnvironment(),
+      stderr: "pipe",
+    });
+    let stderr = "";
+    transport.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    const client = new Client(
+      { name: "image-stdio-entrypoint-test", version: "0.0.0-test" },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+      await expect(
+        client.callTool({
+          name: "image.compose-reference-asset",
+          arguments: {
+            prompt: "Compose a new product scene.",
+            referenceImages,
+          },
+        }),
+      ).resolves.toMatchObject({
+        structuredContent: {
+          image: { mimeType: "image/png", base64Data: stub.generatedData },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+    expect(stderr).toBe("");
+    expect(stub.requests.at(-1)).toMatchObject({
+      path: "/gemini/v1beta/interactions",
+      geminiApiKey: "gemini-stub-key",
+    });
+  });
+
+  it("authenticates MCP HTTP before invoking an image edit", async () => {
+    const token = "image-engine-http-token";
+    const server = await startImageMcpHttp(
+      { expectedBearerToken: token, port: 0 },
+      providerEnvironment(),
+    );
+    const url = new URL(
+      `http://${server.address().host}:${String(server.address().port)}/mcp`,
+    );
+    let client: Client | undefined;
+
+    try {
+      const unauthenticated = await fetch(url, {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "auth-boundary",
+          method: "tools/call",
+          params: {
+            name: "image.edit-asset",
+            arguments: {
+              prompt: "Change the background.",
+              referenceImages: referenceImages.slice(0, 1),
+            },
+          },
+        }),
+      });
+      expect(unauthenticated.status).toBe(401);
+      await unauthenticated.arrayBuffer();
+      expect(stub.requests).toHaveLength(0);
+
+      const transport = new StreamableHTTPClientTransport(url, {
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+      });
+      client = new Client(
+        { name: "image-http-entrypoint-test", version: "0.0.0-test" },
+        { capabilities: {} },
+      );
+      await client.connect(transport as unknown as Transport);
+      await expect(
+        client.callTool({
+          name: "image.edit-asset",
+          arguments: {
+            prompt: "Change the background.",
+            referenceImages: referenceImages.slice(0, 1),
+          },
+        }),
+      ).resolves.toMatchObject({
+        structuredContent: {
+          image: { mimeType: "image/png", base64Data: stub.generatedData },
+        },
+      });
+      expect(stub.requests.at(-1)).toMatchObject({
+        path: "/openai/v1/images/edits",
+        authorization: "Bearer openai-stub-key",
+      });
+    } finally {
+      await client?.close().catch(() => undefined);
+      await server.close();
+    }
+  });
+});

--- a/examples/image-engine/test/image-engine.test.ts
+++ b/examples/image-engine/test/image-engine.test.ts
@@ -1,0 +1,323 @@
+import type { Principal } from "@ai-engine/core";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import type {
+  ImageAsset,
+  ImageEngineDependencies,
+  ReferenceImage,
+} from "../src/application/ports.js";
+import {
+  createConfiguredImageEngine,
+  createImageEngine,
+} from "../src/engine.js";
+
+const principal: Principal = { id: "agent:creative-director" };
+const pngData = Buffer.from("generated png").toString("base64");
+const referenceData = Buffer.from("reference png").toString("base64");
+
+const generatedImage: ImageAsset = {
+  mimeType: "image/png",
+  base64Data: pngData,
+};
+
+const referenceImage: ReferenceImage = {
+  mimeType: "image/png",
+  base64Data: referenceData,
+};
+
+function createDependencies(): ImageEngineDependencies {
+  return {
+    editor: {
+      edit: vi.fn(async () => generatedImage),
+    },
+    textRenderer: {
+      render: vi.fn(async () => generatedImage),
+    },
+    campaignGenerator: {
+      generateSeries: vi.fn(async ({ count }) =>
+        Array.from({ length: count }, () => generatedImage),
+      ),
+    },
+    referenceComposer: {
+      compose: vi.fn(async () => generatedImage),
+    },
+  };
+}
+
+describe("the multi-provider image engine", () => {
+  it("routes existing-image edits exclusively to GPT Image 2", async () => {
+    const dependencies = createDependencies();
+    const engine = createImageEngine(dependencies);
+
+    const result = await engine.invoke(
+      "image.edit-asset",
+      {
+        prompt: "Replace the background with a quiet studio.",
+        referenceImages: [referenceImage],
+        aspectRatio: "3:2",
+      },
+      { source: "direct", principal },
+    );
+
+    expectTypeOf(result.image.base64Data).toEqualTypeOf<string>();
+    expect(result).toEqual({ image: generatedImage });
+    expect(dependencies.editor.edit).toHaveBeenCalledExactlyOnceWith(
+      {
+        prompt: "Replace the background with a quiet studio.",
+        referenceImages: [referenceImage],
+        aspectRatio: "3:2",
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(dependencies.textRenderer.render).not.toHaveBeenCalled();
+    expect(
+      dependencies.campaignGenerator.generateSeries,
+    ).not.toHaveBeenCalled();
+    expect(dependencies.referenceComposer.compose).not.toHaveBeenCalled();
+  });
+
+  it("routes assets with exact marketing copy exclusively to GPT Image 2", async () => {
+    const dependencies = createDependencies();
+    const engine = createImageEngine(dependencies);
+
+    const result = await engine.invoke(
+      "image.render-text-asset",
+      {
+        prompt: "A restrained launch poster with generous whitespace.",
+        requiredText: "SHIP THE RIGHT THING",
+      },
+      { source: "direct", principal },
+    );
+
+    expect(result).toEqual({ image: generatedImage });
+    expect(dependencies.textRenderer.render).toHaveBeenCalledExactlyOnceWith(
+      {
+        prompt: "A restrained launch poster with generous whitespace.",
+        requiredText: "SHIP THE RIGHT THING",
+        aspectRatio: "1:1",
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(dependencies.editor.edit).not.toHaveBeenCalled();
+    expect(
+      dependencies.campaignGenerator.generateSeries,
+    ).not.toHaveBeenCalled();
+    expect(dependencies.referenceComposer.compose).not.toHaveBeenCalled();
+  });
+
+  it("routes coherent campaign series exclusively to Seedream 5.0", async () => {
+    const dependencies = createDependencies();
+    const engine = createImageEngine(dependencies);
+
+    const result = await engine.invoke(
+      "image.generate-campaign-series",
+      {
+        prompt:
+          "Three connected editorial scenes following one product launch.",
+        count: 3,
+        aspectRatio: "16:9",
+        resolution: "4K",
+      },
+      { source: "direct", principal },
+    );
+
+    expect(result.images).toHaveLength(3);
+    expect(
+      dependencies.campaignGenerator.generateSeries,
+    ).toHaveBeenCalledExactlyOnceWith(
+      {
+        prompt:
+          "Three connected editorial scenes following one product launch.",
+        count: 3,
+        aspectRatio: "16:9",
+        resolution: "4K",
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(dependencies.editor.edit).not.toHaveBeenCalled();
+    expect(dependencies.textRenderer.render).not.toHaveBeenCalled();
+    expect(dependencies.referenceComposer.compose).not.toHaveBeenCalled();
+  });
+
+  it("routes multi-reference compositions exclusively to the latest Nano Banana", async () => {
+    const dependencies = createDependencies();
+    const engine = createImageEngine(dependencies);
+
+    const result = await engine.invoke(
+      "image.compose-reference-asset",
+      {
+        prompt: "Create a new scene that preserves both products exactly.",
+        referenceImages: [
+          referenceImage,
+          { ...referenceImage, mimeType: "image/jpeg" },
+        ],
+        aspectRatio: "9:16",
+        resolution: "2K",
+      },
+      { source: "direct", principal },
+    );
+
+    expect(result).toEqual({ image: generatedImage });
+    expect(
+      dependencies.referenceComposer.compose,
+    ).toHaveBeenCalledExactlyOnceWith(
+      {
+        prompt: "Create a new scene that preserves both products exactly.",
+        referenceImages: [
+          referenceImage,
+          { ...referenceImage, mimeType: "image/jpeg" },
+        ],
+        aspectRatio: "9:16",
+        resolution: "2K",
+      },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(dependencies.editor.edit).not.toHaveBeenCalled();
+    expect(dependencies.textRenderer.render).not.toHaveBeenCalled();
+    expect(
+      dependencies.campaignGenerator.generateSeries,
+    ).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "an edit without a reference image",
+      "image.edit-asset",
+      { prompt: "Change the background.", referenceImages: [] },
+    ],
+    [
+      "a reference composition with only one image",
+      "image.compose-reference-asset",
+      { prompt: "Combine references.", referenceImages: [referenceImage] },
+    ],
+    [
+      "a malformed base64 image",
+      "image.edit-asset",
+      {
+        prompt: "Change the background.",
+        referenceImages: [{ mimeType: "image/png", base64Data: "not base64" }],
+      },
+    ],
+    [
+      "more than four campaign images",
+      "image.generate-campaign-series",
+      { prompt: "A connected series.", count: 5 },
+    ],
+  ])(
+    "rejects %s before any provider call",
+    async (_label, capabilityId, input) => {
+      const dependencies = createDependencies();
+      const engine = createImageEngine(dependencies);
+
+      await expect(
+        engine.invoke(capabilityId as never, input as never, {
+          source: "direct",
+          principal,
+        }),
+      ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+      expect(dependencies.editor.edit).not.toHaveBeenCalled();
+      expect(dependencies.textRenderer.render).not.toHaveBeenCalled();
+      expect(
+        dependencies.campaignGenerator.generateSeries,
+      ).not.toHaveBeenCalled();
+      expect(dependencies.referenceComposer.compose).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires a trusted principal before any provider call", async () => {
+    const dependencies = createDependencies();
+    const engine = createImageEngine(dependencies);
+
+    await expect(
+      engine.invoke("image.render-text-asset", {
+        prompt: "A poster.",
+        requiredText: "Hello",
+      }),
+    ).rejects.toMatchObject({ code: "UNAUTHENTICATED" });
+    expect(dependencies.textRenderer.render).not.toHaveBeenCalled();
+  });
+
+  it("rejects provider output outside the public image contract", async () => {
+    const dependencies = createDependencies();
+    dependencies.textRenderer.render = vi.fn(async () => ({
+      mimeType: "image/png" as const,
+      base64Data: "not base64",
+    }));
+    const engine = createImageEngine(dependencies);
+
+    await expect(
+      engine.invoke(
+        "image.render-text-asset",
+        { prompt: "A poster.", requiredText: "Hello" },
+        { source: "direct", principal },
+      ),
+    ).rejects.toMatchObject({ code: "OUTPUT_INVALID" });
+  });
+
+  it("propagates cancellation to the selected provider", async () => {
+    const dependencies = createDependencies();
+    let providerSignal: AbortSignal | undefined;
+    dependencies.textRenderer.render = vi.fn(async (_request, { signal }) => {
+      providerSignal = signal;
+      await new Promise<void>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), {
+          once: true,
+        });
+      });
+      return generatedImage;
+    });
+    const engine = createImageEngine(dependencies);
+    const controller = new AbortController();
+
+    const invocation = engine.invoke(
+      "image.render-text-asset",
+      { prompt: "A poster.", requiredText: "Hello" },
+      { source: "direct", principal, signal: controller.signal },
+    );
+    await vi.waitFor(() => expect(providerSignal).toBeDefined());
+    controller.abort(new Error("Creative request cancelled."));
+
+    await expect(invocation).rejects.toMatchObject({ code: "CANCELLED" });
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
+  it("publishes bounded authenticated domain capabilities", () => {
+    const engine = createImageEngine(createDependencies());
+
+    expect(engine.list().map(({ id }) => id)).toEqual([
+      "image.edit-asset",
+      "image.render-text-asset",
+      "image.generate-campaign-series",
+      "image.compose-reference-asset",
+    ]);
+    expect(engine.describe("image.edit-asset")).toMatchObject({
+      title: "Edit image asset",
+      timeoutMs: 150_000,
+      annotations: { openWorld: true, destructive: false },
+      inputSchema: {
+        type: "object",
+        required: ["prompt", "referenceImages"],
+      },
+      outputSchema: { type: "object", required: ["image"] },
+    });
+    expect(engine.describe("image.generate-campaign-series")).toMatchObject({
+      timeoutMs: 180_000,
+      annotations: { idempotent: false, openWorld: true },
+    });
+  });
+
+  it("fails fast until every published provider has a credential", () => {
+    expect(() => createConfiguredImageEngine({})).toThrow(
+      "OPENAI_API_KEY is required.",
+    );
+    expect(() =>
+      createConfiguredImageEngine({ OPENAI_API_KEY: "openai-key" }),
+    ).toThrow("ARK_API_KEY is required.");
+    expect(() =>
+      createConfiguredImageEngine({
+        OPENAI_API_KEY: "openai-key",
+        ARK_API_KEY: "ark-key",
+      }),
+    ).toThrow("GEMINI_API_KEY is required.");
+  });
+});

--- a/examples/image-engine/test/provider-adapters.test.ts
+++ b/examples/image-engine/test/provider-adapters.test.ts
@@ -1,0 +1,341 @@
+import type { EngineError } from "@ai-engine/core";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ReferenceImage } from "../src/application/ports.js";
+import { createNanoBananaReferenceComposer } from "../src/infrastructure/nano-banana-reference-composer.js";
+import { createOpenAiImageProvider } from "../src/infrastructure/openai-image-provider.js";
+import { createSeedreamCampaignGenerator } from "../src/infrastructure/seedream-campaign-generator.js";
+
+const generatedData = Buffer.from("generated png").toString("base64");
+const referenceData = Buffer.from("reference png").toString("base64");
+const referenceImage: ReferenceImage = {
+  mimeType: "image/png",
+  base64Data: referenceData,
+};
+const signal = new AbortController().signal;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("the OpenAI GPT Image 2 adapter", () => {
+  it("uses the generations endpoint for high-fidelity text assets", async () => {
+    const fetchImplementation = vi.fn<typeof globalThis.fetch>(
+      async (_input, _init) =>
+        jsonResponse({ data: [{ b64_json: generatedData }] }),
+    );
+    const provider = createOpenAiImageProvider({
+      apiKey: "openai-test-key",
+      fetch: fetchImplementation,
+    });
+
+    const image = await provider.render(
+      {
+        prompt: "A restrained launch poster.",
+        requiredText: "SHIP THE RIGHT THING",
+        aspectRatio: "16:9",
+      },
+      { signal },
+    );
+
+    expect(image).toEqual({ mimeType: "image/png", base64Data: generatedData });
+    expect(fetchImplementation).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImplementation.mock.calls[0] ?? [];
+    expect(String(url)).toBe("https://api.openai.com/v1/images/generations");
+    expect(init?.headers).toMatchObject({
+      authorization: "Bearer openai-test-key",
+      "content-type": "application/json",
+    });
+    expect(init?.signal).toBe(signal);
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: "gpt-image-2",
+      prompt:
+        'A restrained launch poster.\n\nRender this text exactly as written, without adding or changing characters: "SHIP THE RIGHT THING"',
+      size: "1792x1008",
+      quality: "high",
+      output_format: "png",
+      n: 1,
+    });
+  });
+
+  it("uses the multipart edits endpoint and preserves every reference", async () => {
+    const fetchImplementation = vi.fn<typeof globalThis.fetch>(
+      async (_input, _init) =>
+        jsonResponse({ data: [{ b64_json: generatedData }] }),
+    );
+    const provider = createOpenAiImageProvider({
+      apiKey: "openai-test-key",
+      fetch: fetchImplementation,
+    });
+
+    const image = await provider.edit(
+      {
+        prompt: "Replace the background.",
+        referenceImages: [
+          referenceImage,
+          { ...referenceImage, mimeType: "image/jpeg" },
+        ],
+        aspectRatio: "3:2",
+      },
+      { signal },
+    );
+
+    expect(image).toEqual({ mimeType: "image/png", base64Data: generatedData });
+    const [url, init] = fetchImplementation.mock.calls[0] ?? [];
+    expect(String(url)).toBe("https://api.openai.com/v1/images/edits");
+    expect(init?.headers).toEqual({ authorization: "Bearer openai-test-key" });
+    expect(init?.body).toBeInstanceOf(FormData);
+    const form = init?.body as FormData;
+    expect(form.get("model")).toBe("gpt-image-2");
+    expect(form.get("prompt")).toBe("Replace the background.");
+    expect(form.get("size")).toBe("1536x1024");
+    expect(form.get("quality")).toBe("high");
+    expect(form.get("output_format")).toBe("png");
+    expect(form.getAll("image[]")).toHaveLength(2);
+    expect(form.getAll("image[]").map((entry) => (entry as File).type)).toEqual(
+      ["image/png", "image/jpeg"],
+    );
+  });
+
+  it("normalizes provider rejection without exposing the credential", async () => {
+    const fetchImplementation = vi.fn(async () =>
+      jsonResponse({ error: { message: "quota exceeded" } }, 429),
+    );
+    const provider = createOpenAiImageProvider({
+      apiKey: "secret-openai-key",
+      fetch: fetchImplementation,
+    });
+
+    const failure = await provider
+      .render(
+        {
+          prompt: "A poster.",
+          requiredText: "Hello",
+          aspectRatio: "1:1",
+        },
+        { signal },
+      )
+      .then(
+        () => undefined,
+        (error: unknown) => error as EngineError,
+      );
+
+    expect(failure).toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "OpenAI rejected the image request.",
+      publicDetails: { provider: "openai", status: 429 },
+    });
+    expect(JSON.stringify(failure)).not.toContain("secret-openai-key");
+  });
+
+  it("rejects a declared response above the 64 MiB provider limit", async () => {
+    const provider = createOpenAiImageProvider({
+      apiKey: "openai-test-key",
+      fetch: vi.fn(
+        async () =>
+          new Response("{}", {
+            headers: { "content-length": String(64 * 1024 * 1024 + 1) },
+          }),
+      ),
+    });
+
+    await expect(
+      provider.render(
+        {
+          prompt: "A poster.",
+          requiredText: "Hello",
+          aspectRatio: "1:1",
+        },
+        { signal },
+      ),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "OpenAI returned an unreadable response.",
+      publicDetails: { provider: "openai" },
+    });
+  });
+});
+
+describe("the BytePlus Seedream 5.0 adapter", () => {
+  it("requests a bounded coherent high-resolution campaign series", async () => {
+    const fetchImplementation = vi.fn<typeof globalThis.fetch>(
+      async (_input, _init) =>
+        jsonResponse({
+          data: [
+            { b64_json: generatedData },
+            { b64_json: generatedData },
+            { b64_json: generatedData },
+          ],
+        }),
+    );
+    const generator = createSeedreamCampaignGenerator({
+      apiKey: "seedream-test-key",
+      fetch: fetchImplementation,
+    });
+
+    const images = await generator.generateSeries(
+      {
+        prompt: "A connected editorial launch campaign.",
+        count: 3,
+        aspectRatio: "16:9",
+        resolution: "4K",
+      },
+      { signal },
+    );
+
+    expect(images).toHaveLength(3);
+    const [url, init] = fetchImplementation.mock.calls[0] ?? [];
+    expect(String(url)).toBe(
+      "https://ark.ap-southeast.bytepluses.com/api/v3/images/generations",
+    );
+    expect(init?.headers).toMatchObject({
+      authorization: "Bearer seedream-test-key",
+      "content-type": "application/json",
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: "seedream-5-0-260128",
+      prompt:
+        "A connected editorial launch campaign.\n\nGenerate exactly 3 visually coherent campaign images at a 16:9 aspect ratio. Preserve the same art direction, subjects, products, and brand cues across the complete series.",
+      size: "4K",
+      output_format: "png",
+      response_format: "b64_json",
+      watermark: false,
+      sequential_image_generation: "auto",
+      sequential_image_generation_options: { max_images: 3 },
+    });
+  });
+
+  it("fails when Seedream returns fewer images than requested", async () => {
+    const generator = createSeedreamCampaignGenerator({
+      apiKey: "seedream-test-key",
+      fetch: vi.fn(async () =>
+        jsonResponse({ data: [{ b64_json: generatedData }] }),
+      ),
+    });
+
+    await expect(
+      generator.generateSeries(
+        {
+          prompt: "A connected campaign.",
+          count: 3,
+          aspectRatio: "1:1",
+          resolution: "2K",
+        },
+        { signal },
+      ),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "Seedream returned an incomplete campaign series.",
+      publicDetails: {
+        provider: "seedream",
+        expectedImages: 3,
+        receivedImages: 1,
+      },
+    });
+  });
+});
+
+describe("the Google Nano Banana 2 adapter", () => {
+  it("uses the latest stable model for multi-reference composition", async () => {
+    const fetchImplementation = vi.fn<typeof globalThis.fetch>(
+      async (_input, _init) =>
+        jsonResponse({
+          status: "completed",
+          steps: [
+            {
+              type: "model_output",
+              content: [
+                { type: "text", text: "Created the composition." },
+                {
+                  type: "image",
+                  mime_type: "image/png",
+                  data: generatedData,
+                },
+              ],
+            },
+          ],
+        }),
+    );
+    const composer = createNanoBananaReferenceComposer({
+      apiKey: "gemini-test-key",
+      fetch: fetchImplementation,
+    });
+
+    const image = await composer.compose(
+      {
+        prompt: "Create a new scene that preserves both products.",
+        referenceImages: [
+          referenceImage,
+          { ...referenceImage, mimeType: "image/webp" },
+        ],
+        aspectRatio: "9:16",
+        resolution: "2K",
+      },
+      { signal },
+    );
+
+    expect(image).toEqual({ mimeType: "image/png", base64Data: generatedData });
+    const [url, init] = fetchImplementation.mock.calls[0] ?? [];
+    expect(String(url)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/interactions",
+    );
+    expect(init?.headers).toMatchObject({
+      "content-type": "application/json",
+      "x-goog-api-key": "gemini-test-key",
+    });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: "gemini-3.1-flash-image",
+      input: [
+        {
+          type: "text",
+          text: "Create a new scene that preserves both products.",
+        },
+        { type: "image", mime_type: "image/png", data: referenceData },
+        { type: "image", mime_type: "image/webp", data: referenceData },
+      ],
+      response_format: {
+        type: "image",
+        mime_type: "image/png",
+        aspect_ratio: "9:16",
+        image_size: "2K",
+        delivery: "inline",
+      },
+    });
+  });
+
+  it("rejects a completed interaction without an inline image", async () => {
+    const composer = createNanoBananaReferenceComposer({
+      apiKey: "gemini-test-key",
+      fetch: vi.fn(async () =>
+        jsonResponse({
+          status: "completed",
+          steps: [
+            {
+              type: "model_output",
+              content: [{ type: "text", text: "No image available." }],
+            },
+          ],
+        }),
+      ),
+    });
+
+    await expect(
+      composer.compose(
+        {
+          prompt: "Compose these references.",
+          referenceImages: [referenceImage, referenceImage],
+          aspectRatio: "1:1",
+          resolution: "2K",
+        },
+        { signal },
+      ),
+    ).rejects.toMatchObject({
+      code: "EXECUTION_FAILED",
+      message: "Nano Banana returned no image.",
+      publicDetails: { provider: "google" },
+    });
+  });
+});

--- a/examples/image-engine/test/provider-stub.ts
+++ b/examples/image-engine/test/provider-stub.ts
@@ -1,0 +1,119 @@
+import { once } from "node:events";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+
+const generatedData = Buffer.from("stub generated png").toString("base64");
+
+export interface ProviderStubRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly authorization: string | undefined;
+  readonly geminiApiKey: string | undefined;
+  readonly body: string;
+}
+
+export interface ProviderStub {
+  readonly openAiBaseUrl: string;
+  readonly seedreamBaseUrl: string;
+  readonly geminiBaseUrl: string;
+  readonly generatedData: string;
+  readonly requests: ReadonlyArray<ProviderStubRequest>;
+  close(): Promise<void>;
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  let body = "";
+  for await (const chunk of request) body += chunk.toString();
+  return body;
+}
+
+function sendJson(
+  response: ServerResponse<IncomingMessage>,
+  body: unknown,
+): void {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+export async function startProviderStub(): Promise<ProviderStub> {
+  const requests: ProviderStubRequest[] = [];
+  const server = createServer(async (request, response) => {
+    const path = new URL(request.url ?? "/", "http://stub.local").pathname;
+    const body = await readBody(request);
+    requests.push({
+      method: request.method ?? "",
+      path,
+      authorization: request.headers.authorization,
+      geminiApiKey:
+        typeof request.headers["x-goog-api-key"] === "string"
+          ? request.headers["x-goog-api-key"]
+          : undefined,
+      body,
+    });
+
+    if (
+      path === "/openai/v1/images/generations" ||
+      path === "/openai/v1/images/edits"
+    ) {
+      sendJson(response, { data: [{ b64_json: generatedData }] });
+      return;
+    }
+    if (path === "/ark/api/v3/images/generations") {
+      const payload = JSON.parse(body) as {
+        readonly sequential_image_generation_options?: {
+          readonly max_images?: number;
+        };
+      };
+      const count =
+        payload.sequential_image_generation_options?.max_images ?? 1;
+      sendJson(response, {
+        data: Array.from({ length: count }, () => ({
+          b64_json: generatedData,
+        })),
+      });
+      return;
+    }
+    if (path === "/gemini/v1beta/interactions") {
+      sendJson(response, {
+        status: "completed",
+        steps: [
+          {
+            type: "model_output",
+            content: [
+              {
+                type: "image",
+                mime_type: "image/png",
+                data: generatedData,
+              },
+            ],
+          },
+        ],
+      });
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Provider stub did not bind a TCP port.");
+  }
+  const origin = `http://127.0.0.1:${String(address.port)}`;
+  return {
+    openAiBaseUrl: `${origin}/openai/v1`,
+    seedreamBaseUrl: `${origin}/ark/api/v3`,
+    geminiBaseUrl: `${origin}/gemini/v1beta`,
+    generatedData,
+    requests,
+    async close() {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}

--- a/examples/image-engine/tsconfig.json
+++ b/examples/image-engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/example-image.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/cli" },
+    { "path": "../../packages/mcp" }
+  ]
+}

--- a/examples/image-engine/tsconfig.test.json
+++ b/examples/image-engine/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "./examples/composed-engine" },
     { "path": "./examples/crawl-engine" },
     { "path": "./examples/hello-engine" },
+    { "path": "./examples/image-engine" },
     { "path": "./examples/spec-engine" },
     { "path": "./examples/support-engine" },
     { "path": "./examples/support-harness" }


### PR DESCRIPTION
## Summary

- add a multi-provider image engine example with outcome-oriented capabilities for editing, text-focused rendering, campaign series, and reference composition
- integrate GPT Image 2, Seedream 5.0 Lite, and Nano Banana 2 behind replaceable domain ports
- expose the same engine through direct, CLI, MCP stdio, and authenticated stateless MCP HTTP entrypoints
- document provider selection, configuration, limits, and probabilistic quality boundaries

## Why

Demonstrates how a custom AI Engine can select image providers by domain use case without adding a framework-level model router or bypassing `engine.invoke`.

## Impact

Adds a private example workspace only; no breaking changes to framework public packages. Provider credentials are required only when running the configured example.

## Validation

- `yarn workspace @ai-engine/example-image test` (25 tests)
- `yarn workspace @ai-engine/example-image typecheck`
- `yarn run check` (71 test files, 1,329 tests; typecheck, lint, format, test, build)
