### PR TITLE
Add Cursor agent routing engine example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Then follow the [getting-started guide](./docs/getting-started.md) or inspect:
 - [`crawl-engine`](./examples/crawl-engine/) for an outbound provider
   integration, crawling the web with Firecrawl behind a port, with target rules
   that run before authorization;
+- [`cursor-agent-routing-engine`](./examples/cursor-agent-routing-engine/) for
+  deterministic Cursor subagent and model selection by development use case;
 - [`spec-engine`](./examples/spec-engine/) for a spec-driven development
   workflow whose ordering, state, and per-step authorization live in the domain
   rather than in a workflow engine.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ conflicts with a contract or ADR, the normative source takes precedence.
 - [`support-engine`: dependency injection and authorization example](../examples/support-engine/)
 - [`support-harness`: private MCP consumer](../examples/support-harness/)
 - [`crawl-engine`: outbound provider integration with Firecrawl](../examples/crawl-engine/)
+- [`cursor-agent-routing-engine`: versioned Cursor subagent and model routing policy](../examples/cursor-agent-routing-engine/)
 - [`spec-engine`: spec-driven development workflow as domain rules](../examples/spec-engine/)
 - [`community-capabilities`: atomic and library capability publication fixture](../examples/community-capabilities/)
 - [`composed-engine`: local, atomic, and library capability composition](../examples/composed-engine/)

