### PR TITLE
feat: add create-invokta-engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added `create-invokta-engine`, a non-interactive standalone engine creator with
+  deterministic, non-overwriting scaffolding and npm, pnpm, and Yarn installation.
+
 ## [0.1.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ and delivery adapters:
   local MCP client targets without changing their configuration;
 - `@invokta/deploy` scaffolds and packages stateless HTTP engines and probes
   deployed endpoints.
+- `create-invokta-engine` creates a standalone starter with direct, CLI, and MCP
+  stdio entry points.
 
 Invokta does not provide identity, model routing, an agent harness, a
 workflow engine, or a production observability platform. Custom engines inject
@@ -103,6 +105,16 @@ their own model, data, tool, authentication, and authorization integrations.
 ## Start here
 
 Requirements: Node.js 22.20.0 or later and Yarn 1.22.22.
+
+Create a standalone engine:
+
+```sh
+npm create invokta-engine@latest my-engine
+cd my-engine
+npm run check
+```
+
+To work on Invokta itself:
 
 ```sh
 yarn install --frozen-lockfile

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -95,6 +95,7 @@ export default defineConfig({
             { slug: "reference/tooling" },
             { slug: "reference/installer" },
             { slug: "reference/deploy" },
+            { slug: "reference/create-invokta-engine" },
             { slug: "reference/errors" },
           ],
         },

--- a/apps/docs/src/content/docs/concepts/scope-and-limits.mdx
+++ b/apps/docs/src/content/docs/concepts/scope-and-limits.mdx
@@ -22,7 +22,7 @@ host owns identity and deployment controls.
 | Authorization | Enforcement of each capability's `access` rule | Roles, scopes, tenants, PDP integration, and domain policy |
 | Observability | Payload-free `onEvent` lifecycle hook and logger | Metrics, tracing, storage, alerts, costs, and domain measurements |
 | AI behavior | Replaceable implementation boundary | Prompts, models, retrieval, tools, evidence, evaluations, and review |
-| Supporting tools | Composition checker, read-only client inventory, deployment artifact generator | Review, approval, execution, and operational authority |
+| Supporting tools | Engine creator, composition checker, read-only client inventory, deployment artifact generator | Review, approval, execution, and operational authority |
 
 ## Deliberately outside the runtime
 

--- a/apps/docs/src/content/docs/getting-started/first-engine.mdx
+++ b/apps/docs/src/content/docs/getting-started/first-engine.mdx
@@ -8,6 +8,10 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 This guide creates a small onboarding capability. It stays deterministic so you
 can inspect the Invokta boundary before connecting a model or another provider.
 
+Generate the complete standalone version with `npm create
+invokta-engine@latest my-engine`, or follow the steps below to assemble the same
+boundary manually.
+
 <Steps>
 
 1. Define the capability

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -16,6 +16,31 @@ install only the adapters and development tools your engine uses.
 
 The examples use Zod 4 because it implements both schema contracts.
 
+## Create a standalone engine
+
+<Tabs syncKey="package-manager">
+  <TabItem label="npm">
+    ```sh
+    npm create invokta-engine@latest my-engine
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```sh
+    pnpm create invokta-engine my-engine
+    ```
+  </TabItem>
+  <TabItem label="Yarn">
+    ```sh
+    yarn create invokta-engine my-engine
+    ```
+  </TabItem>
+</Tabs>
+
+The creator installs dependencies and generates a deterministic public capability
+with direct, CLI, and MCP stdio entry points. Use `--no-install` for an offline
+scaffold. See the [`create-invokta-engine` reference](/reference/create-invokta-engine/)
+for target, package-manager, and failure behavior.
+
 ## Install the core
 
 <Tabs syncKey="package-manager">
@@ -66,6 +91,7 @@ Install the CLI or MCP adapter when the engine needs that boundary.
 | `@invokta/tooling` | Capability-composition checks during development |
 | `@invokta/installer` | Read-only inventory of supported local MCP client targets in its current release |
 | `@invokta/deploy` | Reviewable container packaging and endpoint probes |
+| `create-invokta-engine` | Standalone starter Action Engine creation |
 
 <Aside type="note" title="ESM only">
   Invokta publishes native ESM entry points. Use `import` syntax and include file

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -1,0 +1,126 @@
+---
+title: 'create-invokta-engine'
+description: Complete command, generated-project, filesystem, package-manager, and diagnostic contract for the Invokta engine creator.
+---
+
+`create-invokta-engine` creates one standalone TypeScript Action Engine with a
+public capability shared by direct invocation, the Invokta CLI adapter, and MCP
+stdio. It is a binary-only development package, not a runtime adapter or template
+framework.
+
+## Install
+
+Run the current release without adding it to an existing project:
+
+```sh
+npm create invokta-engine@latest my-engine
+```
+
+The package is native ESM and requires Node.js 22.20.0 or later. The npm
+initializer maps `invokta-engine` to the `create-invokta-engine` package and
+executable.
+
+## Commands
+
+```text
+create-invokta-engine <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+Creation is non-interactive. Options may appear before or after the one project
+directory. `--package-manager` accepts a separate `npm`, `pnpm`, or `yarn` value;
+duplicates, unknown options, `--option=value`, or another positional are invalid.
+
+## Target contract
+
+The project directory is relative to the current working directory. Absolute
+paths and `..` segments are rejected. `.` is accepted when the current directory
+has a valid lowercase kebab-case name and is empty.
+
+| Limit | Value |
+| --- | --- |
+| Project path | At most 1,024 Unicode scalars |
+| Non-dot path segments | At most 32 |
+| Project and engine name | Lowercase kebab-case, at most 214 characters |
+
+The target may be absent or an empty real directory. A symbolic-link target,
+symbolic-link path component, non-directory target, or any existing entry fails
+before scaffold writes. Every file is created exclusively; an entry that appears
+during creation is preserved and reported as `SCAFFOLD_CONFLICT`.
+
+A pre-install write failure removes only paths created by that invocation. The
+creator never overwrites a file. Concurrent creation in one target is unsupported.
+
+## Generated project
+
+Files are deterministic UTF-8 text with LF endings and one trailing newline:
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-welcome-message.ts
+src/cli.ts
+src/direct.ts
+src/engine.ts
+src/mcp-stdio.ts
+test/engine.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The public `onboarding.create-welcome-message` capability is deterministic and
+requires no credential or provider account. Direct, CLI, and MCP stdio entry
+points import the same engine. Generated Invokta dependencies use the exact
+creator version; generated files are project-owned and are never upgraded in
+place.
+
+The starter contains no HTTP endpoint, authentication implementation, model
+provider, telemetry, Git initialization, or template selector. Add stateless
+HTTP later with `@invokta/deploy`, whose fail-closed authentication scaffold
+remains the only official HTTP generator.
+
+## Package-manager behavior
+
+An explicit `--package-manager` wins. Otherwise the creator recognizes npm,
+pnpm, or Yarn from `npm_config_user_agent` and falls back to npm.
+
+| Manager | Install command |
+| --- | --- |
+| npm | `npm install --no-audit --no-fund` |
+| pnpm | `pnpm install` |
+| Yarn | `yarn install` |
+
+Exactly one foreground install is started directly without a shell, retry, or
+creator-owned timeout. An unavailable manager, non-zero exit, or signal is
+`INSTALL_FAILED`; the complete scaffold remains so installation can be retried.
+
+`--no-install` starts no child process and performs no network operation. The
+creator itself never makes a network request.
+
+## Output and errors
+
+Help, version, and the final success summary use standard output. Creator
+diagnostics use standard error. During installation, the selected package manager
+inherits the terminal streams.
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Usage, project path, or project name was invalid |
+
+| Code | Meaning |
+| --- | --- |
+| `TARGET_INVALID` | The path shape or derived project name is invalid |
+| `TARGET_UNSAFE` | A path component is a symlink, not a directory, or cannot be inspected safely |
+| `TARGET_NOT_EMPTY` | The target contains at least one entry |
+| `SCAFFOLD_CONFLICT` | A fixed scaffold path appeared after preflight |
+| `WRITE_FAILED` | A scaffold write or rollback failed |
+| `INSTALL_FAILED` | The selected package manager was unavailable or unsuccessful |
+
+Diagnostics may identify a generated project-relative path or package-manager
+name. They never include a rejected argument, environment value, child error,
+stack, or cause.

--- a/apps/docs/src/content/docs/reference/index.mdx
+++ b/apps/docs/src/content/docs/reference/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Overview
 ---
 
-Invokta publishes three runtime packages and three supporting packages. Each has
+Invokta publishes three runtime packages and four supporting packages. Each has
 one bounded responsibility.
 
 ## Runtime packages
@@ -26,10 +26,12 @@ API and never call capability handlers directly.
 | `@invokta/tooling` | Validate a built, tracked capability composition in development or CI | [Tooling reference](/reference/tooling/) |
 | `@invokta/installer` | Current read-only inventory of supported local MCP client targets | [Installer reference](/reference/installer/) |
 | `@invokta/deploy` | Scaffold and package HTTP deployment artifacts and probe an endpoint | [Deploy reference](/reference/deploy/) |
+| `create-invokta-engine` | Create a standalone starter engine and install its dependencies | [Creator reference](/reference/create-invokta-engine/) |
 
-Supporting packages do not create another capability execution path. Tooling
-imports a trusted composition module, the installer inventory never invokes an
-engine, and deploy generates files or makes one probe request.
+Supporting packages do not create another capability execution path. The creator
+writes a project, tooling imports a trusted composition module, the installer
+inventory never invokes an engine, and deploy generates files or makes one probe
+request.
 
 ## Shared requirements
 
@@ -39,5 +41,5 @@ engine, and deploy generates files or makes one probe request.
 - Runtime behavior remains on `engine.invoke`
 
 Use the [error reference](/reference/errors/) for capability invocation errors.
-Tooling, installer, and deploy diagnostics have separate application-specific
-contracts.
+Creator, tooling, installer, and deploy diagnostics have separate
+application-specific contracts.

--- a/apps/docs/test/site-contract.node.mjs
+++ b/apps/docs/test/site-contract.node.mjs
@@ -25,6 +25,7 @@ const packageReferences = [
   ["tooling", "@invokta/tooling"],
   ["installer", "@invokta/installer"],
   ["deploy", "@invokta/deploy"],
+  ["create-invokta-engine", "create-invokta-engine"],
 ];
 
 const requiredRoutes = [

--- a/docs/adr/0012-standalone-invokta-engine-creator.md
+++ b/docs/adr/0012-standalone-invokta-engine-creator.md
@@ -1,0 +1,113 @@
+# ADR 0012: Standalone Invokta engine creator
+
+- Status: Accepted
+- Date: 2026-07-29
+
+## Context
+
+Engine authors currently assemble the package manifest, TypeScript configuration,
+capability, composition root, execution entry points, and first test by hand or
+adapt the repository-local `hello-engine` example. The example is not a
+standalone template: its configuration and package metadata belong to this
+workspace. Invokta needs one bounded bootstrap path that produces a runnable
+engine without turning project creation into a runtime concern or duplicating
+deployment authority.
+
+## Decision
+
+Invokta publishes a seventh native ESM package, `create-invokta-engine`. It is a
+binary-only supporting application exposing the executable of the same name.
+This decision supersedes only the six-package list and supporting-package count
+in ADR 0004; its dependency direction and package isolation remain in force.
+
+The public command surface is:
+
+```text
+create-invokta-engine <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+Creation is non-interactive. The target is relative to the working directory;
+absolute paths and parent-directory segments are rejected. `.` is accepted when
+the working directory itself is otherwise a valid empty target. The argument is
+limited to 1,024 Unicode scalars and 32 non-dot path segments. The final segment,
+or the working-directory name for `.`, becomes both the private package name and
+engine name. It must be lowercase kebab-case and at most 214 characters.
+
+The target may be absent or an empty real directory. A symbolic-link target, a
+symbolic-link path component, a non-directory target, or any existing directory
+entry fails before a scaffold write. Generated files are fixed, deterministic
+UTF-8 text with LF endings and one trailing newline. Writes use exclusive
+creation and never replace an existing file. A pre-install failure rolls back
+only files and directories created by that invocation; a rollback failure is
+reported and may leave those new paths for manual inspection. Concurrent
+creation in one target is unsupported, while exclusive writes ensure neither
+invocation overwrites the other.
+
+The fixed starter contains these paths in lexicographic order:
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-welcome-message.ts
+src/cli.ts
+src/direct.ts
+src/engine.ts
+src/mcp-stdio.ts
+test/engine.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+It defines one deterministic public capability and reuses it through direct
+invocation, `@invokta/cli`, and MCP stdio. It contains no model provider,
+identity implementation, HTTP server, deployment template, runtime plugin,
+telemetry, or Git initialization. HTTP preparation remains owned by
+`@invokta/deploy`. Generated Invokta dependency versions exactly match the
+creator version. Template changes affect only projects created by that creator
+release; generated files are user-owned and are never upgraded in place.
+
+Unless `--no-install` is present, the creator runs exactly one package-manager
+install as a direct child process without a shell. An explicit package manager
+wins; otherwise the creator recognizes npm, pnpm, or Yarn from
+`npm_config_user_agent` and falls back to npm. It executes `npm install
+--no-audit --no-fund`, `pnpm install`, or `yarn install`, respectively. The
+creator adds no retry or timeout to the foreground install. User cancellation
+ends the operation through normal foreground process signal handling. A failed
+or unavailable package manager produces a failed command but preserves the
+completed scaffold so the author can retry. `--no-install` starts no child
+process and performs no network operation. The creator itself performs no
+network request.
+
+Help, version, and the final success summary use standard output. Creator
+diagnostics use standard error; an install child inherits the terminal streams.
+The exit status is `0` for success, `1` for a target, filesystem, or installation
+failure, and `2` for invalid usage or an invalid project path or name. Public
+diagnostics use the stable codes `TARGET_INVALID`, `TARGET_UNSAFE`,
+`TARGET_NOT_EMPTY`, `SCAFFOLD_CONFLICT`, `WRITE_FAILED`, and `INSTALL_FAILED`.
+They may identify a generated project-relative path or one of the three package
+manager names, but never echo a rejected argument, environment value, child
+error, stack, or cause.
+
+The package imports no Invokta runtime package and creates no capability
+execution path. Its acceptance boundary is the generated consumer: the packed
+creator must generate a project that installs from packed release artifacts,
+type-checks, tests, builds, and invokes the same capability directly, through the
+CLI, and through MCP stdio.
+
+## Consequences
+
+- `npm create invokta-engine@latest my-engine` has one stable Invokta-owned
+  initializer behind it.
+- Project creation becomes a separately versioned compatibility surface without
+  expanding the core or either runtime adapter.
+- The fixed starter is intentionally narrower than an application template
+  system; additional templates require repeated use-case evidence and another
+  contract decision.
+- Package-manager installation is the sole external process and potential
+  network activity; offline and embedded workflows use `--no-install`.
+- Release verification must cover the creator tarball, executable, deterministic
+  scaffold, and isolated generated consumer.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0009](0009-capability-composition-and-dev-tooling.md) | Capability composition and development tooling | Accepted | 2026-07-28 |
 | [0010](0010-standalone-local-capability-mcp-installer.md) | Standalone local capability MCP installer | Accepted | 2026-07-28 |
 | [0011](0011-http-engine-deploy-toolkit.md) | HTTP engine deployment toolkit | Accepted | 2026-07-28 |
+| [0012](0012-standalone-invokta-engine-creator.md) | Standalone Invokta engine creator | Accepted | 2026-07-29 |

--- a/docs/implementation-plan-and-acceptance-criteria.md
+++ b/docs/implementation-plan-and-acceptance-criteria.md
@@ -42,10 +42,11 @@ persistence, configuration field, or operational limit:
 | `AE-SCOPE-01..04`, `AE-LIMIT-01..05` | Manifest and API review prove package roles and the absence of deferred abstractions |
 
 Supporting packages require focused contract tests for their own authority:
-composition diagnostics remain deterministic and payload-free; installer writes
-remain confirmed, atomic, reversible, and secret-free; deploy outputs remain
-deterministic, marked, and non-destructive; and every published tarball passes an
-isolated consumer smoke test.
+creator scaffolds remain deterministic, non-overwriting, and independently
+buildable; composition diagnostics remain deterministic and payload-free;
+installer writes remain confirmed, atomic, reversible, and secret-free; deploy
+outputs remain deterministic, marked, and non-destructive; and every published
+tarball passes an isolated consumer smoke test.
 
 ## Release gates
 

--- a/docs/scope-and-limits.md
+++ b/docs/scope-and-limits.md
@@ -2,7 +2,7 @@
 
 ## Public packages
 
-**AE-SCOPE-01 — Six packages with isolated roles.** Invokta publishes:
+**AE-SCOPE-01 — Seven packages with isolated roles.** Invokta publishes:
 
 | Package | Responsibility |
 | --- | --- |
@@ -12,6 +12,7 @@
 | `@invokta/tooling` | Development-time validation of capability composition |
 | `@invokta/installer` | End-user configuration of supported local MCP clients |
 | `@invokta/deploy` | Development-time HTTP engine scaffolding, packaging, and probing |
+| `create-invokta-engine` | Creation of a standalone starter Action Engine |
 
 All packages are native ESM. The core has no transport dependency. Runtime
 adapters depend only on the core's public API, and supporting applications do
@@ -37,7 +38,7 @@ useful.
 | Dimension | Limit |
 | --- | --- |
 | Framework runtime packages | 3: core, CLI, and MCP |
-| Supporting packages | 3: tooling, installer, and deploy |
+| Supporting packages | 4: tooling, installer, deploy, and engine creator |
 | Official adapters | CLI and MCP |
 | MCP transports | stdio and stateless Streamable HTTP |
 | Core primitives | Capability, Engine, Context, and Principal |

--- a/docs/scope-matrix.md
+++ b/docs/scope-matrix.md
@@ -24,14 +24,14 @@ belongs in Invokta, a custom engine, or a later evidence-driven package.
 | AI implementation | Keep implementation replaceable | Own prompts, models, retrieval, tools, evidence, and risk controls | Provider SDKs, prompt registry, RAG abstraction, or memory |
 | Quality | Validate contracts and provide testable direct execution | Own fixtures, evals, regression suites, and human review | Eval runner, automated judge, or canary platform |
 | Capability reuse | Eager explicit composition with deterministic collision detection | Choose imports, effective IDs, and trusted dependencies | Runtime plugin marketplace or remote discovery |
-| Supporting tools | Composition checker, MCP client installer, and deployment generator | Review generated files and own local or deployment authority | Autonomous installation or deployment service |
+| Supporting tools | Engine creator, composition checker, MCP client installer, and deployment generator | Review generated files and own local or deployment authority | Autonomous installation or deployment service |
 
 ## Fixed limits
 
 | Dimension | Limit |
 | --- | --- |
 | Framework runtime packages | 3 |
-| Supporting packages | 3 |
+| Supporting packages | 4 |
 | Official adapters | 2: CLI and MCP |
 | MCP transports | 2: stdio and stateless Streamable HTTP |
 | Core primitives | 4: Capability, Engine, Context, Principal |