--- a/examples/cursor-agent-routing-engine/README.md
+++ b/examples/cursor-agent-routing-engine/README.md
@@ -1,0 +1,156 @@
+# Cursor Agent Routing Engine
+
+This example publishes `developer-work.route-cursor-task`, a deterministic
+capability that selects a Cursor custom subagent and model for seven software
+development use cases. The same route is available through direct invocation,
+the CLI, MCP stdio, and authenticated stateless MCP HTTP.
+
+The model catalog is a versioned snapshot dated **2026-07-28**. Model names and
+availability change independently of this repository and can vary by plan,
+region, organization allowlist, and Cursor release.
+
+## Routing catalog
+
+| Use case | Custom agent | Primary Cursor model | Fallback | Read-only |
+| --- | --- | --- | --- | --- |
+| `plan` | `planner` | Claude Opus 5 | GPT-5.6 Sol | yes |
+| `review` | `reviewer` | Claude Fable 5 | Claude Opus 5 | yes |
+| `complex-development` | `complex-builder` | Grok 4.5 | GPT-5.6 Sol | no |
+| `debug` | `debugger` | GPT-5.6 Sol | Claude Fable 5 | no |
+| `documentation` | `documenter` | Gemini 3.6 Flash | Composer 2.5 | no |
+| `prototype-development` | `prototyper` | Composer 2.5 Fast | GPT-5.6 Luna | no |
+| `simple-development` | `simple-builder` | GPT-5.6 Luna | Composer 2.5 Fast | no |
+
+The choices use Cursor's current guidance and published evidence:
+
+- [Cursor Router](https://cursor.com/blog/router) sends simple work to
+  price-efficient models and long-horizon work to frontier reasoning models.
+- [Grok 4.5](https://cursor.com/grok) is positioned for long-running agentic
+  work, migrations, multi-service changes, and sustained tool use.
+- [Composer 2.5](https://cursor.com/composer) is Cursor's price-efficient coding
+  model for everyday planning, development, fast interaction, and high-volume
+  work.
+- [CursorBench](https://cursor.com/cursorbench) provides current comparative
+  evidence for code editing, debugging, planning, review, and terminal work.
+- Cursor's [model picker and CLI model list](https://cursor.com/docs/cli/reference/parameters)
+  remain the authoritative source for the selectors enabled for an account.
+
+These assignments are explicit example policy, not a claim that one model is
+universally best. The dated catalog makes policy changes reviewable instead of
+silently changing routing behavior.
+
+## Architecture
+
+```text
+Cursor parent agent
+       |
+       | MCP tool call with one useCase
+       v
+engine.invoke("developer-work.route-cursor-task")
+       |
+       v
+versioned domain routing table
+       |
+       +--> custom agent name and read-only boundary
+       +--> primary model selector
+       +--> fallback model selector
+       +--> self-contained delegation instructions
+```
+
+The framework core does not contain a model router, harness, loop, or Cursor
+dependency. The model-selection policy belongs to this custom engine, and every
+adapter executes the capability through `engine.invoke`.
+
+The engine does not switch Cursor's active model by itself. The supplied custom
+subagent definitions pin the returned selector in their `model` frontmatter;
+the supplied rule tells the parent agent to consult the engine and invoke the
+returned subagent. Cursor still enforces account and organization availability.
+
+## Build and verify
+
+From the repository root:
+
+```sh
+yarn workspace @ai-engine/example-cursor-agent-routing build
+yarn workspace @ai-engine/example-cursor-agent-routing test
+```
+
+Before using the templates, authenticate the Cursor CLI and inspect the models
+available to the current account:
+
+```sh
+agent models
+```
+
+If a selector differs, update both `src/domain/routing.ts` and the matching file
+under `cursor-config/agents/`. The configuration test prevents those two sources
+from drifting.
+
+## Direct and CLI invocation
+
+```sh
+node examples/cursor-agent-routing-engine/dist/direct.js debug
+
+node examples/cursor-agent-routing-engine/dist/cli.js list
+node examples/cursor-agent-routing-engine/dist/cli.js describe developer-work.route-cursor-task
+node examples/cursor-agent-routing-engine/dist/cli.js run developer-work.route-cursor-task \
+  --input '{"useCase":"complex-development"}'
+```
+
+An unsupported use case fails during input validation with `INPUT_INVALID`.
+There is no external request, retry, mutable state, or unbounded work in the
+capability.
+
+## Install the Cursor project configuration
+
+Cursor discovers project subagents only from `<workspace-root>/.cursor/agents/`.
+To use this example from the repository root:
+
+1. Build the example.
+2. Copy the seven files from `cursor-config/agents/` into
+   `.cursor/agents/` at the workspace root.
+3. Copy `cursor-config/rules/model-routing.mdc` into `.cursor/rules/`.
+4. Merge the `cursor-agent-routing` server from `cursor-config/mcp.json` into
+   the workspace `.cursor/mcp.json`; preserve any existing MCP servers.
+5. Reload Cursor and verify the tool with
+   `agent mcp list-tools cursor-agent-routing`.
+
+The rule classifies work into one of the seven use cases, calls
+`developer-work.route-cursor-task`, and delegates to the custom agent named by
+`agent.invocation`. Custom subagent configuration follows Cursor's
+[Subagents documentation](https://cursor.com/docs/subagents). Cursor also
+supports general model family names for subagents, but this example intentionally
+pins a dated model to make routing reproducible.
+
+## MCP stdio and HTTP
+
+The project configuration starts the stdio adapter directly:
+
+```sh
+node examples/cursor-agent-routing-engine/dist/mcp-stdio.js
+```
+
+For an authenticated loopback HTTP demonstration:
+
+```sh
+CURSOR_ROUTING_ENGINE_BEARER_TOKEN=development-only-token \
+  node examples/cursor-agent-routing-engine/dist/mcp-http.js
+```
+
+The literal bearer-token comparison is only a deterministic authentication-hook
+example. It does not issue, rotate, persist, or validate production credentials.
+
+## Updating the catalog
+
+Treat a model refresh as a versioned contract change:
+
+1. Run `agent models` for the target Cursor account and review Cursor's official
+   model guidance and current benchmark evidence.
+2. Update the dated routes and fallbacks in `src/domain/routing.ts`.
+3. Update the matching `model:` values in `cursor-config/agents/`.
+4. Change `catalogDate`, extend the routing tests, and rerun the full validation
+   suite.
+
+Do not silently map an unavailable selector to another model inside the engine.
+The explicit fallback makes that operational decision visible to the parent
+agent and the user.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/complex-builder.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/complex-builder.md
@@ -1,0 +1,11 @@
+---
+name: complex-builder
+description: Use for complex multi-file development, migrations, and long-horizon implementation that requires sustained verification.
+model: grok-4.5
+readonly: false
+---
+
+Own the complete assigned implementation. Read repository instructions and
+contracts first, preserve architectural boundaries, work test-first when behavior
+changes, and keep changes scoped to the request. Run focused validation while
+iterating and finish with the repository's canonical validation commands.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/debugger.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/debugger.md
@@ -1,0 +1,11 @@
+---
+name: debugger
+description: Use for reproducing failures, isolating root causes, and implementing evidence-backed regression fixes.
+model: gpt-5.6-sol
+readonly: false
+---
+
+Reproduce the reported failure before changing code. Trace the failure to its
+root cause, add the smallest regression test that fails for that cause, implement
+the narrow repair, and rerun focused and affected suites. Report evidence that
+separates the observed cause from competing hypotheses.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/documenter.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/documenter.md
@@ -1,0 +1,11 @@
+---
+name: documenter
+description: Use for API documentation, guides, examples, ADR updates, and other source-grounded documentation work.
+model: gemini-3.6-flash
+readonly: false
+---
+
+Read the authoritative implementation and contracts before writing. Update only
+the documentation in scope, use the repository's terminology, keep commands and
+examples executable, and avoid claims that cannot be verified from a primary
+source or the codebase.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/planner.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/planner.md
@@ -1,0 +1,11 @@
+---
+name: planner
+description: Use for implementation planning, dependency analysis, and acceptance-criteria design before code changes.
+model: claude-opus-5
+readonly: true
+---
+
+Create an implementation plan from repository evidence. Resolve the requested
+scope, identify applicable contracts and architectural boundaries, map every
+acceptance criterion to validation evidence, and order dependent work. Do not
+edit files. Return assumptions, risks, and exact validation commands.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/prototyper.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/prototyper.md
@@ -1,0 +1,11 @@
+---
+name: prototyper
+description: Use for runnable spikes and prototypes that test one product or technical assumption quickly.
+model: composer-2.5-fast
+readonly: false
+---
+
+Build the smallest runnable prototype that tests the central assumption. Keep
+the feedback loop short, avoid production abstractions, label deliberate
+shortcuts, add only the validation needed to prove the spike, and record what
+must change before the code can be treated as production-ready.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/reviewer.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/reviewer.md
@@ -1,0 +1,11 @@
+---
+name: reviewer
+description: Use for read-only review of diffs, contracts, security boundaries, and regression risks.
+model: claude-fable-5
+readonly: true
+---
+
+Review the requested change without editing files. Read the relevant contracts,
+implementation, tests, and diff. Report actionable findings first, ordered by
+severity, with file and line evidence. Distinguish defects from suggestions and
+state the validation gaps that remain.

--- a/examples/cursor-agent-routing-engine/cursor-config/agents/simple-builder.md
+++ b/examples/cursor-agent-routing-engine/cursor-config/agents/simple-builder.md
@@ -1,0 +1,10 @@
+---
+name: simple-builder
+description: Use for narrow, well-specified development tasks with limited files and obvious validation.
+model: gpt-5.6-luna
+readonly: false
+---
+
+Make the narrow requested change. Follow existing local patterns, avoid adjacent
+refactors and new abstractions, preserve unrelated work, and run the smallest
+focused validation command that proves the behavior.

--- a/examples/cursor-agent-routing-engine/cursor-config/mcp.json
+++ b/examples/cursor-agent-routing-engine/cursor-config/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "cursor-agent-routing": {
+      "command": "node",
+      "args": ["examples/cursor-agent-routing-engine/dist/mcp-stdio.js"]
+    }
+  }
+}

--- a/examples/cursor-agent-routing-engine/cursor-config/rules/model-routing.mdc
+++ b/examples/cursor-agent-routing-engine/cursor-config/rules/model-routing.mdc
@@ -1,0 +1,23 @@
+---
+description: Route development work through the versioned Cursor agent routing engine before delegating to a custom subagent.
+alwaysApply: true
+---
+
+Before delegating development work, classify it as exactly one of these use
+cases:
+
+- `plan`
+- `review`
+- `complex-development`
+- `debug`
+- `documentation`
+- `prototype-development`
+- `simple-development`
+
+Call the MCP tool `developer-work.route-cursor-task` with that `useCase`. Invoke
+the custom subagent named by `agent.invocation` and give it a self-contained
+task. Keep read-only agents read-only. Use `fallbackModel` only when the primary
+model is unavailable for the current account, region, or organization policy.
+
+The routing result selects an agent and model; it does not authorize broader
+scope, destructive actions, or skipped repository validation.

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ai-engine/example-cursor-agent-routing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "typecheck": "tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false --noEmit",
+    "test": "vitest run test",
+    "direct": "node dist/direct.js",
+    "cli": "node dist/cli.js",
+    "mcp:stdio": "node dist/mcp-stdio.js",
+    "mcp:http": "node dist/mcp-http.js"
+  },
+  "dependencies": {
+    "@ai-engine/cli": "0.1.0",
+    "@ai-engine/core": "0.1.0",
+    "@ai-engine/mcp": "0.1.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  }
+}

--- a/examples/cursor-agent-routing-engine/src/capabilities/route-cursor-task.ts
+++ b/examples/cursor-agent-routing-engine/src/capabilities/route-cursor-task.ts
@@ -1,0 +1,41 @@
+import { defineCapability } from "@ai-engine/core";
+import { z } from "zod";
+
+import { cursorUseCases, routeCursorTask } from "../domain/routing.js";
+
+const modelSelection = z.object({
+  displayName: z.string().min(1),
+  selector: z.string().min(1),
+});
+
+export function createRouteCursorTask() {
+  return defineCapability({
+    title: "Route Cursor development work",
+    description:
+      "Select a versioned Cursor subagent and model configuration for a development use case.",
+    input: z.object({ useCase: z.enum(cursorUseCases) }),
+    output: z.object({
+      catalogDate: z.literal("2026-07-28"),
+      useCase: z.enum(cursorUseCases),
+      agent: z.object({
+        name: z.string().min(1),
+        invocation: z.string().startsWith("/"),
+        readOnly: z.boolean(),
+      }),
+      primaryModel: modelSelection,
+      fallbackModel: modelSelection,
+      rationale: z.string().min(1),
+      instructions: z.string().min(1),
+    }),
+    access: "public",
+    annotations: {
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+      openWorld: false,
+    },
+    async run({ input }) {
+      return routeCursorTask(input.useCase);
+    },
+  });
+}

--- a/examples/cursor-agent-routing-engine/src/cli.ts
+++ b/examples/cursor-agent-routing-engine/src/cli.ts
@@ -1,0 +1,17 @@
+import { pathToFileURL } from "node:url";
+
+import { runCli } from "@ai-engine/cli";
+
+import { engine } from "./engine.js";
+
+export async function main(): Promise<number> {
+  return runCli(engine, { principal: null });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  process.exitCode = await main();
+}

--- a/examples/cursor-agent-routing-engine/src/direct.ts
+++ b/examples/cursor-agent-routing-engine/src/direct.ts
@@ -1,0 +1,22 @@
+import { pathToFileURL } from "node:url";
+
+import type { CursorUseCase } from "./domain/routing.js";
+import { engine } from "./engine.js";
+
+export async function main(args = process.argv.slice(2)): Promise<void> {
+  const useCase = (args[0] ?? "plan") as CursorUseCase;
+  const result = await engine.invoke(
+    "developer-work.route-cursor-task",
+    { useCase },
+    { source: "direct" },
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main();
+}

--- a/examples/cursor-agent-routing-engine/src/domain/routing.ts
+++ b/examples/cursor-agent-routing-engine/src/domain/routing.ts
@@ -1,0 +1,169 @@
+export const cursorUseCases = [
+  "plan",
+  "review",
+  "complex-development",
+  "debug",
+  "documentation",
+  "prototype-development",
+  "simple-development",
+] as const;
+
+export type CursorUseCase = (typeof cursorUseCases)[number];
+
+export interface CursorModelSelection {
+  readonly displayName: string;
+  readonly selector: string;
+}
+
+export interface CursorAgentRoute {
+  readonly catalogDate: "2026-07-28";
+  readonly useCase: CursorUseCase;
+  readonly agent: {
+    readonly name: string;
+    readonly invocation: string;
+    readonly readOnly: boolean;
+  };
+  readonly primaryModel: CursorModelSelection;
+  readonly fallbackModel: CursorModelSelection;
+  readonly rationale: string;
+  readonly instructions: string;
+}
+
+type RouteDefinition = Omit<CursorAgentRoute, "catalogDate" | "useCase">;
+
+const routes = {
+  plan: {
+    agent: { name: "planner", invocation: "/planner", readOnly: true },
+    primaryModel: {
+      displayName: "Claude Opus 5",
+      selector: "claude-opus-5",
+    },
+    fallbackModel: {
+      displayName: "GPT-5.6 Sol",
+      selector: "gpt-5.6-sol",
+    },
+    rationale:
+      "Use the newest high-context Opus model for dependency analysis, ambiguity resolution, and high-consequence planning.",
+    instructions:
+      "Inspect requirements and constraints, produce a dependency-aware plan with validation steps, and do not edit files.",
+  },
+  review: {
+    agent: { name: "reviewer", invocation: "/reviewer", readOnly: true },
+    primaryModel: {
+      displayName: "Claude Fable 5",
+      selector: "claude-fable-5",
+    },
+    fallbackModel: {
+      displayName: "Claude Opus 5",
+      selector: "claude-opus-5",
+    },
+    rationale:
+      "Use the strongest current CursorBench model to trace behavior across the diff and surface subtle correctness risks.",
+    instructions:
+      "Review without editing, report actionable findings first, and cite each finding with file and line evidence.",
+  },
+  "complex-development": {
+    agent: {
+      name: "complex-builder",
+      invocation: "/complex-builder",
+      readOnly: false,
+    },
+    primaryModel: {
+      displayName: "Grok 4.5",
+      selector: "grok-4.5",
+    },
+    fallbackModel: {
+      displayName: "GPT-5.6 Sol",
+      selector: "gpt-5.6-sol",
+    },
+    rationale:
+      "Use Cursor's long-horizon model for multi-file work that requires sustained tool use, recovery, and verification.",
+    instructions:
+      "Own the complete multi-file implementation, preserve architectural boundaries, and keep iterating until focused and full validation pass.",
+  },
+  debug: {
+    agent: { name: "debugger", invocation: "/debugger", readOnly: false },
+    primaryModel: {
+      displayName: "GPT-5.6 Sol",
+      selector: "gpt-5.6-sol",
+    },
+    fallbackModel: {
+      displayName: "Claude Fable 5",
+      selector: "claude-fable-5",
+    },
+    rationale:
+      "Use a frontier reasoning model with strong agentic coding performance for diagnosis, terminal work, and verified repairs.",
+    instructions:
+      "Reproduce the failure, isolate the root cause, add a regression test, implement the smallest repair, and rerun the relevant suite.",
+  },
+  documentation: {
+    agent: {
+      name: "documenter",
+      invocation: "/documenter",
+      readOnly: false,
+    },
+    primaryModel: {
+      displayName: "Gemini 3.6 Flash",
+      selector: "gemini-3.6-flash",
+    },
+    fallbackModel: {
+      displayName: "Composer 2.5",
+      selector: "composer-2.5",
+    },
+    rationale:
+      "Use a careful, broad-context model to reconcile implementation, contracts, examples, and reader-facing explanations.",
+    instructions:
+      "Read the authoritative code and contracts, update only documentation, keep examples executable, and avoid unsupported claims.",
+  },
+  "prototype-development": {
+    agent: {
+      name: "prototyper",
+      invocation: "/prototyper",
+      readOnly: false,
+    },
+    primaryModel: {
+      displayName: "Composer 2.5 Fast",
+      selector: "composer-2.5-fast",
+    },
+    fallbackModel: {
+      displayName: "GPT-5.6 Luna",
+      selector: "gpt-5.6-luna",
+    },
+    rationale:
+      "Use Cursor's fast agentic coding model for short feedback loops and inexpensive exploratory implementation.",
+    instructions:
+      "Build the smallest runnable spike that tests the central assumption, label shortcuts explicitly, and record what must change before production.",
+  },
+  "simple-development": {
+    agent: {
+      name: "simple-builder",
+      invocation: "/simple-builder",
+      readOnly: false,
+    },
+    primaryModel: {
+      displayName: "GPT-5.6 Luna",
+      selector: "gpt-5.6-luna",
+    },
+    fallbackModel: {
+      displayName: "Composer 2.5 Fast",
+      selector: "composer-2.5-fast",
+    },
+    rationale:
+      "Use the lightweight GPT-5.6 tier for narrow, well-specified changes where latency and cost matter most.",
+    instructions:
+      "Make the narrow requested change, avoid adjacent refactors, and run the smallest validation command that proves it.",
+  },
+} as const satisfies Readonly<Record<CursorUseCase, RouteDefinition>>;
+
+export function routeCursorTask(useCase: CursorUseCase): CursorAgentRoute {
+  const route = routes[useCase];
+  return {
+    catalogDate: "2026-07-28",
+    useCase,
+    agent: { ...route.agent },
+    primaryModel: { ...route.primaryModel },
+    fallbackModel: { ...route.fallbackModel },
+    rationale: route.rationale,
+    instructions: route.instructions,
+  };
+}

--- a/examples/cursor-agent-routing-engine/src/engine.ts
+++ b/examples/cursor-agent-routing-engine/src/engine.ts
@@ -1,0 +1,15 @@
+import { createEngine } from "@ai-engine/core";
+
+import { createRouteCursorTask } from "./capabilities/route-cursor-task.js";
+
+export function createCursorAgentRoutingEngine() {
+  return createEngine({
+    name: "cursor-agent-routing-engine",
+    version: "0.1.0",
+    capabilities: {
+      "developer-work.route-cursor-task": createRouteCursorTask(),
+    },
+  });
+}
+
+export const engine = createCursorAgentRoutingEngine();

--- a/examples/cursor-agent-routing-engine/src/mcp-http.ts
+++ b/examples/cursor-agent-routing-engine/src/mcp-http.ts
@@ -1,0 +1,62 @@
+import { pathToFileURL } from "node:url";
+
+import { type McpHttpServerHandle, serveMcpHttp } from "@ai-engine/mcp";
+
+import { engine } from "./engine.js";
+
+export interface CursorRoutingMcpHttpOptions {
+  readonly expectedBearerToken: string;
+  readonly host?: string;
+  readonly port?: number;
+}
+
+export async function startCursorRoutingMcpHttp(
+  options: CursorRoutingMcpHttpOptions,
+): Promise<McpHttpServerHandle> {
+  return serveMcpHttp(engine, {
+    ...(options.host === undefined ? {} : { host: options.host }),
+    ...(options.port === undefined ? {} : { port: options.port }),
+    auth: {
+      mode: "required",
+      authenticate(request) {
+        return request.headers.get("authorization") ===
+          `Bearer ${options.expectedBearerToken}`
+          ? { id: "cursor-routing:http-client" }
+          : null;
+      },
+    },
+  });
+}
+
+export async function main(): Promise<McpHttpServerHandle> {
+  const expectedBearerToken = process.env.CURSOR_ROUTING_ENGINE_BEARER_TOKEN;
+  if (expectedBearerToken === undefined || expectedBearerToken === "") {
+    throw new Error("CURSOR_ROUTING_ENGINE_BEARER_TOKEN is required.");
+  }
+  const configuredPort = process.env.PORT;
+  const port = configuredPort === undefined ? 3000 : Number(configuredPort);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error("PORT must be an integer between 0 and 65535.");
+  }
+  return startCursorRoutingMcpHttp({ expectedBearerToken, port });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main()
+    .then((server) => {
+      const address = server.address();
+      process.stderr.write(
+        `Cursor agent routing MCP HTTP adapter listening on host ${address.host}, port ${address.port}\n`,
+      );
+    })
+    .catch(() => {
+      process.stderr.write(
+        "Cursor agent routing MCP HTTP adapter failed to start.\n",
+      );
+      process.exitCode = 1;
+    });
+}

--- a/examples/cursor-agent-routing-engine/src/mcp-stdio.ts
+++ b/examples/cursor-agent-routing-engine/src/mcp-stdio.ts
@@ -1,0 +1,20 @@
+import { pathToFileURL } from "node:url";
+
+import { serveMcpStdio } from "@ai-engine/mcp";
+
+import { engine } from "./engine.js";
+
+export async function main(): Promise<void> {
+  await serveMcpStdio(engine, { principal: null });
+}
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(entrypoint).href
+) {
+  await main().catch(() => {
+    process.stderr.write("Cursor agent routing MCP stdio adapter failed.\n");
+    process.exitCode = 1;
+  });
+}

--- a/examples/cursor-agent-routing-engine/test/cursor-config.test.ts
+++ b/examples/cursor-agent-routing-engine/test/cursor-config.test.ts
@@ -1,0 +1,59 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { cursorUseCases } from "../src/domain/routing.js";
+import { createCursorAgentRoutingEngine } from "../src/engine.js";
+
+const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
+
+describe("the Cursor project configuration", () => {
+  it.each(cursorUseCases)(
+    "pins the %s route to its recommended custom subagent model",
+    async (useCase) => {
+      const engine = createCursorAgentRoutingEngine();
+      const route = await engine.invoke(
+        "developer-work.route-cursor-task",
+        { useCase },
+        { source: "direct" },
+      );
+
+      const definition = await readFile(
+        `${exampleRoot}/cursor-config/agents/${route.agent.name}.md`,
+        "utf8",
+      );
+
+      expect(definition).toContain(`name: ${route.agent.name}`);
+      expect(definition).toContain(`model: ${route.primaryModel.selector}`);
+      expect(definition).toContain(`readonly: ${String(route.agent.readOnly)}`);
+    },
+  );
+
+  it("teaches the parent agent to consult the engine before delegation", async () => {
+    const rule = await readFile(
+      `${exampleRoot}/cursor-config/rules/model-routing.mdc`,
+      "utf8",
+    );
+
+    expect(rule).toContain("developer-work.route-cursor-task");
+    for (const useCase of cursorUseCases) {
+      expect(rule).toContain(`\`${useCase}\``);
+    }
+  });
+
+  it("registers the stdio engine without duplicating routing rules", async () => {
+    const configuration = JSON.parse(
+      await readFile(`${exampleRoot}/cursor-config/mcp.json`, "utf8"),
+    ) as {
+      readonly mcpServers: Readonly<
+        Record<string, { readonly command: string; readonly args: string[] }>
+      >;
+    };
+
+    expect(configuration.mcpServers["cursor-agent-routing"]).toEqual({
+      command: "node",
+      args: ["examples/cursor-agent-routing-engine/dist/mcp-stdio.js"],
+    });
+  });
+});

--- a/examples/cursor-agent-routing-engine/test/entrypoints.test.ts
+++ b/examples/cursor-agent-routing-engine/test/entrypoints.test.ts
@@ -1,0 +1,191 @@
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
+
+beforeAll(() => {
+  const build = spawnSync(
+    process.execPath,
+    ["../../node_modules/typescript/bin/tsc", "-b", "--pretty", "false"],
+    { cwd: exampleRoot, encoding: "utf8" },
+  );
+  if (build.status !== 0) {
+    throw new Error(`Example build failed:\n${build.stdout}${build.stderr}`);
+  }
+});
+
+function run(entrypoint: string, args: readonly string[] = []) {
+  return spawnSync(process.execPath, [`dist/${entrypoint}.js`, ...args], {
+    cwd: exampleRoot,
+    encoding: "utf8",
+  });
+}
+
+async function stopProcess(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) return;
+  const exited = once(child, "exit");
+  child.kill();
+  await exited;
+}
+
+function structuredContent(result: unknown): Record<string, unknown> {
+  const content = (result as { readonly structuredContent?: unknown })
+    .structuredContent;
+  if (typeof content !== "object" || content === null) {
+    throw new Error("Expected MCP structured content.");
+  }
+  return content as Record<string, unknown>;
+}
+
+describe("Cursor agent routing engine entrypoints", () => {
+  it("routes through the direct entrypoint", () => {
+    const result = run("direct", ["debug"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      useCase: "debug",
+      agent: { name: "debugger" },
+      primaryModel: { selector: "gpt-5.6-sol" },
+    });
+  });
+
+  it("routes the same capability through the CLI", () => {
+    const result = run("cli", [
+      "run",
+      "developer-work.route-cursor-task",
+      "--input",
+      '{"useCase":"documentation"}',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      useCase: "documentation",
+      agent: { name: "documenter" },
+      primaryModel: { selector: "gemini-3.6-flash" },
+    });
+  });
+
+  it("publishes the same route over MCP stdio", async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["dist/mcp-stdio.js"],
+      cwd: exampleRoot,
+      stderr: "pipe",
+    });
+    let stderr = "";
+    transport.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    const client = new Client(
+      { name: "cursor-routing-stdio-test", version: "0.0.0-test" },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: "developer-work.route-cursor-task" }],
+      });
+
+      const result = await client.callTool({
+        name: "developer-work.route-cursor-task",
+        arguments: { useCase: "complex-development" },
+      });
+      expect(structuredContent(result)).toMatchObject({
+        useCase: "complex-development",
+        agent: { name: "complex-builder" },
+        primaryModel: { selector: "grok-4.5" },
+      });
+    } finally {
+      await client.close();
+    }
+
+    expect(stderr).toBe("");
+  });
+
+  it("requires HTTP authentication before publishing the same route", async () => {
+    const token = "test-only-cursor-routing-token";
+    const child = spawn(process.execPath, ["dist/mcp-http.js"], {
+      cwd: exampleRoot,
+      env: {
+        ...process.env,
+        CURSOR_ROUTING_ENGINE_BEARER_TOKEN: token,
+        PORT: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    let client: Client | undefined;
+
+    try {
+      const port = await vi.waitFor(
+        () => {
+          const match = stderr.match(/host 127\.0\.0\.1, port (\d+)/u);
+          expect(match?.[1]).toBeDefined();
+          return Number(match?.[1]);
+        },
+        { timeout: 5_000 },
+      );
+      const url = new URL(`http://127.0.0.1:${String(port)}/mcp`);
+
+      const unauthenticated = await fetch(url, {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "auth-boundary",
+          method: "tools/call",
+          params: {
+            name: "developer-work.route-cursor-task",
+            arguments: { useCase: "simple-development" },
+          },
+        }),
+      });
+      expect(unauthenticated.status).toBe(401);
+      await unauthenticated.arrayBuffer();
+
+      const transport = new StreamableHTTPClientTransport(url, {
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+      });
+      client = new Client(
+        { name: "cursor-routing-http-test", version: "0.0.0-test" },
+        { capabilities: {} },
+      );
+      await client.connect(transport as unknown as Transport);
+
+      const result = await client.callTool({
+        name: "developer-work.route-cursor-task",
+        arguments: { useCase: "simple-development" },
+      });
+      expect(structuredContent(result)).toMatchObject({
+        useCase: "simple-development",
+        agent: { name: "simple-builder" },
+        primaryModel: { selector: "gpt-5.6-luna" },
+      });
+    } finally {
+      await client?.close();
+      await stopProcess(child);
+    }
+
+    expect(stdout).toBe("");
+  });
+});