--- a/packages/create-invokta-engine/LICENSE
+++ b/packages/create-invokta-engine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vini Lana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -1,0 +1,63 @@
+# create-invokta-engine
+
+Create a standalone TypeScript Action Engine with Invokta. The fixed starter
+defines one public capability and exposes it through direct invocation, the
+Invokta CLI adapter, and MCP stdio without duplicating the handler.
+
+## Commands
+
+```text
+create-invokta-engine <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+The npm initializer shorthand resolves to this package:
+
+```sh
+npm create invokta-engine@latest my-engine
+```
+
+Creation is non-interactive. The target must be a relative absent or empty real
+directory. Existing files and symbolic-link path components are refused and
+never overwritten.
+
+The invoking package manager is inferred from `npm_config_user_agent`, with npm
+as the fallback. Use `--package-manager` to choose explicitly or `--no-install`
+to generate files without starting a package manager or performing network I/O.
+
+## Generated project
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-welcome-message.ts
+src/cli.ts
+src/direct.ts
+src/engine.ts
+src/mcp-stdio.ts
+test/engine.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+Generated Invokta dependencies use the exact creator version. The files become
+project-owned immediately and are never updated in place by the creator.
+
+HTTP scaffolding remains a separate, explicit step owned by `@invokta/deploy`.
+The starter contains no HTTP server, authentication implementation, model
+provider, telemetry, template selection, or Git initialization.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Arguments, project path, or project name were invalid |
+
+Creator diagnostics use `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, or `INSTALL_FAILED`. Rejected arguments,
+environment values, child errors, stacks, and causes are not included.

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "create-invokta-engine",
+  "version": "0.1.0",
+  "description": "Create a standalone Invokta Action Engine.",
+  "author": "Vini Lana <vini@aicoders.academy>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vinilana/invokta.git",
+    "directory": "packages/create-invokta-engine"
+  },
+  "homepage": "https://docs.invokta.dev/reference/create-invokta-engine/",
+  "bugs": {
+    "url": "https://github.com/vinilana/invokta/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {},
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "prepack": "npm run --silent build"
+  }
+}

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -25,6 +25,9 @@
     "dist"
   ],
   "exports": {},
+  "bin": {
+    "create-invokta-engine": "./dist/bin.js"
+  },
   "scripts": {
     "build": "tsc -b --pretty false",
     "prepack": "npm run --silent build"

--- a/packages/create-invokta-engine/src/bin.ts
+++ b/packages/create-invokta-engine/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCreateEngineCli } from "./cli.js";
+
+// The composition root owns process status so buffered terminal output can flush.
+process.exitCode = await runCreateEngineCli();

--- a/packages/create-invokta-engine/src/cli.ts
+++ b/packages/create-invokta-engine/src/cli.ts
@@ -1,0 +1,213 @@
+import { CreatorError, renderCreatorDiagnostic } from "./errors.js";
+import { installProjectDependencies, selectPackageManager } from "./install.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+import { createStarterProject } from "./scaffold.js";
+
+const helpText = `Usage:
+  create-invokta-engine <project-directory>
+    [--package-manager npm|pnpm|yarn] [--no-install]
+  create-invokta-engine --help
+  create-invokta-engine --version
+`;
+
+const invalidUsageText =
+  'Invalid arguments. Run "create-invokta-engine --help".\n';
+const unexpectedFailureText = "The project could not be created.\n";
+
+export interface CreateEngineIo {
+  readonly writeStdout: (text: string) => void | Promise<void>;
+  readonly writeStderr: (text: string) => void | Promise<void>;
+}
+
+const processIo: CreateEngineIo = {
+  writeStdout(text) {
+    process.stdout.write(text);
+  },
+  writeStderr(text) {
+    process.stderr.write(text);
+  },
+};
+
+const defaultIo: CreateEngineIo = Object.freeze(processIo);
+
+export interface InstallProjectOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+}
+
+export type InstallProject = (options: InstallProjectOptions) => Promise<void>;
+
+export interface RunCreateEngineCliOptions {
+  readonly argv?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly io?: CreateEngineIo;
+  readonly install?: InstallProject;
+  readonly loadPackageVersion?: () => Promise<string>;
+}
+
+interface CreateArguments {
+  readonly target: string;
+  readonly packageManager?: PackageManager;
+  readonly noInstall: boolean;
+}
+
+function parseCreateArguments(
+  args: readonly string[],
+): CreateArguments | undefined {
+  let target: string | undefined;
+  let packageManager: PackageManager | undefined;
+  let packageManagerSeen = false;
+  let noInstall = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--no-install") {
+      if (noInstall) return undefined;
+      noInstall = true;
+      continue;
+    }
+    if (argument === "--package-manager") {
+      if (packageManagerSeen) return undefined;
+      packageManagerSeen = true;
+      const value = args[index + 1];
+      if (value === undefined || !isPackageManager(value)) return undefined;
+      packageManager = value;
+      index += 1;
+      continue;
+    }
+    if (
+      argument === undefined ||
+      argument.startsWith("-") ||
+      target !== undefined
+    ) {
+      return undefined;
+    }
+    target = argument;
+  }
+
+  if (target === undefined) return undefined;
+  return {
+    target,
+    ...(packageManager === undefined ? {} : { packageManager }),
+    noInstall,
+  };
+}
+
+function asRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  return value as Readonly<Record<string, unknown>>;
+}
+
+async function loadDefaultPackageVersion(): Promise<string> {
+  const manifestUrl = new URL("../package.json", import.meta.url);
+  const namespace = (await import(manifestUrl.href, {
+    with: { type: "json" },
+  })) as unknown;
+  const version = asRecord(asRecord(namespace)?.default)?.version;
+  if (typeof version !== "string" || version === "") {
+    throw new Error("The package version is unreadable.");
+  }
+  return version;
+}
+
+async function writeDiagnostic(
+  io: CreateEngineIo,
+  text: string,
+): Promise<void> {
+  try {
+    await io.writeStderr(text);
+  } catch {
+    // A broken diagnostic stream does not replace the command's numeric result.
+  }
+}
+
+function renderSuccess(
+  projectName: string,
+  packageManager: PackageManager,
+  noInstall: boolean,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  if (noInstall) {
+    return (
+      `Created ${projectName} without installing dependencies.\n\n` +
+      "Next steps:\n" +
+      `  ${commands.installDisplay}\n` +
+      `  ${commands.check}\n`
+    );
+  }
+  return `Created ${projectName}.\n\nNext step:\n  ${commands.check}\n`;
+}
+
+/** Runs the binary command and returns its exit status without exiting. */
+export async function runCreateEngineCli(
+  options: RunCreateEngineCliOptions = {},
+): Promise<0 | 1 | 2> {
+  const argv = options.argv ?? process.argv.slice(2);
+  const io = options.io ?? defaultIo;
+  const [first, ...rest] = argv;
+
+  if (first === "--help" || first === "--version") {
+    if (rest.length > 0) {
+      await writeDiagnostic(io, invalidUsageText);
+      return 2;
+    }
+    try {
+      const output =
+        first === "--help"
+          ? helpText
+          : `${await (options.loadPackageVersion ?? loadDefaultPackageVersion)()}\n`;
+      await io.writeStdout(output);
+      return 0;
+    } catch {
+      await writeDiagnostic(io, unexpectedFailureText);
+      return 1;
+    }
+  }
+
+  const parsed = parseCreateArguments(argv);
+  if (parsed === undefined) {
+    await writeDiagnostic(io, invalidUsageText);
+    return 2;
+  }
+
+  const environment = options.env ?? process.env;
+  const packageManager = selectPackageManager(
+    parsed.packageManager,
+    environment.npm_config_user_agent,
+  );
+  try {
+    const invoktaVersion = await (
+      options.loadPackageVersion ?? loadDefaultPackageVersion
+    )();
+    const project = await createStarterProject({
+      cwd: options.cwd ?? process.cwd(),
+      target: parsed.target,
+      invoktaVersion,
+      packageManager,
+    });
+    if (!parsed.noInstall) {
+      await (options.install ?? installProjectDependencies)({
+        directory: project.directory,
+        packageManager,
+      });
+    }
+    await io.writeStdout(
+      renderSuccess(project.projectName, packageManager, parsed.noInstall),
+    );
+    return 0;
+  } catch (error) {
+    if (error instanceof CreatorError) {
+      await writeDiagnostic(io, renderCreatorDiagnostic(error));
+      return error.exitCode;
+    }
+    await writeDiagnostic(io, unexpectedFailureText);
+    return 1;
+  }
+}

--- a/packages/create-invokta-engine/src/errors.ts
+++ b/packages/create-invokta-engine/src/errors.ts
@@ -1,0 +1,43 @@
+export const creatorErrorMessages = Object.freeze({
+  TARGET_INVALID: "The project path or name is invalid.",
+  TARGET_UNSAFE: "The project target is unsafe to use.",
+  TARGET_NOT_EMPTY: "The project target is not empty.",
+  SCAFFOLD_CONFLICT: "A scaffold file appeared during creation.",
+  WRITE_FAILED: "The project scaffold could not be written.",
+  INSTALL_FAILED: "The project dependencies could not be installed.",
+} as const);
+
+export type CreatorErrorCode = keyof typeof creatorErrorMessages;
+export type CreatorExitCode = 0 | 1 | 2;
+
+const creatorErrorExitCodes = Object.freeze({
+  TARGET_INVALID: 2,
+  TARGET_UNSAFE: 1,
+  TARGET_NOT_EMPTY: 1,
+  SCAFFOLD_CONFLICT: 1,
+  WRITE_FAILED: 1,
+  INSTALL_FAILED: 1,
+} as const) satisfies Readonly<Record<CreatorErrorCode, CreatorExitCode>>;
+
+/** A sanitized creator failure. It intentionally stores no cause or raw input. */
+export class CreatorError extends Error {
+  readonly code: CreatorErrorCode;
+  readonly exitCode: CreatorExitCode;
+  readonly details: readonly string[];
+
+  constructor(code: CreatorErrorCode, details: readonly string[] = []) {
+    super(creatorErrorMessages[code]);
+    this.name = "CreatorError";
+    this.code = code;
+    this.exitCode = creatorErrorExitCodes[code];
+    this.details = Object.freeze([...details]);
+  }
+}
+
+export function renderCreatorDiagnostic(error: CreatorError): string {
+  const lines = [
+    `${error.code}: ${creatorErrorMessages[error.code]}`,
+    ...error.details.map((detail) => `  ${detail}`),
+  ];
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/create-invokta-engine/src/install.ts
+++ b/packages/create-invokta-engine/src/install.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+import { CreatorError } from "./errors.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+
+export interface PackageManagerRunOptions {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly shell: false;
+  readonly stdio: "inherit";
+}
+
+export interface PackageManagerRunResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export type PackageManagerRunner = (
+  options: PackageManagerRunOptions,
+) => Promise<PackageManagerRunResult>;
+
+export const defaultPackageManagerRunner: PackageManagerRunner = (options) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(options.command, [...options.args], {
+      cwd: options.cwd,
+      shell: options.shell,
+      stdio: options.stdio,
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+
+export function selectPackageManager(
+  explicit: PackageManager | undefined,
+  userAgent: string | undefined,
+): PackageManager {
+  if (explicit !== undefined) return explicit;
+  const candidate = userAgent?.split(/\s/u, 1)[0]?.split("/", 1)[0];
+  return candidate !== undefined && isPackageManager(candidate)
+    ? candidate
+    : "npm";
+}
+
+export interface InstallProjectDependenciesOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+  readonly runner?: PackageManagerRunner;
+}
+
+/** Runs the one foreground package-manager install authorized by ADR 0012. */
+export async function installProjectDependencies(
+  options: InstallProjectDependenciesOptions,
+): Promise<void> {
+  const commands = packageManagerCommands[options.packageManager];
+  let result: PackageManagerRunResult;
+  try {
+    result = await (options.runner ?? defaultPackageManagerRunner)({
+      command: commands.installExecutable,
+      args: commands.installArguments,
+      cwd: options.directory,
+      shell: false,
+      stdio: "inherit",
+    });
+  } catch {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+  if (result.code !== 0) {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+}

--- a/packages/create-invokta-engine/src/package-manager.ts
+++ b/packages/create-invokta-engine/src/package-manager.ts
@@ -1,0 +1,55 @@
+export type PackageManager = "npm" | "pnpm" | "yarn";
+
+export interface PackageManagerCommands {
+  readonly installExecutable: PackageManager;
+  readonly installArguments: readonly string[];
+  readonly installDisplay: string;
+  readonly check: string;
+  readonly direct: string;
+  readonly list: string;
+  readonly run: string;
+  readonly stdio: string;
+}
+
+export const packageManagerCommands = Object.freeze({
+  npm: Object.freeze({
+    installExecutable: "npm",
+    installArguments: Object.freeze(["install", "--no-audit", "--no-fund"]),
+    installDisplay: "npm install --no-audit --no-fund",
+    check: "npm run check",
+    direct: "npm run direct -- Ada",
+    list: "npm run cli -- list",
+    run: 'npm run cli -- run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "npm run mcp:stdio",
+  }),
+  pnpm: Object.freeze({
+    installExecutable: "pnpm",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "pnpm install",
+    check: "pnpm run check",
+    direct: "pnpm run direct Ada",
+    list: "pnpm run cli list",
+    run: 'pnpm run cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "pnpm run mcp:stdio",
+  }),
+  yarn: Object.freeze({
+    installExecutable: "yarn",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "yarn install",
+    check: "yarn check",
+    direct: "yarn direct Ada",
+    list: "yarn cli list",
+    run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "yarn mcp:stdio",
+  }),
+} as const) satisfies Readonly<Record<PackageManager, PackageManagerCommands>>;
+
+export const packageManagers = Object.freeze([
+  "npm",
+  "pnpm",
+  "yarn",
+] as const satisfies readonly PackageManager[]);
+
+export function isPackageManager(value: string): value is PackageManager {
+  return packageManagers.some((manager) => manager === value);
+}

--- a/packages/create-invokta-engine/src/package-manager.ts
+++ b/packages/create-invokta-engine/src/package-manager.ts
@@ -36,7 +36,7 @@ export const packageManagerCommands = Object.freeze({
     installExecutable: "yarn",
     installArguments: Object.freeze(["install"]),
     installDisplay: "yarn install",
-    check: "yarn check",
+    check: "yarn run check",
     direct: "yarn direct Ada",
     list: "yarn cli list",
     run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',

--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -10,11 +10,8 @@ import {
 import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
 
 import { CreatorError } from "./errors.js";
-import {
-  createStarterFiles,
-  type PackageManager,
-  type StarterFile,
-} from "./starter.js";
+import type { PackageManager } from "./package-manager.js";
+import { createStarterFiles, type StarterFile } from "./starter.js";
 
 export const creatorTargetLimits = Object.freeze({
   maxPathScalars: 1_024,

--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -1,0 +1,322 @@
+import type { Stats } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  rmdir,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
+
+import { CreatorError } from "./errors.js";
+import {
+  createStarterFiles,
+  type PackageManager,
+  type StarterFile,
+} from "./starter.js";
+
+export const creatorTargetLimits = Object.freeze({
+  maxPathScalars: 1_024,
+  maxPathSegments: 32,
+  maxProjectNameCharacters: 214,
+});
+
+const projectNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export interface ScaffoldFileSystem {
+  readonly lstat: (path: string) => Promise<Stats>;
+  readonly mkdir: (path: string) => Promise<void>;
+  readonly readdir: (path: string) => Promise<string[]>;
+  readonly rmdir: (path: string) => Promise<void>;
+  readonly unlink: (path: string) => Promise<void>;
+  readonly writeFile: (
+    path: string,
+    contents: string,
+    options: Readonly<{ encoding: "utf8"; flag: "wx" }>,
+  ) => Promise<void>;
+}
+
+const nodeScaffoldFileSystem: ScaffoldFileSystem = {
+  lstat,
+  async mkdir(path) {
+    await mkdir(path);
+  },
+  async readdir(path) {
+    return readdir(path);
+  },
+  async rmdir(path) {
+    await rmdir(path);
+  },
+  async unlink(path) {
+    await unlink(path);
+  },
+  async writeFile(path, contents, options) {
+    await writeFile(path, contents, options);
+  },
+};
+
+export const defaultScaffoldFileSystem: ScaffoldFileSystem = Object.freeze(
+  nodeScaffoldFileSystem,
+);
+
+export interface CreateStarterProjectOptions {
+  readonly cwd: string;
+  readonly target: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+  readonly fileSystem?: ScaffoldFileSystem;
+}
+
+export interface StarterProject {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly files: readonly string[];
+}
+
+interface ResolvedTarget {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly segments: readonly string[];
+}
+
+function countScalars(value: string): number {
+  let count = 0;
+  for (const _ of value) count += 1;
+  return count;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function invalidTarget(): never {
+  throw new CreatorError("TARGET_INVALID");
+}
+
+function resolveTarget(cwd: string, target: string): ResolvedTarget {
+  if (
+    target === "" ||
+    target.includes("\u0000") ||
+    countScalars(target) > creatorTargetLimits.maxPathScalars ||
+    isAbsolute(target) ||
+    win32.isAbsolute(target)
+  ) {
+    return invalidTarget();
+  }
+
+  const rawSegments = target.split(/[\\/]/u);
+  if (target !== "." && rawSegments.some((segment) => segment === "")) {
+    return invalidTarget();
+  }
+  const segments = rawSegments.filter((segment) => segment !== ".");
+  if (
+    segments.some((segment) => segment === "..") ||
+    segments.length > creatorTargetLimits.maxPathSegments
+  ) {
+    return invalidTarget();
+  }
+
+  const directory =
+    segments.length === 0 ? resolve(cwd) : resolve(cwd, ...segments);
+  const projectName = basename(directory);
+  if (
+    projectName.length === 0 ||
+    projectName.length > creatorTargetLimits.maxProjectNameCharacters ||
+    !projectNamePattern.test(projectName)
+  ) {
+    return invalidTarget();
+  }
+  return { directory, projectName, segments };
+}
+
+async function readStatus(
+  fileSystem: ScaffoldFileSystem,
+  path: string,
+): Promise<Stats | undefined> {
+  try {
+    return await fileSystem.lstat(path);
+  } catch (error) {
+    const code = readErrorCode(error);
+    if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+}
+
+async function inspectTarget(
+  cwd: string,
+  target: ResolvedTarget,
+  fileSystem: ScaffoldFileSystem,
+): Promise<boolean> {
+  let current = resolve(cwd);
+  if (target.segments.length === 0) {
+    const status = await readStatus(fileSystem, current);
+    if (
+      status === undefined ||
+      status.isSymbolicLink() ||
+      !status.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  } else {
+    for (const segment of target.segments) {
+      current = join(current, segment);
+      const status = await readStatus(fileSystem, current);
+      if (status === undefined) return false;
+      if (status.isSymbolicLink() || !status.isDirectory()) {
+        throw new CreatorError("TARGET_UNSAFE");
+      }
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await fileSystem.readdir(target.directory);
+  } catch {
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+  if (entries.length > 0) throw new CreatorError("TARGET_NOT_EMPTY");
+  return true;
+}
+
+async function ensureDirectory(
+  path: string,
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  const status = await readStatus(fileSystem, path);
+  if (status !== undefined) {
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+    return;
+  }
+  try {
+    await fileSystem.mkdir(path);
+    createdDirectories.push(path);
+  } catch (error) {
+    if (readErrorCode(error) !== "EEXIST") {
+      throw new CreatorError("WRITE_FAILED");
+    }
+    const racedStatus = await readStatus(fileSystem, path);
+    if (
+      racedStatus === undefined ||
+      racedStatus.isSymbolicLink() ||
+      !racedStatus.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  }
+}
+
+async function prepareDirectories(
+  cwd: string,
+  target: ResolvedTarget,
+  files: readonly StarterFile[],
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  let current = resolve(cwd);
+  for (const segment of target.segments) {
+    current = join(current, segment);
+    await ensureDirectory(current, fileSystem, createdDirectories);
+  }
+  for (const directory of new Set(
+    files
+      .map((file) => dirname(file.path))
+      .filter((path) => path !== ".")
+      .sort(),
+  )) {
+    let nested = target.directory;
+    for (const segment of directory.split("/")) {
+      nested = join(nested, segment);
+      await ensureDirectory(nested, fileSystem, createdDirectories);
+    }
+  }
+}
+
+async function rollback(
+  fileSystem: ScaffoldFileSystem,
+  createdFiles: readonly string[],
+  createdDirectories: readonly string[],
+): Promise<boolean> {
+  let failed = false;
+  for (const path of [...createdFiles].reverse()) {
+    try {
+      await fileSystem.unlink(path);
+    } catch (error) {
+      if (readErrorCode(error) !== "ENOENT") failed = true;
+    }
+  }
+  for (const path of [...createdDirectories].reverse()) {
+    try {
+      await fileSystem.rmdir(path);
+    } catch (error) {
+      const code = readErrorCode(error);
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") failed = true;
+    }
+  }
+  return !failed;
+}
+
+/** Creates the fixed starter without installing dependencies or replacing files. */
+export async function createStarterProject(
+  options: CreateStarterProjectOptions,
+): Promise<StarterProject> {
+  const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
+  const target = resolveTarget(options.cwd, options.target);
+  await inspectTarget(options.cwd, target, fileSystem);
+  const files = createStarterFiles({
+    projectName: target.projectName,
+    invoktaVersion: options.invoktaVersion,
+    packageManager: options.packageManager,
+  });
+  const createdFiles: string[] = [];
+  const createdDirectories: string[] = [];
+  let activeFile: StarterFile | undefined;
+
+  try {
+    await prepareDirectories(
+      options.cwd,
+      target,
+      files,
+      fileSystem,
+      createdDirectories,
+    );
+    for (const file of files) {
+      activeFile = file;
+      const path = join(target.directory, ...file.path.split("/"));
+      await fileSystem.writeFile(path, file.contents, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      createdFiles.push(path);
+    }
+  } catch (error) {
+    const rolledBack = await rollback(
+      fileSystem,
+      createdFiles,
+      createdDirectories,
+    );
+    if (!rolledBack) throw new CreatorError("WRITE_FAILED");
+    if (error instanceof CreatorError) throw error;
+    if (readErrorCode(error) === "EEXIST") {
+      throw new CreatorError(
+        "SCAFFOLD_CONFLICT",
+        activeFile === undefined ? [] : [activeFile.path],
+      );
+    }
+    throw new CreatorError(
+      "WRITE_FAILED",
+      activeFile === undefined ? [] : [activeFile.path],
+    );
+  }
+
+  return Object.freeze({
+    directory: target.directory,
+    projectName: target.projectName,
+    files: Object.freeze(files.map((file) => file.path)),
+  });
+}

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -1,4 +1,7 @@
-export type PackageManager = "npm" | "pnpm" | "yarn";
+import {
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
 
 export interface StarterFile {
   /** Project-relative POSIX path. */
@@ -11,41 +14,6 @@ export interface CreateStarterFilesOptions {
   readonly invoktaVersion: string;
   readonly packageManager: PackageManager;
 }
-
-const packageManagerCommands = Object.freeze({
-  npm: Object.freeze({
-    check: "npm run check",
-    direct: "npm run direct -- Ada",
-    list: "npm run cli -- list",
-    run: 'npm run cli -- run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
-    stdio: "npm run mcp:stdio",
-  }),
-  pnpm: Object.freeze({
-    check: "pnpm run check",
-    direct: "pnpm run direct Ada",
-    list: "pnpm run cli list",
-    run: 'pnpm run cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
-    stdio: "pnpm run mcp:stdio",
-  }),
-  yarn: Object.freeze({
-    check: "yarn check",
-    direct: "yarn direct Ada",
-    list: "yarn cli list",
-    run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
-    stdio: "yarn mcp:stdio",
-  }),
-} as const satisfies Readonly<
-  Record<
-    PackageManager,
-    Readonly<{
-      check: string;
-      direct: string;
-      list: string;
-      run: string;
-      stdio: string;
-    }>
-  >
->);
 
 function renderReadme(
   projectName: string,

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -1,0 +1,286 @@
+export type PackageManager = "npm" | "pnpm" | "yarn";
+
+export interface StarterFile {
+  /** Project-relative POSIX path. */
+  readonly path: string;
+  readonly contents: string;
+}
+
+export interface CreateStarterFilesOptions {
+  readonly projectName: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+}
+
+const packageManagerCommands = Object.freeze({
+  npm: Object.freeze({
+    check: "npm run check",
+    direct: "npm run direct -- Ada",
+    list: "npm run cli -- list",
+    run: 'npm run cli -- run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "npm run mcp:stdio",
+  }),
+  pnpm: Object.freeze({
+    check: "pnpm run check",
+    direct: "pnpm run direct Ada",
+    list: "pnpm run cli list",
+    run: 'pnpm run cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "pnpm run mcp:stdio",
+  }),
+  yarn: Object.freeze({
+    check: "yarn check",
+    direct: "yarn direct Ada",
+    list: "yarn cli list",
+    run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "yarn mcp:stdio",
+  }),
+} as const satisfies Readonly<
+  Record<
+    PackageManager,
+    Readonly<{
+      check: string;
+      direct: string;
+      list: string;
+      run: string;
+      stdio: string;
+    }>
+  >
+>);
+
+function renderReadme(
+  projectName: string,
+  packageManager: PackageManager,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  return `# ${projectName}
+
+A standalone [Invokta](https://docs.invokta.dev/) Action Engine with one
+deterministic capability shared by direct, CLI, and MCP stdio entry points.
+
+## Validate
+
+\`\`\`sh
+${commands.check}
+\`\`\`
+
+## Invoke directly
+
+\`\`\`sh
+${commands.direct}
+\`\`\`
+
+## Use the CLI
+
+\`\`\`sh
+${commands.list}
+${commands.run}
+\`\`\`
+
+## Start MCP stdio
+
+\`\`\`sh
+${commands.stdio}
+\`\`\`
+
+MCP stdio reserves standard output for protocol messages. Configure a client to
+start the compiled \`dist/mcp-stdio.js\` file directly with Node.
+
+Add stateless HTTP only when needed. Install \`@invokta/deploy\`, run
+\`invokta-deploy init\`, and implement its fail-closed authentication hook before
+exposing the endpoint.
+`;
+}
+
+function renderPackageManifest(
+  projectName: string,
+  invoktaVersion: string,
+): string {
+  const manifest = {
+    name: projectName,
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    engines: { node: ">=22.20.0" },
+    scripts: {
+      build: "tsc -p tsconfig.json --pretty false",
+      typecheck:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit",
+      test: "vitest run",
+      check:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit && vitest run && tsc -p tsconfig.json --pretty false",
+      direct: "node dist/direct.js",
+      cli: "node dist/cli.js",
+      "mcp:stdio": "node dist/mcp-stdio.js",
+    },
+    dependencies: {
+      "@invokta/cli": invoktaVersion,
+      "@invokta/core": invoktaVersion,
+      "@invokta/mcp": invoktaVersion,
+      zod: "4.4.3",
+    },
+    devDependencies: {
+      "@types/node": "26.1.2",
+      typescript: "7.0.2",
+      vitest: "4.1.10",
+    },
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+const capabilityModule = `import { defineCapability } from "@invokta/core";
+import { z } from "zod";
+
+export const createWelcomeMessage = defineCapability({
+  title: "Create a welcome message",
+  description: "Creates a short welcome message for a new team member.",
+  input: z.object({ name: z.string().trim().min(1) }),
+  output: z.object({ message: z.string().min(1) }),
+  access: "public",
+  annotations: {
+    readOnly: true,
+    destructive: false,
+    idempotent: true,
+    openWorld: false,
+  },
+  async run({ input }) {
+    return { message: \`Welcome, \${input.name}!\` };
+  },
+});
+`;
+
+function renderEngineModule(projectName: string): string {
+  return `import { createEngine } from "@invokta/core";
+
+import { createWelcomeMessage } from "./capabilities/create-welcome-message.js";
+
+export const engine = createEngine({
+  name: ${JSON.stringify(projectName)},
+  version: "0.1.0",
+  capabilities: {
+    "onboarding.create-welcome-message": createWelcomeMessage,
+  },
+});
+`;
+}
+
+const cliModule = `import { runCli } from "@invokta/cli";
+
+import { engine } from "./engine.js";
+
+process.exitCode = await runCli(engine, { principal: null });
+`;
+
+const directModule = `import { engine } from "./engine.js";
+
+const name = process.argv.slice(2).join(" ").trim() || "Developer";
+const result = await engine.invoke(
+  "onboarding.create-welcome-message",
+  { name },
+  { source: "direct", principal: null },
+);
+
+process.stdout.write(\`\${JSON.stringify(result)}\\n\`);
+`;
+
+const mcpStdioModule = `import { serveMcpStdio } from "@invokta/mcp";
+
+import { engine } from "./engine.js";
+
+await serveMcpStdio(engine, { principal: null });
+`;
+
+const engineTestModule = `import { describe, expect, it } from "vitest";
+
+import { engine } from "../src/engine.js";
+
+describe("welcome engine", () => {
+  it("creates a validated welcome message", async () => {
+    await expect(
+      engine.invoke(
+        "onboarding.create-welcome-message",
+        { name: "  Ada  " },
+        { principal: null },
+      ),
+    ).resolves.toEqual({ message: "Welcome, Ada!" });
+  });
+
+  it("rejects an empty name", async () => {
+    await expect(
+      engine.invoke(
+        "onboarding.create-welcome-message",
+        { name: "   " },
+        { principal: null },
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+});
+`;
+
+const tsconfig = `{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}
+`;
+
+const tsconfigTest = `{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+`;
+
+/** Returns the complete starter as deterministic, project-relative text files. */
+export function createStarterFiles(
+  options: CreateStarterFilesOptions,
+): readonly StarterFile[] {
+  return Object.freeze([
+    { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
+    {
+      path: "README.md",
+      contents: renderReadme(options.projectName, options.packageManager),
+    },
+    {
+      path: "package.json",
+      contents: renderPackageManifest(
+        options.projectName,
+        options.invoktaVersion,
+      ),
+    },
+    {
+      path: "src/capabilities/create-welcome-message.ts",
+      contents: capabilityModule,
+    },
+    { path: "src/cli.ts", contents: cliModule },
+    { path: "src/direct.ts", contents: directModule },
+    {
+      path: "src/engine.ts",
+      contents: renderEngineModule(options.projectName),
+    },
+    { path: "src/mcp-stdio.ts", contents: mcpStdioModule },
+    { path: "test/engine.test.ts", contents: engineTestModule },
+    { path: "tsconfig.json", contents: tsconfig },
+    { path: "tsconfig.test.json", contents: tsconfigTest },
+  ]);
+}

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -1,0 +1,279 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type CreateEngineIo,
+  type InstallProject,
+  runCreateEngineCli,
+} from "../src/cli.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-creator-cli-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function createHarness(
+  overrides: Partial<CreateEngineIo> = {},
+): CreateEngineIo & { readonly stdout: string[]; readonly stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    writeStdout:
+      overrides.writeStdout ??
+      ((text) => {
+        stdout.push(text);
+      }),
+    writeStderr:
+      overrides.writeStderr ??
+      ((text) => {
+        stderr.push(text);
+      }),
+  };
+}
+
+const invalidArgumentCases: readonly Readonly<{
+  argv: readonly string[];
+}>[] = [
+  { argv: [] },
+  { argv: ["my-engine", "other-engine"] },
+  { argv: ["my-engine", "--unknown"] },
+  { argv: ["my-engine", "--no-install", "--no-install"] },
+  { argv: ["my-engine", "--package-manager"] },
+  { argv: ["my-engine", "--package-manager", "bun"] },
+  {
+    argv: [
+      "my-engine",
+      "--package-manager",
+      "npm",
+      "--package-manager",
+      "pnpm",
+    ],
+  },
+  { argv: ["--help", "my-engine"] },
+  { argv: ["--version", "fixture-secret-payload-marker"] },
+];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("runCreateEngineCli", () => {
+  it("creates without installing when --no-install is present", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+    const install = vi.fn<InstallProject>();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["my-engine", "--no-install"],
+      cwd,
+      env: {},
+      io,
+      install,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(install).not.toHaveBeenCalled();
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout.join("")).toBe(
+      "Created my-engine without installing dependencies.\n\n" +
+        "Next steps:\n" +
+        "  npm install --no-audit --no-fund\n" +
+        "  npm run check\n",
+    );
+    expect(
+      JSON.parse(readFileSync(join(cwd, "my-engine/package.json"), "utf8")),
+    ).toMatchObject({
+      name: "my-engine",
+      dependencies: { "@invokta/core": "1.2.3" },
+    });
+  });
+
+  it("installs once after the complete scaffold using the inferred manager", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+    const install = vi.fn<InstallProject>(
+      async ({ directory, packageManager }) => {
+        expect(packageManager).toBe("pnpm");
+        expect(existsSync(join(directory, "src/engine.ts"))).toBe(true);
+      },
+    );
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["my-engine"],
+      cwd,
+      env: { npm_config_user_agent: "pnpm/10.14.0 npm/? node/v22.20.0" },
+      io,
+      install,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(install).toHaveBeenCalledOnce();
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout.join("")).toBe(
+      "Created my-engine.\n\nNext step:\n  pnpm run check\n",
+    );
+  });
+
+  it("uses an explicit package manager instead of the inferred manager", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+    const install = vi.fn<InstallProject>(async () => undefined);
+
+    await runCreateEngineCli({
+      argv: ["--package-manager", "yarn", "my-engine"],
+      cwd,
+      env: { npm_config_user_agent: "pnpm/10.14.0" },
+      io,
+      install,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(install).toHaveBeenCalledWith({
+      directory: join(cwd, "my-engine"),
+      packageManager: "yarn",
+    });
+    expect(readFileSync(join(cwd, "my-engine/README.md"), "utf8")).toContain(
+      "yarn check",
+    );
+  });
+
+  it("preserves the complete scaffold when installation fails", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["my-engine"],
+      cwd,
+      env: {},
+      io,
+      install: async () => {
+        const { CreatorError } = await import("../src/errors.js");
+        throw new CreatorError("INSTALL_FAILED", ["npm"]);
+      },
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(1);
+    expect(io.stdout).toEqual([]);
+    expect(io.stderr.join("")).toBe(
+      "INSTALL_FAILED: The project dependencies could not be installed.\n" +
+        "  npm\n",
+    );
+    expect(existsSync(join(cwd, "my-engine/package.json"))).toBe(true);
+    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(7);
+  });
+
+  it.each(invalidArgumentCases)(
+    "rejects invalid arguments without creating a project: $argv",
+    async ({ argv }) => {
+      const cwd = createWorkingDirectory();
+      const io = createHarness();
+      const install = vi.fn<InstallProject>();
+
+      const exitCode = await runCreateEngineCli({
+        argv,
+        cwd,
+        env: {},
+        io,
+        install,
+      });
+
+      expect(exitCode).toBe(2);
+      expect(io.stdout).toEqual([]);
+      expect(io.stderr).toEqual([
+        'Invalid arguments. Run "create-invokta-engine --help".\n',
+      ]);
+      expect(io.stderr.join("")).not.toContain("fixture-secret-payload-marker");
+      expect(install).not.toHaveBeenCalled();
+      expect(readdirSync(cwd)).toEqual([]);
+    },
+  );
+
+  it("prints help without loading the package version", async () => {
+    const io = createHarness();
+    const loadPackageVersion = vi.fn<() => Promise<string>>();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["--help"],
+      io,
+      loadPackageVersion,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(loadPackageVersion).not.toHaveBeenCalled();
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout.join("")).toContain(
+      "create-invokta-engine <project-directory>",
+    );
+  });
+
+  it("prints the loaded package version", async () => {
+    const io = createHarness();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["--version"],
+      io,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout).toEqual(["1.2.3\n"]);
+  });
+
+  it("renders a target error without echoing the rejected path", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["../fixture-secret-payload-marker", "--no-install"],
+      cwd,
+      io,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(2);
+    expect(io.stdout).toEqual([]);
+    expect(io.stderr.join("")).toBe(
+      "TARGET_INVALID: The project path or name is invalid.\n",
+    );
+    expect(io.stderr.join("")).not.toContain("fixture-secret-payload-marker");
+  });
+
+  it("contains a rejected diagnostic writer", async () => {
+    const cwd = createWorkingDirectory();
+    writeFileSync(join(cwd, "sentinel"), "mine\n", "utf8");
+    const io = createHarness({
+      writeStderr: async () => {
+        throw new Error("closed diagnostic stream");
+      },
+    });
+
+    await expect(
+      runCreateEngineCli({
+        argv: ["my-engine", "--unknown"],
+        cwd,
+        io,
+      }),
+    ).resolves.toBe(2);
+  });
+});

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -152,8 +152,9 @@ describe("runCreateEngineCli", () => {
       packageManager: "yarn",
     });
     expect(readFileSync(join(cwd, "my-engine/README.md"), "utf8")).toContain(
-      "yarn check",
+      "yarn run check",
     );
+    expect(io.stdout.join("")).toContain("yarn run check");
   });
 
   it("preserves the complete scaffold when installation fails", async () => {

--- a/packages/create-invokta-engine/test/install.test.ts
+++ b/packages/create-invokta-engine/test/install.test.ts
@@ -86,4 +86,23 @@ describe("installProjectDependencies", () => {
       message: "The project dependencies could not be installed.",
     });
   });
+
+  it("normalizes a package-manager signal as an installation failure", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => ({
+      code: null,
+      signal: "SIGINT",
+    }));
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: "npm",
+        runner,
+      }),
+    ).rejects.toMatchObject({
+      code: "INSTALL_FAILED",
+      exitCode: 1,
+      details: ["npm"],
+    });
+  });
 });

--- a/packages/create-invokta-engine/test/install.test.ts
+++ b/packages/create-invokta-engine/test/install.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CreatorError } from "../src/errors.js";
+import {
+  installProjectDependencies,
+  type PackageManagerRunner,
+  selectPackageManager,
+} from "../src/install.js";
+
+describe("selectPackageManager", () => {
+  it.each([
+    ["npm/11.0.0 node/v22.20.0", "npm"],
+    ["pnpm/10.14.0 npm/? node/v22.20.0", "pnpm"],
+    ["yarn/1.22.22 npm/? node/v22.20.0", "yarn"],
+    [undefined, "npm"],
+    ["unknown/1.0.0", "npm"],
+  ] as const)("selects %s as %s", (userAgent, expected) => {
+    expect(selectPackageManager(undefined, userAgent)).toBe(expected);
+  });
+
+  it("gives an explicit package manager precedence over the user agent", () => {
+    expect(selectPackageManager("yarn", "pnpm/10.14.0")).toBe("yarn");
+  });
+});
+
+describe("installProjectDependencies", () => {
+  it.each([
+    ["npm", "npm", ["install", "--no-audit", "--no-fund"]],
+    ["pnpm", "pnpm", ["install"]],
+    ["yarn", "yarn", ["install"]],
+  ] as const)(
+    "runs one shell-free %s install",
+    async (manager, command, args) => {
+      const runner = vi.fn<PackageManagerRunner>(async () => ({
+        code: 0,
+        signal: null,
+      }));
+
+      await installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: manager,
+        runner,
+      });
+
+      expect(runner).toHaveBeenCalledOnce();
+      expect(runner).toHaveBeenCalledWith({
+        command,
+        args,
+        cwd: "/work/my-engine",
+        shell: false,
+        stdio: "inherit",
+      });
+    },
+  );
+
+  it("normalizes a non-zero child result without exposing child output", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => ({
+      code: 17,
+      signal: null,
+    }));
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: "pnpm",
+        runner,
+      }),
+    ).rejects.toEqual(new CreatorError("INSTALL_FAILED", ["pnpm"]));
+  });
+
+  it("normalizes an unavailable package manager", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => {
+      throw new Error("fixture secret from spawn");
+    });
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: "yarn",
+        runner,
+      }),
+    ).rejects.toMatchObject({
+      code: "INSTALL_FAILED",
+      exitCode: 1,
+      details: ["yarn"],
+      message: "The project dependencies could not be installed.",
+    });
+  });
+});

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -1,0 +1,231 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CreatorError } from "../src/errors.js";
+import {
+  createStarterProject,
+  defaultScaffoldFileSystem,
+  type ScaffoldFileSystem,
+} from "../src/scaffold.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-creator-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function createProject(cwd: string, target = "my-engine") {
+  return createStarterProject({
+    cwd,
+    target,
+    invoktaVersion: "1.2.3",
+    packageManager: "npm",
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("createStarterProject", () => {
+  it("creates a complete project in an absent nested target", async () => {
+    const cwd = createWorkingDirectory();
+
+    const result = await createProject(cwd, "engines/my-engine");
+
+    expect(result.projectName).toBe("my-engine");
+    expect(result.directory).toBe(join(cwd, "engines/my-engine"));
+    expect(result.files).toHaveLength(11);
+    expect(
+      JSON.parse(readFileSync(join(result.directory, "package.json"), "utf8")),
+    ).toMatchObject({ name: "my-engine", private: true });
+  });
+
+  it("creates the starter in an existing empty directory", async () => {
+    const cwd = createWorkingDirectory();
+    mkdirSync(join(cwd, "my-engine"));
+
+    await createProject(cwd);
+
+    expect(readdirSync(join(cwd, "my-engine")).sort()).toEqual([
+      ".gitignore",
+      "README.md",
+      "package.json",
+      "src",
+      "test",
+      "tsconfig.json",
+      "tsconfig.test.json",
+    ]);
+  });
+
+  it("accepts dot only for a valid empty working-directory name", async () => {
+    const parent = createWorkingDirectory();
+    const cwd = join(parent, "current-engine");
+    mkdirSync(cwd);
+
+    const result = await createProject(cwd, ".");
+
+    expect(result.directory).toBe(cwd);
+    expect(result.projectName).toBe("current-engine");
+  });
+
+  it("rejects a non-empty target without changing it", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    mkdirSync(target);
+    writeFileSync(join(target, ".keep"), "mine\n", "utf8");
+
+    await expect(createProject(cwd)).rejects.toMatchObject({
+      code: "TARGET_NOT_EMPTY",
+      exitCode: 1,
+    });
+    expect(readFileSync(join(target, ".keep"), "utf8")).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".keep"]);
+  });
+
+  it.each([
+    ["an absolute path", "/tmp/my-engine"],
+    ["a parent segment", "../my-engine"],
+    ["a nested parent segment", "engines/../my-engine"],
+    ["an invalid package name", "My Engine"],
+    ["an empty name segment", "engines//my-engine"],
+    ["too many segments", `${"nested/".repeat(32)}my-engine`],
+    ["too many scalars", `${"a".repeat(1_025)}-engine`],
+  ])("rejects %s before creating a target", async (_label, target) => {
+    const cwd = createWorkingDirectory();
+
+    await expect(createProject(cwd, target)).rejects.toMatchObject({
+      code: "TARGET_INVALID",
+      exitCode: 2,
+    });
+    expect(readdirSync(cwd)).toEqual([]);
+  });
+
+  it("rejects a symbolic-link target without following it", async () => {
+    const cwd = createWorkingDirectory();
+    const outside = createWorkingDirectory();
+    symlinkSync(outside, join(cwd, "my-engine"), "dir");
+
+    await expect(createProject(cwd)).rejects.toMatchObject({
+      code: "TARGET_UNSAFE",
+      exitCode: 1,
+    });
+    expect(readdirSync(outside)).toEqual([]);
+  });
+
+  it("rejects a symbolic-link parent without following it", async () => {
+    const cwd = createWorkingDirectory();
+    const outside = createWorkingDirectory();
+    symlinkSync(outside, join(cwd, "engines"), "dir");
+
+    await expect(createProject(cwd, "engines/my-engine")).rejects.toMatchObject(
+      {
+        code: "TARGET_UNSAFE",
+        exitCode: 1,
+      },
+    );
+    expect(readdirSync(outside)).toEqual([]);
+  });
+
+  it("preserves a file that wins an exclusive-write race", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    let raced = false;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        if (!raced) {
+          raced = true;
+          writeFileSync(path, "mine\n", "utf8");
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
+    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".gitignore"]);
+  });
+
+  it("rolls back only paths created by a failed scaffold write", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    mkdirSync(target);
+    let writes = 0;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        writes += 1;
+        if (writes === 3) {
+          const error = new Error(
+            "fixture write failure",
+          ) as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toBeInstanceOf(CreatorError);
+    expect(existsSync(target)).toBe(true);
+    expect(readdirSync(target)).toEqual([]);
+  });
+
+  it("removes an absent target root after a failed scaffold write", async () => {
+    const cwd = createWorkingDirectory();
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile() {
+        const error = new Error(
+          "fixture write failure",
+        ) as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "nested/my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "WRITE_FAILED", exitCode: 1 });
+    expect(existsSync(join(cwd, "nested"))).toBe(false);
+  });
+});

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -85,6 +85,30 @@ describe("createStarterProject", () => {
     expect(result.projectName).toBe("current-engine");
   });
 