--- a/examples/cursor-agent-routing-engine/test/routing-engine.test.ts
+++ b/examples/cursor-agent-routing-engine/test/routing-engine.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { createCursorAgentRoutingEngine } from "../src/engine.js";
+
+const expectedRoutes = [
+  ["plan", "planner", "claude-opus-5", true],
+  ["review", "reviewer", "claude-fable-5", true],
+  ["complex-development", "complex-builder", "grok-4.5", false],
+  ["debug", "debugger", "gpt-5.6-sol", false],
+  ["documentation", "documenter", "gemini-3.6-flash", false],
+  ["prototype-development", "prototyper", "composer-2.5-fast", false],
+  ["simple-development", "simple-builder", "gpt-5.6-luna", false],
+] as const;
+
+describe("the Cursor agent routing engine example", () => {
+  it.each(expectedRoutes)(
+    "routes %s to the %s agent on %s",
+    async (useCase, agentName, modelSelector, readOnly) => {
+      const engine = createCursorAgentRoutingEngine();
+
+      const result = await engine.invoke(
+        "developer-work.route-cursor-task",
+        { useCase },
+        { source: "direct" },
+      );
+
+      expect(result).toMatchObject({
+        catalogDate: "2026-07-28",
+        useCase,
+        agent: { name: agentName, readOnly },
+        primaryModel: { selector: modelSelector },
+      });
+      expect(result.primaryModel.displayName).not.toBe("");
+      expect(result.fallbackModel.selector).not.toBe(modelSelector);
+      expect(result.rationale).not.toBe("");
+    },
+  );
+
+  it("rejects a use case outside the routing contract", async () => {
+    const engine = createCursorAgentRoutingEngine();
+
+    await expect(
+      engine.invoke("developer-work.route-cursor-task", {
+        useCase: "write-sql" as never,
+      }),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+});

--- a/examples/cursor-agent-routing-engine/tsconfig.json
+++ b/examples/cursor-agent-routing-engine/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/example-cursor-agent-routing.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/cli" },
+    { "path": "../../packages/mcp" }
+  ]
+}

--- a/examples/cursor-agent-routing-engine/tsconfig.test.json
+++ b/examples/cursor-agent-routing-engine/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "./examples/community-capabilities" },
     { "path": "./examples/composed-engine" },
     { "path": "./examples/crawl-engine" },
+    { "path": "./examples/cursor-agent-routing-engine" },
     { "path": "./examples/hello-engine" },
     { "path": "./examples/spec-engine" },
     { "path": "./examples/support-engine" },


### PR DESCRIPTION
## Summary

- add `developer-work.route-cursor-task`, a deterministic capability that maps seven development use cases to current Cursor custom agents and model selectors
- expose the same route through direct, CLI, MCP stdio, and authenticated MCP HTTP entrypoints
- add seven Cursor custom-agent templates, an orchestration rule, MCP project configuration, and dated model-catalog documentation
- register the example in the workspace and repository documentation

## Why

Teams may want an explicit, reviewable routing policy when Cursor Auto Router is unavailable or when model selection must be deterministic and auditable. The catalog is dated 2026-07-28 and includes explicit fallbacks for plan, region, and policy differences.

## Impact

Consumers can run the example directly or install the provided `.cursor` templates. This is an additive example and does not change the public contracts of `@ai-engine/core`, the CLI, or MCP adapters.

## Validation

- `yarn workspace @ai-engine/example-cursor-agent-routing test` — 21 tests passed
- `yarn run check` — typecheck, lint, formatting, 1,325 tests, and build passed