+  it("accepts the inclusive project-name limit", async () => {
+    const cwd = createWorkingDirectory();
+    const projectName = "a".repeat(214);
+
+    const result = await createProject(cwd, projectName);
+
+    expect(result.projectName).toBe(projectName);
+    expect(existsSync(join(result.directory, "package.json"))).toBe(true);
+  });
+
+  it("accepts the inclusive path-scalar and segment limits", async () => {
+    const cwd = createWorkingDirectory();
+    const target = [
+      ...Array.from({ length: 31 }, () => "a".repeat(31)),
+      "b".repeat(32),
+    ].join("/");
+    expect([...target]).toHaveLength(1_024);
+
+    const result = await createProject(cwd, target);
+
+    expect(result.projectName).toBe("b".repeat(32));
+    expect(existsSync(join(result.directory, "package.json"))).toBe(true);
+  });
+
   it("rejects a non-empty target without changing it", async () => {
     const cwd = createWorkingDirectory();
     const target = join(cwd, "my-engine");
@@ -105,6 +129,7 @@ describe("createStarterProject", () => {
     ["a nested parent segment", "engines/../my-engine"],
     ["an invalid package name", "My Engine"],
     ["an empty name segment", "engines//my-engine"],
+    ["a project name over 214 characters", "a".repeat(215)],
     ["too many segments", `${"nested/".repeat(32)}my-engine`],
     ["too many scalars", `${"a".repeat(1_025)}-engine`],
   ])("rejects %s before creating a target", async (_label, target) => {
@@ -127,6 +152,17 @@ describe("createStarterProject", () => {
       exitCode: 1,
     });
     expect(readdirSync(outside)).toEqual([]);
+  });
+
+  it("rejects a non-directory target without replacing it", async () => {
+    const cwd = createWorkingDirectory();
+    writeFileSync(join(cwd, "my-engine"), "mine\n", "utf8");
+
+    await expect(createProject(cwd)).rejects.toMatchObject({
+      code: "TARGET_UNSAFE",
+      exitCode: 1,
+    });
+    expect(readFileSync(join(cwd, "my-engine"), "utf8")).toBe("mine\n");
   });
 
   it("rejects a symbolic-link parent without following it", async () => {

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { createStarterFiles } from "../src/starter.js";
+
+const expectedPaths = [
+  ".gitignore",
+  "README.md",
+  "package.json",
+  "src/capabilities/create-welcome-message.ts",
+  "src/cli.ts",
+  "src/direct.ts",
+  "src/engine.ts",
+  "src/mcp-stdio.ts",
+  "test/engine.test.ts",
+  "tsconfig.json",
+  "tsconfig.test.json",
+] as const;
+
+describe("createStarterFiles", () => {
+  it("renders the fixed standalone starter in lexicographic path order", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+
+    expect(files.map((file) => file.path)).toEqual(expectedPaths);
+    expect(files).toEqual(
+      createStarterFiles({
+        projectName: "customer-support-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    );
+    for (const file of files) {
+      expect(file.contents).not.toContain("\r");
+      expect(file.contents).not.toContain("\u0000");
+      expect(file.contents.endsWith("\n")).toBe(true);
+      expect(file.contents.endsWith("\n\n")).toBe(false);
+    }
+  });
+
+  it("pins Invokta packages to the creator version in a private ESM project", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3-beta.1",
+      packageManager: "npm",
+    });
+    const manifestFile = files.find((file) => file.path === "package.json");
+    const manifest = JSON.parse(manifestFile?.contents ?? "") as Record<
+      string,
+      unknown
+    >;
+
+    expect(manifest).toMatchObject({
+      name: "customer-support-engine",
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      engines: { node: ">=22.20.0" },
+      dependencies: {
+        "@invokta/cli": "1.2.3-beta.1",
+        "@invokta/core": "1.2.3-beta.1",
+        "@invokta/mcp": "1.2.3-beta.1",
+        zod: "4.4.3",
+      },
+      devDependencies: {
+        "@types/node": "26.1.2",
+        typescript: "7.0.2",
+        vitest: "4.1.10",
+      },
+    });
+  });
+
+  it("uses one public capability through direct, CLI, and MCP stdio entry points", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+    const contents = new Map(files.map((file) => [file.path, file.contents]));
+
+    expect(
+      contents.get("src/capabilities/create-welcome-message.ts"),
+    ).toContain('access: "public"');
+    expect(contents.get("src/engine.ts")).toContain(
+      '"onboarding.create-welcome-message": createWelcomeMessage',
+    );
+    expect(contents.get("src/engine.ts")).toContain(
+      'name: "customer-support-engine"',
+    );
+    expect(contents.get("src/direct.ts")).toContain("engine.invoke(");
+    expect(contents.get("src/cli.ts")).toContain("runCli(engine");
+    expect(contents.get("src/mcp-stdio.ts")).toContain("serveMcpStdio(engine");
+    expect([...contents.keys()]).not.toContain("src/mcp-http.ts");
+  });
+
+  it.each([
+    ["npm", "npm run check"],
+    ["pnpm", "pnpm run check"],
+    ["yarn", "yarn check"],
+  ] as const)(
+    "renders %s commands in the generated README",
+    (manager, command) => {
+      const files = createStarterFiles({
+        projectName: "customer-support-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: manager,
+      });
+
+      expect(
+        files.find((file) => file.path === "README.md")?.contents,
+      ).toContain(command);
+    },
+  );
+});

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -98,7 +98,7 @@ describe("createStarterFiles", () => {
   it.each([
     ["npm", "npm run check"],
     ["pnpm", "pnpm run check"],
-    ["yarn", "yarn check"],
+    ["yarn", "yarn run check"],
   ] as const)(
     "renders %s commands in the generated README",
     (manager, command) => {

--- a/packages/create-invokta-engine/tsconfig.json
+++ b/packages/create-invokta-engine/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -17,6 +18,7 @@ const temporaryRoot = mkdtempSync(join(tmpdir(), "invokta-release-verify-"));
 const checkoutDirectory = join(temporaryRoot, "checkout");
 const artifactDirectory = join(temporaryRoot, "artifacts");
 const consumerDirectory = join(temporaryRoot, "consumer");
+const generatedDirectory = join(temporaryRoot, "generated");
 const distEntryFiles = ["dist/index.js", "dist/index.d.ts"];
 const repositoryUrl = "git+https://github.com/vinilana/invokta.git";
 const issuesUrl = "https://github.com/vinilana/invokta/issues";
@@ -47,6 +49,12 @@ const publicPackages = [
     name: "@invokta/deploy",
     // The toolkit ships both an import API and the `invokta-deploy` executable.
     requiredFiles: [...distEntryFiles, "dist/bin.js"],
+  },
+  {
+    directory: "create-invokta-engine",
+    name: "create-invokta-engine",
+    // The creator is binary-only and ships no import API.
+    requiredFiles: ["dist/bin.js"],
   },
 ];
 
@@ -194,10 +202,102 @@ function verifyChangelog(changelog, releaseVersion) {
   }
 }
 
+function writeGeneratedMcpSmoke(projectDirectory) {
+  const program = `
+    import assert from "node:assert/strict";
+    import { spawn } from "node:child_process";
+    import { createInterface } from "node:readline";
+
+    const child = spawn(process.execPath, ["dist/mcp-stdio.js"], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+    const iterator = lines[Symbol.asyncIterator]();
+    const childError = new Promise((_, reject) => child.once("error", reject));
+    const childExit = new Promise((resolve) =>
+      child.once("exit", (code, signal) => resolve({ code, signal })),
+    );
+
+    function withTimeout(promise, label) {
+      let timer;
+      const timeout = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(label)), 5_000);
+      });
+      return Promise.race([promise, childError, timeout]).finally(() =>
+        clearTimeout(timer),
+      );
+    }
+
+    async function nextMessage() {
+      const result = await withTimeout(
+        Promise.race([
+          iterator.next(),
+          childExit.then(() => {
+            throw new Error("MCP server exited before its response");
+          }),
+        ]),
+        "MCP response timed out",
+      );
+      if (result.done) throw new Error("MCP stdout ended before its response");
+      return JSON.parse(result.value);
+    }
+
+    function send(message) {
+      child.stdin.write(\`\${JSON.stringify(message)}\\n\`);
+    }
+
+    try {
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "creator-release-smoke", version: "0.0.0-test" },
+        },
+      });
+      const initialized = await nextMessage();
+      assert.equal(initialized.id, 1);
+      assert.equal(initialized.result.serverInfo.name, "release-engine");
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "onboarding.create-welcome-message",
+          arguments: { name: "Ada" },
+        },
+      });
+      const called = await nextMessage();
+      assert.equal(called.id, 2);
+      assert.deepEqual(called.result.structuredContent, {
+        message: "Welcome, Ada!",
+      });
+      child.stdin.end();
+      const result = await withTimeout(childExit, "MCP server exit timed out");
+      assert.equal(result.code, 0);
+      assert.equal(result.signal, null);
+      assert.equal(stderr, "");
+    } finally {
+      lines.close();
+      if (child.exitCode === null && child.signalCode === null) child.kill();
+    }
+  `;
+  writeFileSync(join(projectDirectory, "mcp-smoke.mjs"), program);
+}
+
 try {
   mkdirSync(checkoutDirectory);
   mkdirSync(artifactDirectory);
   mkdirSync(consumerDirectory);
+  mkdirSync(generatedDirectory);
 
   const indexTree = execFileSync("git", ["write-tree"], {
     cwd: repositoryRoot,
@@ -227,6 +327,7 @@ try {
   );
 
   const tarballs = [];
+  const tarballsByName = new Map();
 
   for (const publicPackage of publicPackages) {
     const packageDirectory = join(
@@ -270,7 +371,9 @@ try {
       }
     }
 
-    tarballs.push(join(artifactDirectory, report.filename));
+    const tarball = join(artifactDirectory, report.filename);
+    tarballs.push(tarball);
+    tarballsByName.set(publicPackage.name, tarball);
   }
 
   writeFileSync(
@@ -332,6 +435,99 @@ try {
   const networkSentinel = pathToFileURL(
     join(sentinelDirectory, "forbid-network-access.mjs"),
   ).href;
+
+  const creatorCommand = join(
+    consumerDirectory,
+    "node_modules",
+    ".bin",
+    "create-invokta-engine",
+  );
+  const creatorVersion = run(creatorCommand, ["--version"], {
+    cwd: generatedDirectory,
+    capture: true,
+    env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+  });
+  if (creatorVersion !== `${releaseVersion}\n`) {
+    throw new Error("creator binary version smoke failed");
+  }
+  const creatorOutput = run(
+    creatorCommand,
+    ["release-engine", "--package-manager", "npm", "--no-install"],
+    {
+      cwd: generatedDirectory,
+      capture: true,
+      env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+    },
+  );
+  if (!creatorOutput.startsWith("Created release-engine without installing")) {
+    throw new Error("creator scaffold smoke failed");
+  }
+
+  const generatedProjectDirectory = join(generatedDirectory, "release-engine");
+  const generatedManifest = JSON.parse(
+    readFileSync(join(generatedProjectDirectory, "package.json"), "utf8"),
+  );
+  for (const packageName of ["@invokta/core", "@invokta/cli", "@invokta/mcp"]) {
+    if (generatedManifest.dependencies?.[packageName] !== releaseVersion) {
+      throw new Error(
+        `generated ${packageName} version is not release-aligned`,
+      );
+    }
+  }
+  if (existsSync(join(generatedProjectDirectory, "src", "mcp-http.ts"))) {
+    throw new Error("creator unexpectedly generated an HTTP entry point");
+  }
+
+  const generatedRuntimeTarballs = [
+    tarballsByName.get("@invokta/core"),
+    tarballsByName.get("@invokta/cli"),
+    tarballsByName.get("@invokta/mcp"),
+  ];
+  if (generatedRuntimeTarballs.some((tarball) => tarball === undefined)) {
+    throw new Error("generated consumer tarballs are incomplete");
+  }
+  run(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      ...generatedRuntimeTarballs,
+    ],
+    { cwd: generatedProjectDirectory },
+  );
+  run("npm", ["run", "--silent", "check"], {
+    cwd: generatedProjectDirectory,
+  });
+
+  const directResult = run("npm", ["run", "--silent", "direct", "--", "Ada"], {
+    cwd: generatedProjectDirectory,
+    capture: true,
+  });
+  if (directResult !== '{"message":"Welcome, Ada!"}\n') {
+    throw new Error("generated direct entry point smoke failed");
+  }
+  const cliResult = run(
+    "npm",
+    [
+      "run",
+      "--silent",
+      "cli",
+      "--",
+      "run",
+      "onboarding.create-welcome-message",
+      "--input",
+      '{"name":"Ada"}',
+    ],
+    { cwd: generatedProjectDirectory, capture: true },
+  );
+  if (cliResult !== '{"message":"Welcome, Ada!"}\n') {
+    throw new Error("generated CLI entry point smoke failed");
+  }
+  writeGeneratedMcpSmoke(generatedProjectDirectory);
+  run("node", ["mcp-smoke.mjs"], { cwd: generatedProjectDirectory });
+
   const installerVersion = run(installerCommand, ["--version"], {
     cwd: consumerDirectory,
     capture: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./packages/cli" },
     { "path": "./packages/mcp" },
     { "path": "./packages/deploy" },
+    { "path": "./packages/create-invokta-engine" },
     { "path": "./packages/installer" },
     { "path": "./packages/tooling" },
     { "path": "./examples/community-capabilities" },


### PR DESCRIPTION
## Summary

- add the binary-only `create-invokta-engine` package and the `npm create invokta-engine@latest` initializer
- generate a deterministic standalone TypeScript Action Engine with direct, CLI, and MCP stdio entrypoints
- add bounded target validation, non-overwriting writes, rollback, npm/pnpm/Yarn installs, and `--no-install`
- document ADR 0012, package/reference usage, and extend release verification with a generated-consumer smoke test

## Why

Engine authors currently assemble standalone projects manually or adapt the repository-local hello example. This introduces one Invokta-owned bootstrap path without changing the runtime or duplicating `@invokta/deploy`'s HTTP and authentication responsibility.

## Impact

New projects can be created with:

```sh
npm create invokta-engine@latest my-engine
```

The generated project pins Invokta packages to the creator version and exposes one capability through the shared `engine.invoke` path. Existing projects and public runtime packages are unchanged.

## Validation

- `yarn vitest run packages/create-invokta-engine/test` — 55 passed
- `yarn typecheck`
- tracked-file Biome lint and format checks — 449 files
- `yarn test:run` — 3,091 passed, 2 skipped
- `yarn build`
- `yarn --cwd apps/docs validate`
- `yarn release:verify` — packed creator plus generated direct, CLI, and MCP stdio consumer smoke tests

## Note

The existing untracked `.claude/` directory is intentionally excluded. Its nested Biome configuration prevents the root `yarn run check` wrapper from completing locally, so the same constituent gates were run against tracked repository files.