### PR TITLE
feat: install and manage Action Engines as MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added `create-invokta-engine`, a non-interactive standalone engine creator with
+  deterministic, non-overwriting scaffolding and npm, pnpm, and Yarn installation.
+
 ## [0.1.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Added `create-invokta-engine`, a non-interactive standalone engine creator with
   deterministic, non-overwriting scaffolding and npm, pnpm, and Yarn installation.
+- Added one-command local Action Engine installation through the generated
+  `mcp:install` script and strict `invokta.mcp.json` manifest.
+- Added confirmed, transactional multi-client installation with independent
+  per-target results, idempotent reruns, drift detection, and rollback.
+- Added interactive `status`, `enable`, `disable`, and `remove` commands for
+  installer-managed MCP entries.
+- Added offline registration of explicit Streamable HTTP endpoints with
+  environment-variable credential references.
+- Added VS Code user-profile and Claude Desktop macOS targets, bringing the
+  catalog to eleven configuration targets across twelve executable surfaces.
+
+### Security
+
+- Local installation validates owned, no-follow project paths and never imports,
+  executes, or reflects on the engine during discovery.
+- Remote installation performs no network request and rejects embedded
+  credentials, queries, fragments, noncanonical routes, and non-loopback HTTP.
+- Client updates use bounded locks, atomic replacements, per-target state, and
+  exact configuration rollback when a state commit fails.
 
 ## [0.1.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ and delivery adapters:
   local MCP client targets without changing their configuration;
 - `@invokta/deploy` scaffolds and packages stateless HTTP engines and probes
   deployed endpoints.
+- `create-invokta-engine` creates a standalone starter with direct, CLI, and MCP
+  stdio entry points.
 
 Invokta does not provide identity, model routing, an agent harness, a
 workflow engine, or a production observability platform. Custom engines inject
@@ -103,6 +105,16 @@ their own model, data, tool, authentication, and authorization integrations.
 ## Start here
 
 Requirements: Node.js 22.20.0 or later and Yarn 1.22.22.
+
+Create a standalone engine:
+
+```sh
+npm create invokta-engine@latest my-engine
+cd my-engine
+npm run check
+```
+
+To work on Invokta itself:
 
 ```sh
 yarn install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ and delivery adapters:
 - `@invokta/mcp` publishes capabilities as tools over stdio and secure
   stateless HTTP while keeping the official MCP SDK behind the adapter boundary;
 - `@invokta/tooling` validates composed capabilities during development;
-- `@invokta/installer` currently provides a read-only inventory of supported
-  local MCP client targets without changing their configuration;
+- `@invokta/installer` detects supported local MCP clients, installs local or
+  remote Action Engines across selected clients, and manages those entries;
 - `@invokta/deploy` scaffolds and packages stateless HTTP engines and probes
   deployed endpoints.
 - `create-invokta-engine` creates a standalone starter with direct, CLI, and MCP
@@ -112,7 +112,13 @@ Create a standalone engine:
 npm create invokta-engine@latest my-engine
 cd my-engine
 npm run check
+npm run mcp:install
 ```
+
+`mcp:install` builds the generated engine, detects eligible MCP clients,
+preselects them, and asks for one confirmation before updating their user
+configuration. See the [installer reference](./apps/docs/src/content/docs/reference/installer.mdx)
+for remote HTTP registration and lifecycle commands.
 
 To work on Invokta itself:
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -95,6 +95,7 @@ export default defineConfig({
             { slug: "reference/tooling" },
             { slug: "reference/installer" },
             { slug: "reference/deploy" },
+            { slug: "reference/create-invokta-engine" },
             { slug: "reference/errors" },
           ],
         },

--- a/apps/docs/src/content/docs/concepts/scope-and-limits.mdx
+++ b/apps/docs/src/content/docs/concepts/scope-and-limits.mdx
@@ -22,7 +22,7 @@ host owns identity and deployment controls.
 | Authorization | Enforcement of each capability's `access` rule | Roles, scopes, tenants, PDP integration, and domain policy |
 | Observability | Payload-free `onEvent` lifecycle hook and logger | Metrics, tracing, storage, alerts, costs, and domain measurements |
 | AI behavior | Replaceable implementation boundary | Prompts, models, retrieval, tools, evidence, evaluations, and review |
-| Supporting tools | Engine creator, composition checker, read-only client inventory, deployment artifact generator | Review, approval, execution, and operational authority |
+| Supporting tools | Engine creator, composition checker, confirmed MCP client configuration, deployment artifact generator | Engine execution, client policy, and operational authority |
 
 ## Deliberately outside the runtime
 

--- a/apps/docs/src/content/docs/concepts/scope-and-limits.mdx
+++ b/apps/docs/src/content/docs/concepts/scope-and-limits.mdx
@@ -22,7 +22,7 @@ host owns identity and deployment controls.
 | Authorization | Enforcement of each capability's `access` rule | Roles, scopes, tenants, PDP integration, and domain policy |
 | Observability | Payload-free `onEvent` lifecycle hook and logger | Metrics, tracing, storage, alerts, costs, and domain measurements |
 | AI behavior | Replaceable implementation boundary | Prompts, models, retrieval, tools, evidence, evaluations, and review |
-| Supporting tools | Composition checker, read-only client inventory, deployment artifact generator | Review, approval, execution, and operational authority |
+| Supporting tools | Engine creator, composition checker, read-only client inventory, deployment artifact generator | Review, approval, execution, and operational authority |
 
 ## Deliberately outside the runtime
 

--- a/apps/docs/src/content/docs/getting-started/first-engine.mdx
+++ b/apps/docs/src/content/docs/getting-started/first-engine.mdx
@@ -8,6 +8,10 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 This guide creates a small onboarding capability. It stays deterministic so you
 can inspect the Invokta boundary before connecting a model or another provider.
 
+Generate the complete standalone version with `npm create
+invokta-engine@latest my-engine`, or follow the steps below to assemble the same
+boundary manually.
+
 <Steps>
 
 1. Define the capability

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -41,6 +41,20 @@ with direct, CLI, and MCP stdio entry points. Use `--no-install` for an offline
 scaffold. See the [`create-invokta-engine` reference](/reference/create-invokta-engine/)
 for target, package-manager, and failure behavior.
 
+After validating the generated project, install its MCP server in detected
+clients with one command:
+
+```sh
+cd my-engine
+npm run check
+npm run mcp:install
+```
+
+The script builds first, preselects every eligible client, and requires one
+confirmation before writing user configuration. See the
+[installer reference](/reference/installer/) for supported clients, remote HTTP
+registration, and lifecycle management.
+
 ## Install the core
 
 <Tabs syncKey="package-manager">
@@ -89,7 +103,7 @@ Install the CLI or MCP adapter when the engine needs that boundary.
 | `@invokta/cli` | `list`, `describe`, and `run` commands |
 | `@invokta/mcp` | MCP tools over stdio or stateless Streamable HTTP |
 | `@invokta/tooling` | Capability-composition checks during development |
-| `@invokta/installer` | Read-only inventory of supported local MCP client targets in its current release |
+| `@invokta/installer` | Install and manage local or remote Action Engine MCP servers in supported clients |
 | `@invokta/deploy` | Reviewable container packaging and endpoint probes |
 | `create-invokta-engine` | Standalone starter Action Engine creation |
 

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -16,6 +16,31 @@ install only the adapters and development tools your engine uses.
 
 The examples use Zod 4 because it implements both schema contracts.
 
+## Create a standalone engine
+
+<Tabs syncKey="package-manager">
+  <TabItem label="npm">
+    ```sh
+    npm create invokta-engine@latest my-engine
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```sh
+    pnpm create invokta-engine my-engine
+    ```
+  </TabItem>
+  <TabItem label="Yarn">
+    ```sh
+    yarn create invokta-engine my-engine
+    ```
+  </TabItem>
+</Tabs>
+
+The creator installs dependencies and generates a deterministic public capability
+with direct, CLI, and MCP stdio entry points. Use `--no-install` for an offline
+scaffold. See the [`create-invokta-engine` reference](/reference/create-invokta-engine/)
+for target, package-manager, and failure behavior.
+
 ## Install the core
 
 <Tabs syncKey="package-manager">
@@ -66,6 +91,7 @@ Install the CLI or MCP adapter when the engine needs that boundary.
 | `@invokta/tooling` | Capability-composition checks during development |
 | `@invokta/installer` | Read-only inventory of supported local MCP client targets in its current release |
 | `@invokta/deploy` | Reviewable container packaging and endpoint probes |
+| `create-invokta-engine` | Standalone starter Action Engine creation |
 
 <Aside type="note" title="ESM only">
   Invokta publishes native ESM entry points. Use `import` syntax and include file

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -1,0 +1,126 @@
+---
+title: 'create-invokta-engine'
+description: Complete command, generated-project, filesystem, package-manager, and diagnostic contract for the Invokta engine creator.
+---
+
+`create-invokta-engine` creates one standalone TypeScript Action Engine with a
+public capability shared by direct invocation, the Invokta CLI adapter, and MCP
+stdio. It is a binary-only development package, not a runtime adapter or template
+framework.
+
+## Install
+
+Run the current release without adding it to an existing project:
+
+```sh
+npm create invokta-engine@latest my-engine
+```
+
+The package is native ESM and requires Node.js 22.20.0 or later. The npm
+initializer maps `invokta-engine` to the `create-invokta-engine` package and
+executable.
+
+## Commands
+
+```text
+create-invokta-engine <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+Creation is non-interactive. Options may appear before or after the one project
+directory. `--package-manager` accepts a separate `npm`, `pnpm`, or `yarn` value;
+duplicates, unknown options, `--option=value`, or another positional are invalid.
+
+## Target contract
+
+The project directory is relative to the current working directory. Absolute
+paths and `..` segments are rejected. `.` is accepted when the current directory
+has a valid lowercase kebab-case name and is empty.
+
+| Limit | Value |
+| --- | --- |
+| Project path | At most 1,024 Unicode scalars |
+| Non-dot path segments | At most 32 |
+| Project and engine name | Lowercase kebab-case, at most 214 characters |
+
+The target may be absent or an empty real directory. A symbolic-link target,
+symbolic-link path component, non-directory target, or any existing entry fails
+before scaffold writes. Every file is created exclusively; an entry that appears
+during creation is preserved and reported as `SCAFFOLD_CONFLICT`.
+
+A pre-install write failure removes only paths created by that invocation. The
+creator never overwrites a file. Concurrent creation in one target is unsupported.
+
+## Generated project
+
+Files are deterministic UTF-8 text with LF endings and one trailing newline:
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-welcome-message.ts
+src/cli.ts
+src/direct.ts
+src/engine.ts
+src/mcp-stdio.ts
+test/engine.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The public `onboarding.create-welcome-message` capability is deterministic and
+requires no credential or provider account. Direct, CLI, and MCP stdio entry
+points import the same engine. Generated Invokta dependencies use the exact
+creator version; generated files are project-owned and are never upgraded in
+place.
+
+The starter contains no HTTP endpoint, authentication implementation, model
+provider, telemetry, Git initialization, or template selector. Add stateless
+HTTP later with `@invokta/deploy`, whose fail-closed authentication scaffold
+remains the only official HTTP generator.
+
+## Package-manager behavior
+
+An explicit `--package-manager` wins. Otherwise the creator recognizes npm,
+pnpm, or Yarn from `npm_config_user_agent` and falls back to npm.
+
+| Manager | Install command |
+| --- | --- |
+| npm | `npm install --no-audit --no-fund` |
+| pnpm | `pnpm install` |
+| Yarn | `yarn install` |
+
+Exactly one foreground install is started directly without a shell, retry, or
+creator-owned timeout. An unavailable manager, non-zero exit, or signal is
+`INSTALL_FAILED`; the complete scaffold remains so installation can be retried.
+
+`--no-install` starts no child process and performs no network operation. The
+creator itself never makes a network request.
+
+## Output and errors
+
+Help, version, and the final success summary use standard output. Creator
+diagnostics use standard error. During installation, the selected package manager
+inherits the terminal streams.
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Usage, project path, or project name was invalid |
+
+| Code | Meaning |
+| --- | --- |
+| `TARGET_INVALID` | The path shape or derived project name is invalid |
+| `TARGET_UNSAFE` | A path component is a symlink, not a directory, or cannot be inspected safely |
+| `TARGET_NOT_EMPTY` | The target contains at least one entry |
+| `SCAFFOLD_CONFLICT` | A fixed scaffold path appeared after preflight |
+| `WRITE_FAILED` | A scaffold write or rollback failed |
+| `INSTALL_FAILED` | The selected package manager was unavailable or unsuccessful |
+
+Diagnostics may identify a generated project-relative path or package-manager
+name. They never include a rejected argument, environment value, child error,
+stack, or cause.

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -60,6 +60,7 @@ Files are deterministic UTF-8 text with LF endings and one trailing newline:
 ```text
 .gitignore
 README.md
+invokta.mcp.json
 package.json
 src/capabilities/create-welcome-message.ts
 src/cli.ts
@@ -76,6 +77,19 @@ requires no credential or provider account. Direct, CLI, and MCP stdio entry
 points import the same engine. Generated Invokta dependencies use the exact
 creator version; generated files are project-owned and are never upgraded in
 place.
+
+The project includes `@invokta/installer`, a strict local install manifest, and
+an `mcp:install` script. It builds the engine before client detection so a build
+failure cannot lead to a partial MCP configuration update:
+
+```sh
+npm run mcp:install
+```
+
+The installer preselects eligible clients and requests one confirmation. It
+validates the built entry point without importing or executing the engine. See
+the [installer reference](/reference/installer/) for the manifest contract and
+management commands.
 
 The starter contains no HTTP endpoint, authentication implementation, model
 provider, telemetry, Git initialization, or template selector. Add stateless

--- a/apps/docs/src/content/docs/reference/index.mdx
+++ b/apps/docs/src/content/docs/reference/index.mdx
@@ -24,14 +24,14 @@ API and never call capability handlers directly.
 | Package | Public role | Start here |
 | --- | --- | --- |
 | `@invokta/tooling` | Validate a built, tracked capability composition in development or CI | [Tooling reference](/reference/tooling/) |
-| `@invokta/installer` | Current read-only inventory of supported local MCP client targets | [Installer reference](/reference/installer/) |
+| `@invokta/installer` | Install and manage Action Engine MCP servers in supported local clients | [Installer reference](/reference/installer/) |
 | `@invokta/deploy` | Scaffold and package HTTP deployment artifacts and probe an endpoint | [Deploy reference](/reference/deploy/) |
 | `create-invokta-engine` | Create a standalone starter engine and install its dependencies | [Creator reference](/reference/create-invokta-engine/) |
 
 Supporting packages do not create another capability execution path. The creator
 writes a project, tooling imports a trusted composition module, the installer
-inventory never invokes an engine, and deploy generates files or makes one probe
-request.
+updates client configuration without invoking an engine, and deploy generates
+files or makes one probe request.
 
 ## Shared requirements
 

--- a/apps/docs/src/content/docs/reference/index.mdx
+++ b/apps/docs/src/content/docs/reference/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Overview
 ---
 
-Invokta publishes three runtime packages and three supporting packages. Each has
+Invokta publishes three runtime packages and four supporting packages. Each has
 one bounded responsibility.
 
 ## Runtime packages
@@ -26,10 +26,12 @@ API and never call capability handlers directly.
 | `@invokta/tooling` | Validate a built, tracked capability composition in development or CI | [Tooling reference](/reference/tooling/) |
 | `@invokta/installer` | Current read-only inventory of supported local MCP client targets | [Installer reference](/reference/installer/) |
 | `@invokta/deploy` | Scaffold and package HTTP deployment artifacts and probe an endpoint | [Deploy reference](/reference/deploy/) |
+| `create-invokta-engine` | Create a standalone starter engine and install its dependencies | [Creator reference](/reference/create-invokta-engine/) |
 
-Supporting packages do not create another capability execution path. Tooling
-imports a trusted composition module, the installer inventory never invokes an
-engine, and deploy generates files or makes one probe request.
+Supporting packages do not create another capability execution path. The creator
+writes a project, tooling imports a trusted composition module, the installer
+inventory never invokes an engine, and deploy generates files or makes one probe
+request.
 
 ## Shared requirements
 
@@ -39,5 +41,5 @@ engine, and deploy generates files or makes one probe request.
 - Runtime behavior remains on `engine.invoke`
 
 Use the [error reference](/reference/errors/) for capability invocation errors.
-Tooling, installer, and deploy diagnostics have separate application-specific
-contracts.
+Creator, tooling, installer, and deploy diagnostics have separate
+application-specific contracts.

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -1,97 +1,227 @@
 ---
 title: '@invokta/installer'
-description: Current command reference for the read-only local MCP client inventory.
+description: Install and manage local or remote Action Engine MCP servers in supported user clients.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-`@invokta/installer` is a standalone terminal application for local MCP client
-configuration work. In the current release, its executable provides a read-only
-inventory: it detects supported harnesses and configuration targets but does not
-read configuration contents or change files.
+`@invokta/installer` is a binary-only terminal application that detects
+supported MCP clients, updates their user configuration, and keeps enough local
+state to manage only the entries it owns. It never invokes an Action Engine.
 
-<Aside type="caution" title="Current status: read-only inventory">
-  The bundled production registry is empty and the mutation coordinator is not
-  connected to the executable. The current command does not install, adopt,
-  enable, disable, update, or remove an MCP server. It does not provide backup or
-  rollback behavior. Those actions must not be inferred from the package name.
-</Aside>
+The shortest path is generated with every starter engine:
+
+```sh
+npm create invokta-engine@latest my-engine
+cd my-engine
+npm run mcp:install
+```
+
+`mcp:install` builds the engine, validates its local installation manifest,
+preselects every eligible client, and requests one confirmation before any
+write.
 
 ## Install
 
-Install the binary as a development dependency:
+The generated project already includes the installer. Add it manually to an
+existing engine when needed:
 
 ```sh
-yarn add --dev @invokta/installer
+npm install --save-dev @invokta/installer
 ```
 
-The package is native ESM, requires Node.js 22.20.0 or later, and exposes no
-JavaScript import API. Its only public package surface is the
-`invokta-installer` binary.
+The package is native ESM, requires Node.js 22.20.0 or later, exposes no
+JavaScript import API, and publishes only the `invokta-installer` binary.
+
+The bundled capability registry may remain empty. Explicit local-engine and
+remote-HTTP commands supply their own reviewed descriptors; new managed state
+persists the launch descriptor required for later lifecycle operations.
+
+All interactive commands require both standard input and standard output to be
+attached to a TTY. Help and version output do not require a TTY.
 
 ## Commands
 
 ```text
 invokta-installer
+invokta-installer install --engine <project-directory>
+invokta-installer install --http <server-name> <url>
+  [--bearer-token-env <NAME>] [--header-env <HEADER=NAME>]...
+invokta-installer status
+invokta-installer enable
+invokta-installer disable
+invokta-installer remove
 invokta-installer --help
 invokta-installer --version
 ```
 
-`--help` and `--version` work without a terminal. The inventory itself requires
-both standard input and standard output to be attached to a TTY. `-h`, `-v`, and
-any other argument are invalid usage.
+The argument-free command remains a read-only inventory. It shows detected
+client evidence, safe configuration paths, and reload guidance without reading
+configuration contents or changing files.
 
-From this repository, build and run it in a terminal:
+### Install a local Action Engine
 
 ```sh
-yarn workspace @invokta/installer build
-node packages/installer/dist/cli.js
+invokta-installer install --engine .
 ```
 
-The session lets you select one detected target and inspect its executable
-evidence, configuration path evidence, and reload guidance. It finishes with a
-confirmation that no changes were made.
+The directory must contain a built entry point and `invokta.mcp.json`. A
+generated project provides the build-first package script below, which is the
+recommended interface:
 
-### Exit behavior
+```json
+{
+  "scripts": {
+    "mcp:install": "tsc -p tsconfig.json --pretty false && invokta-installer install --engine ."
+  }
+}
+```
 
-| Code | Current behavior |
-| --- | --- |
-| `0` | Help, version, or read-only inventory completed |
-| `2` | Invalid usage, no TTY, registry failure, or initialization failure |
-| `130` | The user cancelled an interactive prompt |
+The manifest is strict UTF-8 JSON with this closed version-one shape:
 
-Diagnostics use stable installer-specific codes and messages. They are not
-`EngineError` values and do not extend the seven capability invocation errors.
+```json
+{
+  "schemaVersion": 1,
+  "id": "support-engine",
+  "version": "0.1.0",
+  "title": "Support Engine",
+  "description": "Classify and route support tickets.",
+  "capabilityIds": ["support.classify-ticket"],
+  "server": {
+    "name": "support-engine",
+    "entrypoint": "dist/mcp-stdio.js",
+    "forwardEnv": ["SUPPORT_API_TOKEN"]
+  }
+}
+```
 
-## Supported inventory targets
+The manifest declares only metadata, a project-relative entry point, and
+environment variable names. It cannot choose an arbitrary command or persist an
+environment value. The installer validates owned, no-follow path components and
+the built regular file, then records the current Node executable and absolute
+entry-point path. It does not import, reflect on, or execute project code.
 
-The inventory recognizes ten executable surfaces that map to nine configuration
-targets:
+Moving or deleting the project invalidates the recorded launch descriptor.
+Build and install again from the new location to update it explicitly.
 
-| Target | Executable evidence | Default configuration path |
+### Install a remote HTTP server
+
+Register an existing Streamable HTTP endpoint directly:
+
+```sh
+invokta-installer install --http support-engine https://support.example.com/mcp \
+  --bearer-token-env SUPPORT_API_TOKEN \
+  --header-env X-Support-Tenant=SUPPORT_TENANT
+```
+
+This command performs no network request. The URL must be canonical HTTPS with
+the exact `/mcp` path. Canonical `http://127.0.0.1/mcp` and
+`http://[::1]/mcp` are accepted for local development. User information, query
+strings, fragments, embedded credentials, and other paths are rejected.
+
+Authentication and header options name environment variables; they never read
+or persist their values. `--header-env` may be repeated. Header names are
+normalized and duplicate, reserved, or conflicting authorization headers fail
+closed.
+
+## Selection and confirmation
+
+An installation includes targets that have either a safely discovered user
+configuration or an installed client executable. A missing configuration file
+may be created only when executable evidence exists. Compatibility checks then
+remove clients that cannot represent the requested transport or environment
+references.
+
+All remaining targets are preselected. You may change the selection, then one
+confirmation authorizes the complete set of per-client transactions. A failure
+in one client is reported independently and does not undo a different client
+that already committed. Repeating the same installation is idempotent.
+
+## Manage installations
+
+`status` is read-only and reports installer-managed entries as enabled,
+disabled, outdated, drifted, unavailable, or missing their runtime requirement.
+
+`enable`, `disable`, and `remove` each present only eligible managed entries,
+select one interactively, and require confirmation. Disable uses the client's
+native toggle when available and otherwise detaches the server definition while
+retaining its descriptor in installer state. Enable restores the exact managed
+definition. Remove deletes the owned server entry and state record; it never
+deletes the surrounding client configuration.
+
+An entry changed outside the installer is drift and is never overwritten or
+removed automatically. A different server using the same name is a conflict.
+
+## Supported targets
+
+The catalog recognizes twelve executable surfaces mapped to eleven user-scope
+configuration targets:
+
+| Target | Executable evidence | Default user configuration |
 | --- | --- | --- |
 | Antigravity | `agy` or `antigravity` | `~/.gemini/config/mcp_config.json` |
 | Claude Code | `claude` | `~/.claude.json` |
+| Claude Desktop | `Claude` | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json` |
 | Codex | `codex` | `~/.codex/config.toml` |
 | Cursor | `cursor` or `cursor-agent` | `~/.cursor/mcp.json` |
 | Grok Build | `grok` | `~/.grok/config.toml` |
 | Hermes Agent | `hermes` | `~/.hermes/config.yaml` |
 | Kimi Code | `kimi` | `~/.kimi-code/mcp.json` |
-| OpenClaw | `openclaw` | Discovered below its supported home or state directory |
+| OpenClaw | `openclaw` | Its supported home or state directory |
 | OpenCode v2 | `opencode2` | `~/.config/opencode/opencode.json` or `.jsonc` |
+| Visual Studio Code | `code` | Linux: `~/.config/Code/User/mcp.json`; macOS: `~/Library/Application Support/Code/User/mcp.json` |
 
-Antigravity CLI and IDE share one target. Cursor's two executable names also
-share one target. When both OpenCode JSON and JSONC files exist, the evidence is
-ambiguous and fails closed.
+Antigravity CLI and IDE share one target. Cursor's executable aliases also
+share one target. Claude Desktop mutation is macOS-only; it is unsupported on
+Linux. Windows configuration mutation is not supported in this release.
 
-Several targets respect their own established home overrides, including
+VS Code uses its JSONC `servers` object and `${env:NAME}` variables. Claude
+Desktop uses the JSON `mcpServers` object. Existing comments, trailing commas,
+unrelated servers, byte-order marks, newline conventions, and safe file modes
+are preserved according to each target contract.
+
+Established client-specific path overrides remain supported, including
 `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GROK_HOME`, `HERMES_HOME`,
-`KIMI_CODE_HOME`, `OPENCODE_CONFIG_DIR`, `XDG_CONFIG_HOME`, and the supported
-OpenClaw path variables.
+`KIMI_CODE_HOME`, `OPENCODE_CONFIG_DIR`, `XDG_CONFIG_HOME`, and the documented
+OpenClaw variables.
 
-## Public surface
+## Transaction and state boundary
 
-The package manifest deliberately exposes no programmatic API:
+Each selected target is one transaction. The installer acquires bounded state
+and configuration locks, revalidates ownership and contents, atomically replaces
+the configuration, then atomically replaces its state. If the state commit
+fails, it restores the exact configuration pre-image. A rollback failure is
+reported explicitly for manual inspection.
+
+State defaults to `~/.local/state/invokta/installer.json` and honors an absolute
+`XDG_STATE_HOME`. It contains normalized launch structure, environment variable
+names, ownership fingerprints, and timestamps. It contains no environment
+values or configuration-file copies.
+
+The installer makes no network request, package import, engine invocation, or
+shell execution while detecting or mutating clients. Diagnostics omit rejected
+values, configuration bytes, credentials, causes, and stacks.
+
+<Aside type="note" title="Engine execution remains on one path">
+  After configuration, the selected client starts the engine through
+  `@invokta/mcp`. Every tool call still reaches the same `engine.invoke`
+  pipeline used by direct and CLI consumers. Installer management is outside
+  that call graph.
+</Aside>
+
+## Exit behavior
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, inventory, installation, management, or an idempotent result succeeded |
+| `1` | An operational validation, compatibility, lock, conflict, drift, write, or rollback failure occurred |
+| `2` | Usage was invalid, a TTY was unavailable, or initialization failed |
+| `130` | The user cancelled an interactive prompt |
+
+Installer diagnostics use stable installer-specific codes. They are not
+`EngineError` values and do not extend the seven capability invocation errors.
+
+## Public package surface
 
 ```json
 {
@@ -103,28 +233,4 @@ The package manifest deliberately exposes no programmatic API:
 ```
 
 Registry parsers, target adapters, ownership planners, state transitions, locks,
-and file-system primitives are internal groundwork. They are tested, but they
-are not importable package contracts and are not connected into a public write
-workflow in the current executable.
-
-## Current safety boundary
-
-The inventory:
-
-- checks a finite catalog of executable names and user-home configuration paths;
-- uses file metadata and real paths instead of executing a detected command;
-- performs no network request, package loading, shell execution, or MCP call;
-- does not read or validate the contents of a harness configuration;
-- does not inspect arbitrary project-local configurations;
-- makes no file-system writes; and
-- fails closed when ownership or path evidence cannot be established safely.
-
-Executable presence does not validate a client version. Configuration-path
-evidence alone also does not authorize future file creation; installed harness
-evidence would be required by the internal planning model.
-
-<Aside type="note" title="Installer scope is separate from engine execution">
-  A configured client would later reach an engine through `@invokta/mcp` and the
-  normal `engine.invoke` path. The inventory does not execute capabilities and
-  is not part of the engine request path.
-</Aside>
+and filesystem primitives are internal implementation details.

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -176,9 +176,12 @@ share one target. Claude Desktop mutation is macOS-only; it is unsupported on
 Linux. Windows configuration mutation is not supported in this release.
 
 VS Code uses its JSONC `servers` object and `${env:NAME}` variables. Claude
-Desktop uses the JSON `mcpServers` object. Existing comments, trailing commas,
-unrelated servers, byte-order marks, newline conventions, and safe file modes
-are preserved according to each target contract.
+Desktop uses the JSON `mcpServers` object for credential-free local stdio
+servers. Its file contract cannot safely express forwarded environment names,
+and remote servers must be added through Claude's connector interface, so those
+descriptors are filtered out for this target. Existing comments, trailing
+commas, unrelated servers, byte-order marks, newline conventions, and safe file
+modes are preserved according to each target contract.
 
 Established client-specific path overrides remain supported, including
 `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GROK_HOME`, `HERMES_HOME`,

--- a/apps/docs/test/site-contract.node.mjs
+++ b/apps/docs/test/site-contract.node.mjs
@@ -245,7 +245,7 @@ test("all required routes are reachable from the sidebar", async () => {
   }
 });
 
-test("an empty installer registry is documented as read-only", async () => {
+test("an empty installer registry does not hide direct installation", async () => {
   const registry = JSON.parse(
     await readFile(
       join(
@@ -270,14 +270,15 @@ test("an empty installer registry is documented as read-only", async () => {
   );
   const rootReadme = await readFile(join(repositoryRoot, "README.md"), "utf8");
 
-  for (const [name, source] of [
-    ["installer reference", reference],
-    ["installation guide", installation],
-    ["root README", rootReadme],
-  ]) {
-    assert.match(source, /read-only/iu, name);
-  }
-  assert.match(reference, /does not\s+install/iu);
+  assert.match(
+    reference,
+    /argument-free command remains a read-only inventory/iu,
+  );
+  assert.match(reference, /bundled capability registry may remain empty/iu);
+  assert.match(reference, /install --engine/iu);
+  assert.match(reference, /install --http/iu);
+  assert.match(installation, /npm run mcp:install/iu);
+  assert.match(rootReadme, /npm run mcp:install/iu);
 });
 
 test("the capability package guide covers authoring, publishing, and consuming", async () => {

--- a/apps/docs/test/site-contract.node.mjs
+++ b/apps/docs/test/site-contract.node.mjs
@@ -25,6 +25,7 @@ const packageReferences = [
   ["tooling", "@invokta/tooling"],
   ["installer", "@invokta/installer"],
   ["deploy", "@invokta/deploy"],
+  ["create-invokta-engine", "create-invokta-engine"],
 ];
 
 const requiredRoutes = [

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ conflicts with a contract or ADR, the normative source takes precedence.
 - [Integrating an identity provider at the HTTP boundary](./http-authentication.md)
 - [Integrating a PDP through a capability access rule](./capability-authorization.md)
 - [Authoring and composing community capabilities](./capability-composition.md)
+- [Installing Action Engines in MCP clients](../apps/docs/src/content/docs/reference/installer.mdx)
 - [Scope and maturity matrix](./scope-matrix.md)
 - [`hello-engine`: minimal onboarding example](../examples/hello-engine/)
 - [`support-engine`: dependency injection and authorization example](../examples/support-engine/)

--- a/docs/adr/0010-standalone-local-capability-mcp-installer.md
+++ b/docs/adr/0010-standalone-local-capability-mcp-installer.md
@@ -11,6 +11,12 @@ neither capability execution nor a development-time composition check.
 
 ## Decision
 
+ADR 0013 extends this decision with explicit project-local and direct remote
+sources, persisted launch descriptors, lifecycle commands, and two additional
+client targets. Its source and management rules supersede the bundled-registry-
+only boundary below; the package isolation and no-execution/no-network boundary
+remain in force.
+
 `@invokta/installer` is a standalone native ESM end-user application exposing
 `invokta-installer`. It owns a bundled, immutable capability registry, finite
 detection of supported harnesses, format-preserving configuration adapters,

--- a/docs/adr/0012-standalone-invokta-engine-creator.md
+++ b/docs/adr/0012-standalone-invokta-engine-creator.md
@@ -1,0 +1,113 @@
+# ADR 0012: Standalone Invokta engine creator
+
+- Status: Accepted
+- Date: 2026-07-29
+
+## Context
+
+Engine authors currently assemble the package manifest, TypeScript configuration,
+capability, composition root, execution entry points, and first test by hand or
+adapt the repository-local `hello-engine` example. The example is not a
+standalone template: its configuration and package metadata belong to this
+workspace. Invokta needs one bounded bootstrap path that produces a runnable
+engine without turning project creation into a runtime concern or duplicating
+deployment authority.
+
+## Decision
+
+Invokta publishes a seventh native ESM package, `create-invokta-engine`. It is a
+binary-only supporting application exposing the executable of the same name.
+This decision supersedes only the six-package list and supporting-package count
+in ADR 0004; its dependency direction and package isolation remain in force.
+
+The public command surface is:
+
+```text
+create-invokta-engine <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+Creation is non-interactive. The target is relative to the working directory;
+absolute paths and parent-directory segments are rejected. `.` is accepted when
+the working directory itself is otherwise a valid empty target. The argument is
+limited to 1,024 Unicode scalars and 32 non-dot path segments. The final segment,
+or the working-directory name for `.`, becomes both the private package name and
+engine name. It must be lowercase kebab-case and at most 214 characters.
+
+The target may be absent or an empty real directory. A symbolic-link target, a
+symbolic-link path component, a non-directory target, or any existing directory
+entry fails before a scaffold write. Generated files are fixed, deterministic
+UTF-8 text with LF endings and one trailing newline. Writes use exclusive
+creation and never replace an existing file. A pre-install failure rolls back
+only files and directories created by that invocation; a rollback failure is
+reported and may leave those new paths for manual inspection. Concurrent
+creation in one target is unsupported, while exclusive writes ensure neither
+invocation overwrites the other.
+
+The fixed starter contains these paths in lexicographic order:
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-welcome-message.ts
+src/cli.ts
+src/direct.ts
+src/engine.ts
+src/mcp-stdio.ts
+test/engine.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+It defines one deterministic public capability and reuses it through direct
+invocation, `@invokta/cli`, and MCP stdio. It contains no model provider,
+identity implementation, HTTP server, deployment template, runtime plugin,
+telemetry, or Git initialization. HTTP preparation remains owned by
+`@invokta/deploy`. Generated Invokta dependency versions exactly match the
+creator version. Template changes affect only projects created by that creator
+release; generated files are user-owned and are never upgraded in place.
+
+Unless `--no-install` is present, the creator runs exactly one package-manager
+install as a direct child process without a shell. An explicit package manager
+wins; otherwise the creator recognizes npm, pnpm, or Yarn from
+`npm_config_user_agent` and falls back to npm. It executes `npm install
+--no-audit --no-fund`, `pnpm install`, or `yarn install`, respectively. The
+creator adds no retry or timeout to the foreground install. User cancellation
+ends the operation through normal foreground process signal handling. A failed
+or unavailable package manager produces a failed command but preserves the
+completed scaffold so the author can retry. `--no-install` starts no child
+process and performs no network operation. The creator itself performs no
+network request.
+
+Help, version, and the final success summary use standard output. Creator
+diagnostics use standard error; an install child inherits the terminal streams.
+The exit status is `0` for success, `1` for a target, filesystem, or installation
+failure, and `2` for invalid usage or an invalid project path or name. Public
+diagnostics use the stable codes `TARGET_INVALID`, `TARGET_UNSAFE`,
+`TARGET_NOT_EMPTY`, `SCAFFOLD_CONFLICT`, `WRITE_FAILED`, and `INSTALL_FAILED`.
+They may identify a generated project-relative path or one of the three package
+manager names, but never echo a rejected argument, environment value, child
+error, stack, or cause.
+
+The package imports no Invokta runtime package and creates no capability
+execution path. Its acceptance boundary is the generated consumer: the packed
+creator must generate a project that installs from packed release artifacts,
+type-checks, tests, builds, and invokes the same capability directly, through the
+CLI, and through MCP stdio.
+
+## Consequences
+
+- `npm create invokta-engine@latest my-engine` has one stable Invokta-owned
+  initializer behind it.
+- Project creation becomes a separately versioned compatibility surface without
+  expanding the core or either runtime adapter.
+- The fixed starter is intentionally narrower than an application template
+  system; additional templates require repeated use-case evidence and another
+  contract decision.
+- Package-manager installation is the sole external process and potential
+  network activity; offline and embedded workflows use `--no-install`.
+- Release verification must cover the creator tarball, executable, deterministic
+  scaffold, and isolated generated consumer.

--- a/docs/adr/0012-standalone-invokta-engine-creator.md
+++ b/docs/adr/0012-standalone-invokta-engine-creator.md
@@ -51,6 +51,7 @@ The fixed starter contains these paths in lexicographic order:
 ```text
 .gitignore
 README.md
+invokta.mcp.json
 package.json
 src/capabilities/create-welcome-message.ts
 src/cli.ts
@@ -69,6 +70,12 @@ telemetry, or Git initialization. HTTP preparation remains owned by
 `@invokta/deploy`. Generated Invokta dependency versions exactly match the
 creator version. Template changes affect only projects created by that creator
 release; generated files are user-owned and are never upgraded in place.
+
+The generated version-one `invokta.mcp.json` manifest statically identifies the
+compiled MCP stdio entry point and declared starter capability. The package adds
+`@invokta/installer` as a development dependency and an `mcp:install` script
+that builds before starting the interactive project-local installation defined
+by ADR 0013.
 
 Unless `--no-install` is present, the creator runs exactly one package-manager
 install as a direct child process without a shell. An explicit package manager

--- a/docs/adr/0013-action-engine-mcp-installation-and-management.md
+++ b/docs/adr/0013-action-engine-mcp-installation-and-management.md
@@ -107,6 +107,9 @@ Desktop. VS Code uses the default user profile on Linux and macOS. Claude Deskto
 uses its documented macOS configuration and is unsupported on Linux. Windows
 configuration mutation remains unsupported until the installer has an
 equivalent no-follow ownership and atomic-write contract for that platform.
+Claude Desktop's file contract is compatible only with credential-free local
+stdio descriptors; environment forwarding and remote servers require client
+surfaces that can obtain credential values without persisting them.
 
 ### Persistence and management
 

--- a/docs/adr/0013-action-engine-mcp-installation-and-management.md
+++ b/docs/adr/0013-action-engine-mcp-installation-and-management.md
@@ -1,0 +1,164 @@
+# ADR 0013: Action Engine MCP installation and management
+
+- Status: Accepted
+- Date: 2026-07-29
+
+## Context
+
+The standalone engine creator produces a working MCP stdio entry point, while
+the installer already owns reviewed client configuration adapters and safety
+primitives. The current public workflow does not connect those boundaries: the
+creator asks the author to configure a client manually, the bundled installer
+registry is empty, and the installer executable exposes only a read-only
+inventory.
+
+An engine author needs one local command to build an Action Engine and register
+that exact MCP entry point with installed clients. The same configurator also
+needs bounded management operations and a way to register an already deployed
+stateless MCP HTTP endpoint without turning the installer into a package loader,
+network discovery service, or capability executor.
+
+## Decision
+
+`@invokta/installer` remains a binary-only, standalone end-user application. It
+adds interactive `install`, `status`, `enable`, `disable`, and `remove`
+operations. The existing argument-free read-only inventory remains compatible.
+Every interactive operation requires stdin and stdout TTYs. Exit status is `0`
+for success or an idempotent result, `1` for an operational failure, `2` for
+invalid usage or initialization, and `130` for cancellation.
+
+The additive public command surface is:
+
+```text
+invokta-installer
+invokta-installer install --engine <project-directory>
+invokta-installer install --http <server-name> <url>
+  [--bearer-token-env <NAME>] [--header-env <HEADER=NAME>]...
+invokta-installer status
+invokta-installer enable
+invokta-installer disable
+invokta-installer remove
+invokta-installer --help
+invokta-installer --version
+```
+
+Management commands select one eligible managed installation interactively and
+perform at most one target transaction. Unknown, reordered, repeated, or mixed
+source options are invalid usage. The new stable diagnostic codes are
+`ENGINE_MANIFEST_INVALID`, `ENGINE_PATH_UNSAFE`, `ENGINE_ENTRYPOINT_MISSING`,
+`REMOTE_INVALID`, and `INSTALLATION_UNAVAILABLE`; existing ownership,
+configuration, state, runtime, locking, rollback, cancellation, and
+initialization codes retain their meanings.
+
+### Local engine source
+
+A local engine installation reads one closed `invokta.mcp.json` manifest from an
+explicit engine directory. Schema version `1` contains the registry identity,
+display metadata, declared capability IDs, server name, project-relative MCP
+stdio entry point, and names of environment variables to forward. The manifest
+contains no command, absolute path, environment value, credential, or executable
+code.
+
+The manifest is strict UTF-8 JSON without a BOM or duplicate keys and is bounded
+to 1 MiB. It has exactly these fields: `schemaVersion`, `id`, `version`, `title`,
+`description`, `capabilityIds`, and `server`; `server` has exactly `name`,
+`entrypoint`, and `forwardEnv`. It reuses the bundled registry's inclusive
+identity, string, capability-count, environment-name, and server-name limits.
+The entry point is a slash-separated relative path of at most 1,024 Unicode
+scalars and 32 nonempty segments; `.`, `..`, empty segments, a leading slash,
+backslash separators, NULs, and absolute paths are invalid.
+
+The installer resolves the real engine directory, validates every manifest and
+entry-point path component without following symbolic links, requires the built
+entry point to be a regular file owned by the current user, and converts it to a
+reviewed stdio launch descriptor. The descriptor uses the current absolute Node
+executable and the absolute entry-point path. The installer never imports,
+reflects on, or executes the engine. Moving or deleting the engine intentionally
+invalidates that launch descriptor; `status` reports the missing command or
+entry point, and a later install from the new location is an explicit update.
+
+`create-invokta-engine` generates this manifest, adds
+`@invokta/installer` as a development dependency, and adds `mcp:install`. The
+script builds the project before invoking `invokta-installer install --engine .`.
+A build failure therefore occurs before client detection, confirmation, or
+configuration writes.
+
+### Direct remote source
+
+`install --http` accepts an explicit server name and canonical Streamable HTTP
+URL plus optional environment-variable references for a bearer token and HTTP
+headers. It performs no request. HTTPS is required except for canonical loopback
+HTTP development URLs. Credentials, query strings, fragments, user information,
+and non-`/mcp` paths are rejected. Only environment variable names are persisted;
+their values are never read into configuration, state, or diagnostics.
+
+### Selection and authority
+
+Install detects a finite client catalog, filters it through each target's
+compatibility function, preselects all eligible targets, and requires one
+explicit confirmation before any write. A target with an existing safe user
+configuration is eligible. Creating a missing user configuration additionally
+requires installed-client evidence. The first management release owns only
+default user-scope configurations; project, profile, remote-workspace, and
+organization-managed scopes require later decisions.
+
+The initial catalog contains the existing nine targets plus VS Code and Claude
+Desktop. VS Code uses the default user profile on Linux and macOS. Claude Desktop
+uses its documented macOS configuration and is unsupported on Linux. Windows
+configuration mutation remains unsupported until the installer has an
+equivalent no-follow ownership and atomic-write contract for that platform.
+
+### Persistence and management
+
+New managed installation records persist the normalized launch descriptor in
+addition to ownership metadata. This contains command or URL structure and
+environment variable names, never environment values. Existing version-one
+state without a persisted descriptor remains readable; it can be managed only
+when the bundled registry still supplies the matching descriptor.
+
+`status` re-inspects every managed target and reports enabled, disabled,
+outdated, drifted, unavailable, or missing-runtime state without mutation.
+`enable` and `disable` operate only on an installation selected from state.
+`remove` deletes the owned server definition, including a natively disabled
+definition, and removes the corresponding state record. It never deletes an
+unrelated configuration file or an externally changed definition. Drift and
+name conflicts fail closed.
+
+### Transaction boundary
+
+Each selected client is one independent transaction. Multi-client installation
+is deterministic but not globally atomic: a failure for one client does not
+roll back already committed clients, and the final result identifies success
+and failure per target. Re-running the command is idempotent.
+
+For one target, the installer:
+
+1. acquires the shared state lock and then the target configuration lock;
+2. re-reads and revalidates state, path identities, configuration, runtime
+   requirements, ownership, and the planned action;
+3. writes and atomically renames the configuration post-image;
+4. writes and atomically renames the state post-image; and
+5. restores the exact configuration pre-image if the state commit fails.
+
+Temporary files are exclusive, same-directory, bounded, flushed, and preserve
+safe ownership and mode. Locks are bounded and identity-owned. A rollback
+failure is reported separately and leaves artifacts for manual inspection. No
+diagnostic includes configuration bytes, environment values, credentials,
+causes, or stacks.
+
+The configured client later starts `@invokta/mcp`; every tool call continues
+through the engine's single `engine.invoke` path. Installer management never
+enters the capability call graph.
+
+## Consequences
+
+- A generated engine gains one package-manager script for local MCP client
+  installation without a new framework package or runtime abstraction.
+- The local manifest, installer commands, target formats, stored launch
+  descriptor, errors, exit codes, and user-scope defaults are compatibility
+  surfaces.
+- Persisting a launch descriptor enables offline management while preserving the
+  installer prohibition on package loading, reflection, execution, and network
+  access.
+- Adding project scope, Windows mutation, remote discovery, package acquisition,
+  or a mutable registry requires a separate architectural decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0010](0010-standalone-local-capability-mcp-installer.md) | Standalone local capability MCP installer | Accepted | 2026-07-28 |
 | [0011](0011-http-engine-deploy-toolkit.md) | HTTP engine deployment toolkit | Accepted | 2026-07-28 |
 | [0012](0012-standalone-invokta-engine-creator.md) | Standalone Invokta engine creator | Accepted | 2026-07-29 |
+| [0013](0013-action-engine-mcp-installation-and-management.md) | Action Engine MCP installation and management | Accepted | 2026-07-29 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0009](0009-capability-composition-and-dev-tooling.md) | Capability composition and development tooling | Accepted | 2026-07-28 |
 | [0010](0010-standalone-local-capability-mcp-installer.md) | Standalone local capability MCP installer | Accepted | 2026-07-28 |
 | [0011](0011-http-engine-deploy-toolkit.md) | HTTP engine deployment toolkit | Accepted | 2026-07-28 |
+| [0012](0012-standalone-invokta-engine-creator.md) | Standalone Invokta engine creator | Accepted | 2026-07-29 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,3 +285,40 @@ gives `access` and `run` independent copies. Malformed or uncloneable identity i
 
 The framework does not issue tokens, perform login, store users, validate JWTs
 from a specific provider, or implement an Authorization Server/policy engine.
+
+## MCP client installation
+
+**AE-INSTALL-01 — Static sources.** `@invokta/installer` MAY configure a
+reviewed bundled descriptor, an explicitly selected project-local
+`invokta.mcp.json` manifest, or an explicitly supplied canonical Streamable HTTP
+URL. It MUST NOT discover remote servers, download or load packages, reflect on
+or execute an engine, start a transport, call a capability, or open a network
+connection. Local manifests and persisted state contain environment variable
+names but no environment values or credentials.
+
+**AE-INSTALL-02 — Confirmed user scope.** Installation targets only the finite
+catalog of supported default user configurations. All compatible eligible
+targets are preselected, but no mutation occurs without explicit confirmation.
+Creating a missing configuration requires installed-client evidence. Project,
+profile, remote-workspace, organization-managed, and Windows configuration
+mutation are not provided by this profile.
+
+**AE-INSTALL-03 — Managed lifecycle.** New ownership records persist the
+normalized launch descriptor. `status`, `enable`, `disable`, and `remove`
+re-inspect current configuration and fail closed on conflicts, drift, an unsafe
+path, a missing runtime, or unavailable legacy metadata. Removal deletes only a
+definition whose managed identity still matches and then removes its ownership
+record.
+
+**AE-INSTALL-04 — Per-target transaction.** Each client mutation acquires the
+shared state lock before its configuration lock, revalidates after locking,
+commits same-directory atomic configuration and state post-images, and restores
+the exact configuration pre-image if state commit fails. Multi-client operations
+are ordered independent transactions, report partial results, and become
+idempotent when repeated.
+
+**AE-INSTALL-05 — Execution boundary.** A generated local launch descriptor
+uses the current absolute Node executable and the validated absolute compiled
+entry point. The configured MCP adapter continues to call only
+`engine.invoke`; installer operations never enter the capability execution
+path.

--- a/docs/implementation-plan-and-acceptance-criteria.md
+++ b/docs/implementation-plan-and-acceptance-criteria.md
@@ -42,10 +42,11 @@ persistence, configuration field, or operational limit:
 | `AE-SCOPE-01..04`, `AE-LIMIT-01..05` | Manifest and API review prove package roles and the absence of deferred abstractions |
 
 Supporting packages require focused contract tests for their own authority:
-composition diagnostics remain deterministic and payload-free; installer writes
-remain confirmed, atomic, reversible, and secret-free; deploy outputs remain
-deterministic, marked, and non-destructive; and every published tarball passes an
-isolated consumer smoke test.
+creator scaffolds remain deterministic, non-overwriting, and independently
+buildable; composition diagnostics remain deterministic and payload-free;
+installer writes remain confirmed, atomic, reversible, and secret-free; deploy
+outputs remain deterministic, marked, and non-destructive; and every published
+tarball passes an isolated consumer smoke test.
 
 ## Release gates
 

--- a/docs/implementation-plan-and-acceptance-criteria.md
+++ b/docs/implementation-plan-and-acceptance-criteria.md
@@ -39,6 +39,7 @@ persistence, configuration field, or operational limit:
 | `AE-CLI-01..02` | Integration covers commands, input channels, UTF-8 failure, writers, and exit codes |
 | `AE-MCP-01..04` | An official client lists and calls tools over stdio and HTTP; tests cover schemas, errors, cancellation boundaries, statelessness, and boundary security |
 | `AE-SEC-01..02` | Authentication occurs before `invoke`; authorization occurs before `run`; insecure authentication requires explicit opt-in |
+| `AE-INSTALL-01..05` | Packed creator smoke tests install a built local engine; target transactions cover confirmation, idempotency, drift, locks, rollback, management, remote descriptors, and secret-free diagnostics without process or network access |
 | `AE-SCOPE-01..04`, `AE-LIMIT-01..05` | Manifest and API review prove package roles and the absence of deferred abstractions |
 
 Supporting packages require focused contract tests for their own authority:

--- a/docs/scope-and-limits.md
+++ b/docs/scope-and-limits.md
@@ -2,7 +2,7 @@
 
 ## Public packages
 
-**AE-SCOPE-01 — Six packages with isolated roles.** Invokta publishes:
+**AE-SCOPE-01 — Seven packages with isolated roles.** Invokta publishes:
 
 | Package | Responsibility |
 | --- | --- |
@@ -12,6 +12,7 @@
 | `@invokta/tooling` | Development-time validation of capability composition |
 | `@invokta/installer` | End-user configuration of supported local MCP clients |
 | `@invokta/deploy` | Development-time HTTP engine scaffolding, packaging, and probing |
+| `create-invokta-engine` | Creation of a standalone starter Action Engine |
 
 All packages are native ESM. The core has no transport dependency. Runtime
 adapters depend only on the core's public API, and supporting applications do
@@ -37,7 +38,7 @@ useful.
 | Dimension | Limit |
 | --- | --- |
 | Framework runtime packages | 3: core, CLI, and MCP |
-| Supporting packages | 3: tooling, installer, and deploy |
+| Supporting packages | 4: tooling, installer, deploy, and engine creator |
 | Official adapters | CLI and MCP |
 | MCP transports | stdio and stateless Streamable HTTP |
 | Core primitives | Capability, Engine, Context, and Principal |

--- a/docs/scope-matrix.md
+++ b/docs/scope-matrix.md
@@ -24,14 +24,14 @@ belongs in Invokta, a custom engine, or a later evidence-driven package.
 | AI implementation | Keep implementation replaceable | Own prompts, models, retrieval, tools, evidence, and risk controls | Provider SDKs, prompt registry, RAG abstraction, or memory |
 | Quality | Validate contracts and provide testable direct execution | Own fixtures, evals, regression suites, and human review | Eval runner, automated judge, or canary platform |
 | Capability reuse | Eager explicit composition with deterministic collision detection | Choose imports, effective IDs, and trusted dependencies | Runtime plugin marketplace or remote discovery |
-| Supporting tools | Composition checker, MCP client installer, and deployment generator | Review generated files and own local or deployment authority | Autonomous installation or deployment service |
+| Supporting tools | Engine creator, composition checker, MCP client installer, and deployment generator | Review generated files and own local or deployment authority | Autonomous installation or deployment service |
 
 ## Fixed limits
 
 | Dimension | Limit |
 | --- | --- |
 | Framework runtime packages | 3 |
-| Supporting packages | 3 |
+| Supporting packages | 4 |
 | Official adapters | 2: CLI and MCP |
 | MCP transports | 2: stdio and stateless Streamable HTTP |
 | Core primitives | 4: Capability, Engine, Context, Principal |

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,7 +1,8 @@
 # Validation record
 
 - Last reviewed: 2026-07-29
-- Public API changes: none
+- Public API changes: Action Engine creator installation scaffold and installer
+  CLI commands accepted in ADR 0013
 
 ## Reuse evidence
 
@@ -35,6 +36,10 @@ consumer can use the protocol surface without coupling to engine code.
   on effective-ID collisions.
 - The installer and deploy packages remain outside the capability call graph and
   exercise only their documented local configuration and generation authority.
+- Packed creator smoke tests build a generated engine and exercise its
+  `mcp:install` path; installer tests cover local manifests, remote descriptors,
+  multi-client transactions, lifecycle management, eleven target adapters, and
+  forbidden process, network, and write sentinels.
 
 ## Ownership conclusions
 

--- a/packages/create-invokta-engine/LICENSE
+++ b/packages/create-invokta-engine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vini Lana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -32,6 +32,7 @@ to generate files without starting a package manager or performing network I/O.
 ```text
 .gitignore
 README.md
+invokta.mcp.json
 package.json
 src/capabilities/create-welcome-message.ts
 src/cli.ts
@@ -45,6 +46,18 @@ tsconfig.test.json
 
 Generated Invokta dependencies use the exact creator version. The files become
 project-owned immediately and are never updated in place by the creator.
+
+The starter also includes `@invokta/installer` and a build-first installation
+command:
+
+```sh
+npm run mcp:install
+```
+
+That command validates `invokta.mcp.json`, detects eligible MCP clients,
+preselects all of them, and requires one confirmation before changing user
+configuration. The installer never imports or executes the engine while
+discovering its MCP entry point.
 
 HTTP scaffolding remains a separate, explicit step owned by `@invokta/deploy`.
 The starter contains no HTTP server, authentication implementation, model

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -1,0 +1,63 @@
+# create-invokta-engine
+
+Create a standalone TypeScript Action Engine with Invokta. The fixed starter
+defines one public capability and exposes it through direct invocation, the
+Invokta CLI adapter, and MCP stdio without duplicating the handler.
+
+## Commands
+
+```text
+create-invokta-engine <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+The npm initializer shorthand resolves to this package:
+
+```sh
+npm create invokta-engine@latest my-engine
+```
+
+Creation is non-interactive. The target must be a relative absent or empty real
+directory. Existing files and symbolic-link path components are refused and
+never overwritten.
+
+The invoking package manager is inferred from `npm_config_user_agent`, with npm
+as the fallback. Use `--package-manager` to choose explicitly or `--no-install`
+to generate files without starting a package manager or performing network I/O.
+
+## Generated project
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-welcome-message.ts
+src/cli.ts
+src/direct.ts
+src/engine.ts
+src/mcp-stdio.ts
+test/engine.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+Generated Invokta dependencies use the exact creator version. The files become
+project-owned immediately and are never updated in place by the creator.
+
+HTTP scaffolding remains a separate, explicit step owned by `@invokta/deploy`.
+The starter contains no HTTP server, authentication implementation, model
+provider, telemetry, template selection, or Git initialization.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Arguments, project path, or project name were invalid |
+
+Creator diagnostics use `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, or `INSTALL_FAILED`. Rejected arguments,
+environment values, child errors, stacks, and causes are not included.

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "create-invokta-engine",
+  "version": "0.1.0",
+  "description": "Create a standalone Invokta Action Engine.",
+  "author": "Vini Lana <vini@aicoders.academy>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vinilana/invokta.git",
+    "directory": "packages/create-invokta-engine"
+  },
+  "homepage": "https://docs.invokta.dev/reference/create-invokta-engine/",
+  "bugs": {
+    "url": "https://github.com/vinilana/invokta/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {},
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "prepack": "npm run --silent build"
+  }
+}

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -25,6 +25,9 @@
     "dist"
   ],
   "exports": {},
+  "bin": {
+    "create-invokta-engine": "./dist/bin.js"
+  },
   "scripts": {
     "build": "tsc -b --pretty false",
     "prepack": "npm run --silent build"

--- a/packages/create-invokta-engine/src/bin.ts
+++ b/packages/create-invokta-engine/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCreateEngineCli } from "./cli.js";
+
+// The composition root owns process status so buffered terminal output can flush.
+process.exitCode = await runCreateEngineCli();

--- a/packages/create-invokta-engine/src/cli.ts
+++ b/packages/create-invokta-engine/src/cli.ts
@@ -1,0 +1,213 @@
+import { CreatorError, renderCreatorDiagnostic } from "./errors.js";
+import { installProjectDependencies, selectPackageManager } from "./install.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+import { createStarterProject } from "./scaffold.js";
+
+const helpText = `Usage:
+  create-invokta-engine <project-directory>
+    [--package-manager npm|pnpm|yarn] [--no-install]
+  create-invokta-engine --help
+  create-invokta-engine --version
+`;
+
+const invalidUsageText =
+  'Invalid arguments. Run "create-invokta-engine --help".\n';
+const unexpectedFailureText = "The project could not be created.\n";
+
+export interface CreateEngineIo {
+  readonly writeStdout: (text: string) => void | Promise<void>;
+  readonly writeStderr: (text: string) => void | Promise<void>;
+}
+
+const processIo: CreateEngineIo = {
+  writeStdout(text) {
+    process.stdout.write(text);
+  },
+  writeStderr(text) {
+    process.stderr.write(text);
+  },
+};
+
+const defaultIo: CreateEngineIo = Object.freeze(processIo);
+
+export interface InstallProjectOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+}
+
+export type InstallProject = (options: InstallProjectOptions) => Promise<void>;
+
+export interface RunCreateEngineCliOptions {
+  readonly argv?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly io?: CreateEngineIo;
+  readonly install?: InstallProject;
+  readonly loadPackageVersion?: () => Promise<string>;
+}
+
+interface CreateArguments {
+  readonly target: string;
+  readonly packageManager?: PackageManager;
+  readonly noInstall: boolean;
+}
+
+function parseCreateArguments(
+  args: readonly string[],
+): CreateArguments | undefined {
+  let target: string | undefined;
+  let packageManager: PackageManager | undefined;
+  let packageManagerSeen = false;
+  let noInstall = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--no-install") {
+      if (noInstall) return undefined;
+      noInstall = true;
+      continue;
+    }
+    if (argument === "--package-manager") {
+      if (packageManagerSeen) return undefined;
+      packageManagerSeen = true;
+      const value = args[index + 1];
+      if (value === undefined || !isPackageManager(value)) return undefined;
+      packageManager = value;
+      index += 1;
+      continue;
+    }
+    if (
+      argument === undefined ||
+      argument.startsWith("-") ||
+      target !== undefined
+    ) {
+      return undefined;
+    }
+    target = argument;
+  }
+
+  if (target === undefined) return undefined;
+  return {
+    target,
+    ...(packageManager === undefined ? {} : { packageManager }),
+    noInstall,
+  };
+}
+
+function asRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  return value as Readonly<Record<string, unknown>>;
+}
+
+async function loadDefaultPackageVersion(): Promise<string> {
+  const manifestUrl = new URL("../package.json", import.meta.url);
+  const namespace = (await import(manifestUrl.href, {
+    with: { type: "json" },
+  })) as unknown;
+  const version = asRecord(asRecord(namespace)?.default)?.version;
+  if (typeof version !== "string" || version === "") {
+    throw new Error("The package version is unreadable.");
+  }
+  return version;
+}
+
+async function writeDiagnostic(
+  io: CreateEngineIo,
+  text: string,
+): Promise<void> {
+  try {
+    await io.writeStderr(text);
+  } catch {
+    // A broken diagnostic stream does not replace the command's numeric result.
+  }
+}
+
+function renderSuccess(
+  projectName: string,
+  packageManager: PackageManager,
+  noInstall: boolean,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  if (noInstall) {
+    return (
+      `Created ${projectName} without installing dependencies.\n\n` +
+      "Next steps:\n" +
+      `  ${commands.installDisplay}\n` +
+      `  ${commands.check}\n`
+    );
+  }
+  return `Created ${projectName}.\n\nNext step:\n  ${commands.check}\n`;
+}
+
+/** Runs the binary command and returns its exit status without exiting. */
+export async function runCreateEngineCli(
+  options: RunCreateEngineCliOptions = {},
+): Promise<0 | 1 | 2> {
+  const argv = options.argv ?? process.argv.slice(2);
+  const io = options.io ?? defaultIo;
+  const [first, ...rest] = argv;
+
+  if (first === "--help" || first === "--version") {
+    if (rest.length > 0) {
+      await writeDiagnostic(io, invalidUsageText);
+      return 2;
+    }
+    try {
+      const output =
+        first === "--help"
+          ? helpText
+          : `${await (options.loadPackageVersion ?? loadDefaultPackageVersion)()}\n`;
+      await io.writeStdout(output);
+      return 0;
+    } catch {
+      await writeDiagnostic(io, unexpectedFailureText);
+      return 1;
+    }
+  }
+
+  const parsed = parseCreateArguments(argv);
+  if (parsed === undefined) {
+    await writeDiagnostic(io, invalidUsageText);
+    return 2;
+  }
+
+  const environment = options.env ?? process.env;
+  const packageManager = selectPackageManager(
+    parsed.packageManager,
+    environment.npm_config_user_agent,
+  );
+  try {
+    const invoktaVersion = await (
+      options.loadPackageVersion ?? loadDefaultPackageVersion
+    )();
+    const project = await createStarterProject({
+      cwd: options.cwd ?? process.cwd(),
+      target: parsed.target,
+      invoktaVersion,
+      packageManager,
+    });
+    if (!parsed.noInstall) {
+      await (options.install ?? installProjectDependencies)({
+        directory: project.directory,
+        packageManager,
+      });
+    }
+    await io.writeStdout(
+      renderSuccess(project.projectName, packageManager, parsed.noInstall),
+    );
+    return 0;
+  } catch (error) {
+    if (error instanceof CreatorError) {
+      await writeDiagnostic(io, renderCreatorDiagnostic(error));
+      return error.exitCode;
+    }
+    await writeDiagnostic(io, unexpectedFailureText);
+    return 1;
+  }
+}

--- a/packages/create-invokta-engine/src/errors.ts
+++ b/packages/create-invokta-engine/src/errors.ts
@@ -1,0 +1,43 @@
+export const creatorErrorMessages = Object.freeze({
+  TARGET_INVALID: "The project path or name is invalid.",
+  TARGET_UNSAFE: "The project target is unsafe to use.",
+  TARGET_NOT_EMPTY: "The project target is not empty.",
+  SCAFFOLD_CONFLICT: "A scaffold file appeared during creation.",
+  WRITE_FAILED: "The project scaffold could not be written.",
+  INSTALL_FAILED: "The project dependencies could not be installed.",
+} as const);
+
+export type CreatorErrorCode = keyof typeof creatorErrorMessages;
+export type CreatorExitCode = 0 | 1 | 2;
+
+const creatorErrorExitCodes = Object.freeze({
+  TARGET_INVALID: 2,
+  TARGET_UNSAFE: 1,
+  TARGET_NOT_EMPTY: 1,
+  SCAFFOLD_CONFLICT: 1,
+  WRITE_FAILED: 1,
+  INSTALL_FAILED: 1,
+} as const) satisfies Readonly<Record<CreatorErrorCode, CreatorExitCode>>;
+
+/** A sanitized creator failure. It intentionally stores no cause or raw input. */
+export class CreatorError extends Error {
+  readonly code: CreatorErrorCode;
+  readonly exitCode: CreatorExitCode;
+  readonly details: readonly string[];
+
+  constructor(code: CreatorErrorCode, details: readonly string[] = []) {
+    super(creatorErrorMessages[code]);
+    this.name = "CreatorError";
+    this.code = code;
+    this.exitCode = creatorErrorExitCodes[code];
+    this.details = Object.freeze([...details]);
+  }
+}
+
+export function renderCreatorDiagnostic(error: CreatorError): string {
+  const lines = [
+    `${error.code}: ${creatorErrorMessages[error.code]}`,
+    ...error.details.map((detail) => `  ${detail}`),
+  ];
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/create-invokta-engine/src/install.ts
+++ b/packages/create-invokta-engine/src/install.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+import { CreatorError } from "./errors.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+
+export interface PackageManagerRunOptions {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly shell: false;
+  readonly stdio: "inherit";
+}
+
+export interface PackageManagerRunResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export type PackageManagerRunner = (
+  options: PackageManagerRunOptions,
+) => Promise<PackageManagerRunResult>;
+
+export const defaultPackageManagerRunner: PackageManagerRunner = (options) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(options.command, [...options.args], {
+      cwd: options.cwd,
+      shell: options.shell,
+      stdio: options.stdio,
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+
+export function selectPackageManager(
+  explicit: PackageManager | undefined,
+  userAgent: string | undefined,
+): PackageManager {
+  if (explicit !== undefined) return explicit;
+  const candidate = userAgent?.split(/\s/u, 1)[0]?.split("/", 1)[0];
+  return candidate !== undefined && isPackageManager(candidate)
+    ? candidate
+    : "npm";
+}
+
+export interface InstallProjectDependenciesOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+  readonly runner?: PackageManagerRunner;
+}
+
+/** Runs the one foreground package-manager install authorized by ADR 0012. */
+export async function installProjectDependencies(
+  options: InstallProjectDependenciesOptions,
+): Promise<void> {
+  const commands = packageManagerCommands[options.packageManager];
+  let result: PackageManagerRunResult;
+  try {
+    result = await (options.runner ?? defaultPackageManagerRunner)({
+      command: commands.installExecutable,
+      args: commands.installArguments,
+      cwd: options.directory,
+      shell: false,
+      stdio: "inherit",
+    });
+  } catch {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+  if (result.code !== 0) {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+}

--- a/packages/create-invokta-engine/src/package-manager.ts
+++ b/packages/create-invokta-engine/src/package-manager.ts
@@ -1,0 +1,55 @@
+export type PackageManager = "npm" | "pnpm" | "yarn";
+
+export interface PackageManagerCommands {
+  readonly installExecutable: PackageManager;
+  readonly installArguments: readonly string[];
+  readonly installDisplay: string;
+  readonly check: string;
+  readonly direct: string;
+  readonly list: string;
+  readonly run: string;
+  readonly stdio: string;
+}
+
+export const packageManagerCommands = Object.freeze({
+  npm: Object.freeze({
+    installExecutable: "npm",
+    installArguments: Object.freeze(["install", "--no-audit", "--no-fund"]),
+    installDisplay: "npm install --no-audit --no-fund",
+    check: "npm run check",
+    direct: "npm run direct -- Ada",
+    list: "npm run cli -- list",
+    run: 'npm run cli -- run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "npm run mcp:stdio",
+  }),
+  pnpm: Object.freeze({
+    installExecutable: "pnpm",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "pnpm install",
+    check: "pnpm run check",
+    direct: "pnpm run direct Ada",
+    list: "pnpm run cli list",
+    run: 'pnpm run cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "pnpm run mcp:stdio",
+  }),
+  yarn: Object.freeze({
+    installExecutable: "yarn",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "yarn install",
+    check: "yarn check",
+    direct: "yarn direct Ada",
+    list: "yarn cli list",
+    run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "yarn mcp:stdio",
+  }),
+} as const) satisfies Readonly<Record<PackageManager, PackageManagerCommands>>;
+
+export const packageManagers = Object.freeze([
+  "npm",
+  "pnpm",
+  "yarn",
+] as const satisfies readonly PackageManager[]);
+
+export function isPackageManager(value: string): value is PackageManager {
+  return packageManagers.some((manager) => manager === value);
+}

--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -10,11 +10,8 @@ import {
 import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
 
 import { CreatorError } from "./errors.js";
-import {
-  createStarterFiles,
-  type PackageManager,
-  type StarterFile,
-} from "./starter.js";
+import type { PackageManager } from "./package-manager.js";
+import { createStarterFiles, type StarterFile } from "./starter.js";
 
 export const creatorTargetLimits = Object.freeze({
   maxPathScalars: 1_024,

--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -1,0 +1,322 @@
+import type { Stats } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  rmdir,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
+
+import { CreatorError } from "./errors.js";
+import {
+  createStarterFiles,
+  type PackageManager,
+  type StarterFile,
+} from "./starter.js";
+
+export const creatorTargetLimits = Object.freeze({
+  maxPathScalars: 1_024,
+  maxPathSegments: 32,
+  maxProjectNameCharacters: 214,
+});
+
+const projectNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export interface ScaffoldFileSystem {
+  readonly lstat: (path: string) => Promise<Stats>;
+  readonly mkdir: (path: string) => Promise<void>;
+  readonly readdir: (path: string) => Promise<string[]>;
+  readonly rmdir: (path: string) => Promise<void>;
+  readonly unlink: (path: string) => Promise<void>;
+  readonly writeFile: (
+    path: string,
+    contents: string,
+    options: Readonly<{ encoding: "utf8"; flag: "wx" }>,
+  ) => Promise<void>;
+}
+
+const nodeScaffoldFileSystem: ScaffoldFileSystem = {
+  lstat,
+  async mkdir(path) {
+    await mkdir(path);
+  },
+  async readdir(path) {
+    return readdir(path);
+  },
+  async rmdir(path) {
+    await rmdir(path);
+  },
+  async unlink(path) {
+    await unlink(path);
+  },
+  async writeFile(path, contents, options) {
+    await writeFile(path, contents, options);
+  },
+};
+
+export const defaultScaffoldFileSystem: ScaffoldFileSystem = Object.freeze(
+  nodeScaffoldFileSystem,
+);
+
+export interface CreateStarterProjectOptions {
+  readonly cwd: string;
+  readonly target: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+  readonly fileSystem?: ScaffoldFileSystem;
+}
+
+export interface StarterProject {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly files: readonly string[];
+}
+
+interface ResolvedTarget {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly segments: readonly string[];
+}
+
+function countScalars(value: string): number {
+  let count = 0;
+  for (const _ of value) count += 1;
+  return count;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function invalidTarget(): never {
+  throw new CreatorError("TARGET_INVALID");
+}
+
+function resolveTarget(cwd: string, target: string): ResolvedTarget {
+  if (
+    target === "" ||
+    target.includes("\u0000") ||
+    countScalars(target) > creatorTargetLimits.maxPathScalars ||
+    isAbsolute(target) ||
+    win32.isAbsolute(target)
+  ) {
+    return invalidTarget();
+  }
+
+  const rawSegments = target.split(/[\\/]/u);
+  if (target !== "." && rawSegments.some((segment) => segment === "")) {
+    return invalidTarget();
+  }
+  const segments = rawSegments.filter((segment) => segment !== ".");
+  if (
+    segments.some((segment) => segment === "..") ||
+    segments.length > creatorTargetLimits.maxPathSegments
+  ) {
+    return invalidTarget();
+  }
+
+  const directory =
+    segments.length === 0 ? resolve(cwd) : resolve(cwd, ...segments);
+  const projectName = basename(directory);
+  if (
+    projectName.length === 0 ||
+    projectName.length > creatorTargetLimits.maxProjectNameCharacters ||
+    !projectNamePattern.test(projectName)
+  ) {
+    return invalidTarget();
+  }
+  return { directory, projectName, segments };
+}
+
+async function readStatus(
+  fileSystem: ScaffoldFileSystem,
+  path: string,
+): Promise<Stats | undefined> {
+  try {
+    return await fileSystem.lstat(path);
+  } catch (error) {
+    const code = readErrorCode(error);
+    if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+}
+
+async function inspectTarget(
+  cwd: string,
+  target: ResolvedTarget,
+  fileSystem: ScaffoldFileSystem,
+): Promise<boolean> {
+  let current = resolve(cwd);
+  if (target.segments.length === 0) {
+    const status = await readStatus(fileSystem, current);
+    if (
+      status === undefined ||
+      status.isSymbolicLink() ||
+      !status.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  } else {
+    for (const segment of target.segments) {
+      current = join(current, segment);
+      const status = await readStatus(fileSystem, current);
+      if (status === undefined) return false;
+      if (status.isSymbolicLink() || !status.isDirectory()) {
+        throw new CreatorError("TARGET_UNSAFE");
+      }
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await fileSystem.readdir(target.directory);
+  } catch {
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+  if (entries.length > 0) throw new CreatorError("TARGET_NOT_EMPTY");
+  return true;
+}
+
+async function ensureDirectory(
+  path: string,
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  const status = await readStatus(fileSystem, path);
+  if (status !== undefined) {
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+    return;
+  }
+  try {
+    await fileSystem.mkdir(path);
+    createdDirectories.push(path);
+  } catch (error) {
+    if (readErrorCode(error) !== "EEXIST") {
+      throw new CreatorError("WRITE_FAILED");
+    }
+    const racedStatus = await readStatus(fileSystem, path);
+    if (
+      racedStatus === undefined ||
+      racedStatus.isSymbolicLink() ||
+      !racedStatus.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  }
+}
+
+async function prepareDirectories(
+  cwd: string,
+  target: ResolvedTarget,
+  files: readonly StarterFile[],
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  let current = resolve(cwd);
+  for (const segment of target.segments) {
+    current = join(current, segment);
+    await ensureDirectory(current, fileSystem, createdDirectories);
+  }
+  for (const directory of new Set(
+    files
+      .map((file) => dirname(file.path))
+      .filter((path) => path !== ".")
+      .sort(),
+  )) {
+    let nested = target.directory;
+    for (const segment of directory.split("/")) {
+      nested = join(nested, segment);
+      await ensureDirectory(nested, fileSystem, createdDirectories);
+    }
+  }
+}
+
+async function rollback(
+  fileSystem: ScaffoldFileSystem,
+  createdFiles: readonly string[],
+  createdDirectories: readonly string[],
+): Promise<boolean> {
+  let failed = false;
+  for (const path of [...createdFiles].reverse()) {
+    try {
+      await fileSystem.unlink(path);
+    } catch (error) {
+      if (readErrorCode(error) !== "ENOENT") failed = true;
+    }
+  }
+  for (const path of [...createdDirectories].reverse()) {
+    try {
+      await fileSystem.rmdir(path);
+    } catch (error) {
+      const code = readErrorCode(error);
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") failed = true;
+    }
+  }
+  return !failed;
+}
+
+/** Creates the fixed starter without installing dependencies or replacing files. */
+export async function createStarterProject(
+  options: CreateStarterProjectOptions,
+): Promise<StarterProject> {
+  const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
+  const target = resolveTarget(options.cwd, options.target);
+  await inspectTarget(options.cwd, target, fileSystem);
+  const files = createStarterFiles({
+    projectName: target.projectName,
+    invoktaVersion: options.invoktaVersion,
+    packageManager: options.packageManager,
+  });
+  const createdFiles: string[] = [];
+  const createdDirectories: string[] = [];
+  let activeFile: StarterFile | undefined;
+
+  try {
+    await prepareDirectories(
+      options.cwd,
+      target,
+      files,
+      fileSystem,
+      createdDirectories,
+    );
+    for (const file of files) {
+      activeFile = file;
+      const path = join(target.directory, ...file.path.split("/"));
+      await fileSystem.writeFile(path, file.contents, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      createdFiles.push(path);
+    }
+  } catch (error) {
+    const rolledBack = await rollback(
+      fileSystem,
+      createdFiles,
+      createdDirectories,
+    );
+    if (!rolledBack) throw new CreatorError("WRITE_FAILED");
+    if (error instanceof CreatorError) throw error;
+    if (readErrorCode(error) === "EEXIST") {
+      throw new CreatorError(
+        "SCAFFOLD_CONFLICT",
+        activeFile === undefined ? [] : [activeFile.path],
+      );
+    }
+    throw new CreatorError(
+      "WRITE_FAILED",
+      activeFile === undefined ? [] : [activeFile.path],
+    );
+  }
+
+  return Object.freeze({
+    directory: target.directory,
+    projectName: target.projectName,
+    files: Object.freeze(files.map((file) => file.path)),
+  });
+}

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -50,8 +50,12 @@ ${commands.run}
 ${commands.stdio}
 \`\`\`
 
-MCP stdio reserves standard output for protocol messages. Configure a client to
-start the compiled \`dist/mcp-stdio.js\` file directly with Node.
+MCP stdio reserves standard output for protocol messages. Install this engine in
+all detected MCP clients with:
+
+\`\`\`sh
+${packageManager === "yarn" ? "yarn mcp:install" : `${packageManager} run mcp:install`}
+\`\`\`
 
 Add stateless HTTP only when needed. Install \`@invokta/deploy\`, run
 \`invokta-deploy init\`, and implement its fail-closed authentication hook before
@@ -79,6 +83,8 @@ function renderPackageManifest(
       direct: "node dist/direct.js",
       cli: "node dist/cli.js",
       "mcp:stdio": "node dist/mcp-stdio.js",
+      "mcp:install":
+        "tsc -p tsconfig.json --pretty false && invokta-installer install --engine .",
     },
     dependencies: {
       "@invokta/cli": invoktaVersion,
@@ -87,12 +93,33 @@ function renderPackageManifest(
       zod: "4.4.3",
     },
     devDependencies: {
+      "@invokta/installer": invoktaVersion,
       "@types/node": "26.1.2",
       typescript: "7.0.2",
       vitest: "4.1.10",
     },
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function renderMcpInstallManifest(projectName: string): string {
+  return `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      id: projectName,
+      version: "0.1.0",
+      title: projectName,
+      description: `MCP access to the ${projectName} Action Engine.`,
+      capabilityIds: ["onboarding.create-welcome-message"],
+      server: {
+        name: projectName,
+        entrypoint: "dist/mcp-stdio.js",
+        forwardEnv: [],
+      },
+    },
+    null,
+    2,
+  )}\n`;
 }
 
 const capabilityModule = `import { defineCapability } from "@invokta/core";
@@ -228,6 +255,10 @@ export function createStarterFiles(
     {
       path: "README.md",
       contents: renderReadme(options.projectName, options.packageManager),
+    },
+    {
+      path: "invokta.mcp.json",
+      contents: renderMcpInstallManifest(options.projectName),
     },
     {
       path: "package.json",

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -1,4 +1,7 @@
-export type PackageManager = "npm" | "pnpm" | "yarn";
+import {
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
 
 export interface StarterFile {
   /** Project-relative POSIX path. */
@@ -11,41 +14,6 @@ export interface CreateStarterFilesOptions {
   readonly invoktaVersion: string;
   readonly packageManager: PackageManager;
 }
-
-const packageManagerCommands = Object.freeze({
-  npm: Object.freeze({
-    check: "npm run check",
-    direct: "npm run direct -- Ada",
-    list: "npm run cli -- list",
-    run: 'npm run cli -- run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
-    stdio: "npm run mcp:stdio",
-  }),
-  pnpm: Object.freeze({
-    check: "pnpm run check",
-    direct: "pnpm run direct Ada",
-    list: "pnpm run cli list",
-    run: 'pnpm run cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
-    stdio: "pnpm run mcp:stdio",
-  }),
-  yarn: Object.freeze({
-    check: "yarn check",
-    direct: "yarn direct Ada",
-    list: "yarn cli list",
-    run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
-    stdio: "yarn mcp:stdio",
-  }),
-} as const satisfies Readonly<
-  Record<
-    PackageManager,
-    Readonly<{
-      check: string;
-      direct: string;
-      list: string;
-      run: string;
-      stdio: string;
-    }>
-  >
->);
 
 function renderReadme(
   projectName: string,

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -1,0 +1,286 @@
+export type PackageManager = "npm" | "pnpm" | "yarn";
+
+export interface StarterFile {
+  /** Project-relative POSIX path. */
+  readonly path: string;
+  readonly contents: string;
+}
+
+export interface CreateStarterFilesOptions {
+  readonly projectName: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+}
+
+const packageManagerCommands = Object.freeze({
+  npm: Object.freeze({
+    check: "npm run check",
+    direct: "npm run direct -- Ada",
+    list: "npm run cli -- list",
+    run: 'npm run cli -- run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "npm run mcp:stdio",
+  }),
+  pnpm: Object.freeze({
+    check: "pnpm run check",
+    direct: "pnpm run direct Ada",
+    list: "pnpm run cli list",
+    run: 'pnpm run cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "pnpm run mcp:stdio",
+  }),
+  yarn: Object.freeze({
+    check: "yarn check",
+    direct: "yarn direct Ada",
+    list: "yarn cli list",
+    run: 'yarn cli run onboarding.create-welcome-message --input \'{"name":"Ada"}\'',
+    stdio: "yarn mcp:stdio",
+  }),
+} as const satisfies Readonly<
+  Record<
+    PackageManager,
+    Readonly<{
+      check: string;
+      direct: string;
+      list: string;
+      run: string;
+      stdio: string;
+    }>
+  >
+>);
+
+function renderReadme(
+  projectName: string,
+  packageManager: PackageManager,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  return `# ${projectName}
+
+A standalone [Invokta](https://docs.invokta.dev/) Action Engine with one
+deterministic capability shared by direct, CLI, and MCP stdio entry points.
+
+## Validate
+
+\`\`\`sh
+${commands.check}
+\`\`\`
+
+## Invoke directly
+
+\`\`\`sh
+${commands.direct}
+\`\`\`
+
+## Use the CLI
+
+\`\`\`sh
+${commands.list}
+${commands.run}
+\`\`\`
+
+## Start MCP stdio
+
+\`\`\`sh
+${commands.stdio}
+\`\`\`
+
+MCP stdio reserves standard output for protocol messages. Configure a client to
+start the compiled \`dist/mcp-stdio.js\` file directly with Node.
+
+Add stateless HTTP only when needed. Install \`@invokta/deploy\`, run
+\`invokta-deploy init\`, and implement its fail-closed authentication hook before
+exposing the endpoint.
+`;
+}
+
+function renderPackageManifest(
+  projectName: string,
+  invoktaVersion: string,
+): string {
+  const manifest = {
+    name: projectName,
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    engines: { node: ">=22.20.0" },
+    scripts: {
+      build: "tsc -p tsconfig.json --pretty false",
+      typecheck:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit",
+      test: "vitest run",
+      check:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit && vitest run && tsc -p tsconfig.json --pretty false",
+      direct: "node dist/direct.js",
+      cli: "node dist/cli.js",
+      "mcp:stdio": "node dist/mcp-stdio.js",
+    },
+    dependencies: {
+      "@invokta/cli": invoktaVersion,
+      "@invokta/core": invoktaVersion,
+      "@invokta/mcp": invoktaVersion,
+      zod: "4.4.3",
+    },
+    devDependencies: {
+      "@types/node": "26.1.2",
+      typescript: "7.0.2",
+      vitest: "4.1.10",
+    },
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+const capabilityModule = `import { defineCapability } from "@invokta/core";
+import { z } from "zod";
+
+export const createWelcomeMessage = defineCapability({
+  title: "Create a welcome message",
+  description: "Creates a short welcome message for a new team member.",
+  input: z.object({ name: z.string().trim().min(1) }),
+  output: z.object({ message: z.string().min(1) }),
+  access: "public",
+  annotations: {
+    readOnly: true,
+    destructive: false,
+    idempotent: true,
+    openWorld: false,
+  },
+  async run({ input }) {
+    return { message: \`Welcome, \${input.name}!\` };
+  },
+});
+`;
+
+function renderEngineModule(projectName: string): string {
+  return `import { createEngine } from "@invokta/core";
+
+import { createWelcomeMessage } from "./capabilities/create-welcome-message.js";
+
+export const engine = createEngine({
+  name: ${JSON.stringify(projectName)},
+  version: "0.1.0",
+  capabilities: {
+    "onboarding.create-welcome-message": createWelcomeMessage,
+  },
+});
+`;
+}
+
+const cliModule = `import { runCli } from "@invokta/cli";
+
+import { engine } from "./engine.js";
+
+process.exitCode = await runCli(engine, { principal: null });
+`;
+
+const directModule = `import { engine } from "./engine.js";
+
+const name = process.argv.slice(2).join(" ").trim() || "Developer";
+const result = await engine.invoke(
+  "onboarding.create-welcome-message",
+  { name },
+  { source: "direct", principal: null },
+);
+
+process.stdout.write(\`\${JSON.stringify(result)}\\n\`);
+`;
+
+const mcpStdioModule = `import { serveMcpStdio } from "@invokta/mcp";
+
+import { engine } from "./engine.js";
+
+await serveMcpStdio(engine, { principal: null });
+`;
+
+const engineTestModule = `import { describe, expect, it } from "vitest";
+
+import { engine } from "../src/engine.js";
+
+describe("welcome engine", () => {
+  it("creates a validated welcome message", async () => {
+    await expect(
+      engine.invoke(
+        "onboarding.create-welcome-message",
+        { name: "  Ada  " },
+        { principal: null },
+      ),
+    ).resolves.toEqual({ message: "Welcome, Ada!" });
+  });
+
+  it("rejects an empty name", async () => {
+    await expect(
+      engine.invoke(
+        "onboarding.create-welcome-message",
+        { name: "   " },
+        { principal: null },
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+});
+`;
+
+const tsconfig = `{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}
+`;
+
+const tsconfigTest = `{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+`;
+
+/** Returns the complete starter as deterministic, project-relative text files. */
+export function createStarterFiles(
+  options: CreateStarterFilesOptions,
+): readonly StarterFile[] {
+  return Object.freeze([
+    { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
+    {
+      path: "README.md",
+      contents: renderReadme(options.projectName, options.packageManager),
+    },
+    {
+      path: "package.json",
+      contents: renderPackageManifest(
+        options.projectName,
+        options.invoktaVersion,
+      ),
+    },
+    {
+      path: "src/capabilities/create-welcome-message.ts",
+      contents: capabilityModule,
+    },
+    { path: "src/cli.ts", contents: cliModule },
+    { path: "src/direct.ts", contents: directModule },
+    {
+      path: "src/engine.ts",
+      contents: renderEngineModule(options.projectName),
+    },
+    { path: "src/mcp-stdio.ts", contents: mcpStdioModule },
+    { path: "test/engine.test.ts", contents: engineTestModule },
+    { path: "tsconfig.json", contents: tsconfig },
+    { path: "tsconfig.test.json", contents: tsconfigTest },
+  ]);
+}

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -1,0 +1,279 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type CreateEngineIo,
+  type InstallProject,
+  runCreateEngineCli,
+} from "../src/cli.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-creator-cli-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function createHarness(
+  overrides: Partial<CreateEngineIo> = {},
+): CreateEngineIo & { readonly stdout: string[]; readonly stderr: string[] } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    writeStdout:
+      overrides.writeStdout ??
+      ((text) => {
+        stdout.push(text);
+      }),
+    writeStderr:
+      overrides.writeStderr ??
+      ((text) => {
+        stderr.push(text);
+      }),
+  };
+}
+
+const invalidArgumentCases: readonly Readonly<{
+  argv: readonly string[];
+}>[] = [
+  { argv: [] },
+  { argv: ["my-engine", "other-engine"] },
+  { argv: ["my-engine", "--unknown"] },
+  { argv: ["my-engine", "--no-install", "--no-install"] },
+  { argv: ["my-engine", "--package-manager"] },
+  { argv: ["my-engine", "--package-manager", "bun"] },
+  {
+    argv: [
+      "my-engine",
+      "--package-manager",
+      "npm",
+      "--package-manager",
+      "pnpm",
+    ],
+  },
+  { argv: ["--help", "my-engine"] },
+  { argv: ["--version", "fixture-secret-payload-marker"] },
+];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("runCreateEngineCli", () => {
+  it("creates without installing when --no-install is present", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+    const install = vi.fn<InstallProject>();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["my-engine", "--no-install"],
+      cwd,
+      env: {},
+      io,
+      install,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(install).not.toHaveBeenCalled();
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout.join("")).toBe(
+      "Created my-engine without installing dependencies.\n\n" +
+        "Next steps:\n" +
+        "  npm install --no-audit --no-fund\n" +
+        "  npm run check\n",
+    );
+    expect(
+      JSON.parse(readFileSync(join(cwd, "my-engine/package.json"), "utf8")),
+    ).toMatchObject({
+      name: "my-engine",
+      dependencies: { "@invokta/core": "1.2.3" },
+    });
+  });
+
+  it("installs once after the complete scaffold using the inferred manager", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+    const install = vi.fn<InstallProject>(
+      async ({ directory, packageManager }) => {
+        expect(packageManager).toBe("pnpm");
+        expect(existsSync(join(directory, "src/engine.ts"))).toBe(true);
+      },
+    );
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["my-engine"],
+      cwd,
+      env: { npm_config_user_agent: "pnpm/10.14.0 npm/? node/v22.20.0" },
+      io,
+      install,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(install).toHaveBeenCalledOnce();
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout.join("")).toBe(
+      "Created my-engine.\n\nNext step:\n  pnpm run check\n",
+    );
+  });
+
+  it("uses an explicit package manager instead of the inferred manager", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+    const install = vi.fn<InstallProject>(async () => undefined);
+
+    await runCreateEngineCli({
+      argv: ["--package-manager", "yarn", "my-engine"],
+      cwd,
+      env: { npm_config_user_agent: "pnpm/10.14.0" },
+      io,
+      install,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(install).toHaveBeenCalledWith({
+      directory: join(cwd, "my-engine"),
+      packageManager: "yarn",
+    });
+    expect(readFileSync(join(cwd, "my-engine/README.md"), "utf8")).toContain(
+      "yarn check",
+    );
+  });
+
+  it("preserves the complete scaffold when installation fails", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["my-engine"],
+      cwd,
+      env: {},
+      io,
+      install: async () => {
+        const { CreatorError } = await import("../src/errors.js");
+        throw new CreatorError("INSTALL_FAILED", ["npm"]);
+      },
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(1);
+    expect(io.stdout).toEqual([]);
+    expect(io.stderr.join("")).toBe(
+      "INSTALL_FAILED: The project dependencies could not be installed.\n" +
+        "  npm\n",
+    );
+    expect(existsSync(join(cwd, "my-engine/package.json"))).toBe(true);
+    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(7);
+  });
+
+  it.each(invalidArgumentCases)(
+    "rejects invalid arguments without creating a project: $argv",
+    async ({ argv }) => {
+      const cwd = createWorkingDirectory();
+      const io = createHarness();
+      const install = vi.fn<InstallProject>();
+
+      const exitCode = await runCreateEngineCli({
+        argv,
+        cwd,
+        env: {},
+        io,
+        install,
+      });
+
+      expect(exitCode).toBe(2);
+      expect(io.stdout).toEqual([]);
+      expect(io.stderr).toEqual([
+        'Invalid arguments. Run "create-invokta-engine --help".\n',
+      ]);
+      expect(io.stderr.join("")).not.toContain("fixture-secret-payload-marker");
+      expect(install).not.toHaveBeenCalled();
+      expect(readdirSync(cwd)).toEqual([]);
+    },
+  );
+
+  it("prints help without loading the package version", async () => {
+    const io = createHarness();
+    const loadPackageVersion = vi.fn<() => Promise<string>>();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["--help"],
+      io,
+      loadPackageVersion,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(loadPackageVersion).not.toHaveBeenCalled();
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout.join("")).toContain(
+      "create-invokta-engine <project-directory>",
+    );
+  });
+
+  it("prints the loaded package version", async () => {
+    const io = createHarness();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["--version"],
+      io,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(io.stderr).toEqual([]);
+    expect(io.stdout).toEqual(["1.2.3\n"]);
+  });
+
+  it("renders a target error without echoing the rejected path", async () => {
+    const cwd = createWorkingDirectory();
+    const io = createHarness();
+
+    const exitCode = await runCreateEngineCli({
+      argv: ["../fixture-secret-payload-marker", "--no-install"],
+      cwd,
+      io,
+      loadPackageVersion: async () => "1.2.3",
+    });
+
+    expect(exitCode).toBe(2);
+    expect(io.stdout).toEqual([]);
+    expect(io.stderr.join("")).toBe(
+      "TARGET_INVALID: The project path or name is invalid.\n",
+    );
+    expect(io.stderr.join("")).not.toContain("fixture-secret-payload-marker");
+  });
+
+  it("contains a rejected diagnostic writer", async () => {
+    const cwd = createWorkingDirectory();
+    writeFileSync(join(cwd, "sentinel"), "mine\n", "utf8");
+    const io = createHarness({
+      writeStderr: async () => {
+        throw new Error("closed diagnostic stream");
+      },
+    });
+
+    await expect(
+      runCreateEngineCli({
+        argv: ["my-engine", "--unknown"],
+        cwd,
+        io,
+      }),
+    ).resolves.toBe(2);
+  });
+});

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -179,7 +179,7 @@ describe("runCreateEngineCli", () => {
         "  npm\n",
     );
     expect(existsSync(join(cwd, "my-engine/package.json"))).toBe(true);
-    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(7);
+    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(8);
   });
 
   it.each(invalidArgumentCases)(

--- a/packages/create-invokta-engine/test/install.test.ts
+++ b/packages/create-invokta-engine/test/install.test.ts
@@ -86,4 +86,23 @@ describe("installProjectDependencies", () => {
       message: "The project dependencies could not be installed.",
     });
   });
+
+  it("normalizes a package-manager signal as an installation failure", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => ({
+      code: null,
+      signal: "SIGINT",
+    }));
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: "npm",
+        runner,
+      }),
+    ).rejects.toMatchObject({
+      code: "INSTALL_FAILED",
+      exitCode: 1,
+      details: ["npm"],
+    });
+  });
 });

--- a/packages/create-invokta-engine/test/install.test.ts
+++ b/packages/create-invokta-engine/test/install.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CreatorError } from "../src/errors.js";
+import {
+  installProjectDependencies,
+  type PackageManagerRunner,
+  selectPackageManager,
+} from "../src/install.js";
+
+describe("selectPackageManager", () => {
+  it.each([
+    ["npm/11.0.0 node/v22.20.0", "npm"],
+    ["pnpm/10.14.0 npm/? node/v22.20.0", "pnpm"],
+    ["yarn/1.22.22 npm/? node/v22.20.0", "yarn"],
+    [undefined, "npm"],
+    ["unknown/1.0.0", "npm"],
+  ] as const)("selects %s as %s", (userAgent, expected) => {
+    expect(selectPackageManager(undefined, userAgent)).toBe(expected);
+  });
+
+  it("gives an explicit package manager precedence over the user agent", () => {
+    expect(selectPackageManager("yarn", "pnpm/10.14.0")).toBe("yarn");
+  });
+});
+
+describe("installProjectDependencies", () => {
+  it.each([
+    ["npm", "npm", ["install", "--no-audit", "--no-fund"]],
+    ["pnpm", "pnpm", ["install"]],
+    ["yarn", "yarn", ["install"]],
+  ] as const)(
+    "runs one shell-free %s install",
+    async (manager, command, args) => {
+      const runner = vi.fn<PackageManagerRunner>(async () => ({
+        code: 0,
+        signal: null,
+      }));
+
+      await installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: manager,
+        runner,
+      });
+
+      expect(runner).toHaveBeenCalledOnce();
+      expect(runner).toHaveBeenCalledWith({
+        command,
+        args,
+        cwd: "/work/my-engine",
+        shell: false,
+        stdio: "inherit",
+      });
+    },
+  );
+
+  it("normalizes a non-zero child result without exposing child output", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => ({
+      code: 17,
+      signal: null,
+    }));
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: "pnpm",
+        runner,
+      }),
+    ).rejects.toEqual(new CreatorError("INSTALL_FAILED", ["pnpm"]));
+  });
+
+  it("normalizes an unavailable package manager", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => {
+      throw new Error("fixture secret from spawn");
+    });
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/my-engine",
+        packageManager: "yarn",
+        runner,
+      }),
+    ).rejects.toMatchObject({
+      code: "INSTALL_FAILED",
+      exitCode: 1,
+      details: ["yarn"],
+      message: "The project dependencies could not be installed.",
+    });
+  });
+});

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -1,0 +1,231 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CreatorError } from "../src/errors.js";
+import {
+  createStarterProject,
+  defaultScaffoldFileSystem,
+  type ScaffoldFileSystem,
+} from "../src/scaffold.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-creator-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function createProject(cwd: string, target = "my-engine") {
+  return createStarterProject({
+    cwd,
+    target,
+    invoktaVersion: "1.2.3",
+    packageManager: "npm",
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("createStarterProject", () => {
+  it("creates a complete project in an absent nested target", async () => {
+    const cwd = createWorkingDirectory();
+
+    const result = await createProject(cwd, "engines/my-engine");
+
+    expect(result.projectName).toBe("my-engine");
+    expect(result.directory).toBe(join(cwd, "engines/my-engine"));
+    expect(result.files).toHaveLength(11);
+    expect(
+      JSON.parse(readFileSync(join(result.directory, "package.json"), "utf8")),
+    ).toMatchObject({ name: "my-engine", private: true });
+  });
+
+  it("creates the starter in an existing empty directory", async () => {
+    const cwd = createWorkingDirectory();
+    mkdirSync(join(cwd, "my-engine"));
+
+    await createProject(cwd);
+
+    expect(readdirSync(join(cwd, "my-engine")).sort()).toEqual([
+      ".gitignore",
+      "README.md",
+      "package.json",
+      "src",
+      "test",
+      "tsconfig.json",
+      "tsconfig.test.json",
+    ]);
+  });
+
+  it("accepts dot only for a valid empty working-directory name", async () => {
+    const parent = createWorkingDirectory();
+    const cwd = join(parent, "current-engine");
+    mkdirSync(cwd);
+
+    const result = await createProject(cwd, ".");
+
+    expect(result.directory).toBe(cwd);
+    expect(result.projectName).toBe("current-engine");
+  });
+
+  it("rejects a non-empty target without changing it", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    mkdirSync(target);
+    writeFileSync(join(target, ".keep"), "mine\n", "utf8");
+
+    await expect(createProject(cwd)).rejects.toMatchObject({
+      code: "TARGET_NOT_EMPTY",
+      exitCode: 1,
+    });
+    expect(readFileSync(join(target, ".keep"), "utf8")).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".keep"]);
+  });
+
+  it.each([
+    ["an absolute path", "/tmp/my-engine"],
+    ["a parent segment", "../my-engine"],
+    ["a nested parent segment", "engines/../my-engine"],
+    ["an invalid package name", "My Engine"],
+    ["an empty name segment", "engines//my-engine"],
+    ["too many segments", `${"nested/".repeat(32)}my-engine`],
+    ["too many scalars", `${"a".repeat(1_025)}-engine`],
+  ])("rejects %s before creating a target", async (_label, target) => {
+    const cwd = createWorkingDirectory();
+
+    await expect(createProject(cwd, target)).rejects.toMatchObject({
+      code: "TARGET_INVALID",
+      exitCode: 2,
+    });
+    expect(readdirSync(cwd)).toEqual([]);
+  });
+
+  it("rejects a symbolic-link target without following it", async () => {
+    const cwd = createWorkingDirectory();
+    const outside = createWorkingDirectory();
+    symlinkSync(outside, join(cwd, "my-engine"), "dir");
+
+    await expect(createProject(cwd)).rejects.toMatchObject({
+      code: "TARGET_UNSAFE",
+      exitCode: 1,
+    });
+    expect(readdirSync(outside)).toEqual([]);
+  });
+
+  it("rejects a symbolic-link parent without following it", async () => {
+    const cwd = createWorkingDirectory();
+    const outside = createWorkingDirectory();
+    symlinkSync(outside, join(cwd, "engines"), "dir");
+
+    await expect(createProject(cwd, "engines/my-engine")).rejects.toMatchObject(
+      {
+        code: "TARGET_UNSAFE",
+        exitCode: 1,
+      },
+    );
+    expect(readdirSync(outside)).toEqual([]);
+  });
+
+  it("preserves a file that wins an exclusive-write race", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    let raced = false;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        if (!raced) {
+          raced = true;
+          writeFileSync(path, "mine\n", "utf8");
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
+    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".gitignore"]);
+  });
+
+  it("rolls back only paths created by a failed scaffold write", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    mkdirSync(target);
+    let writes = 0;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        writes += 1;
+        if (writes === 3) {
+          const error = new Error(
+            "fixture write failure",
+          ) as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toBeInstanceOf(CreatorError);
+    expect(existsSync(target)).toBe(true);
+    expect(readdirSync(target)).toEqual([]);
+  });
+
+  it("removes an absent target root after a failed scaffold write", async () => {
+    const cwd = createWorkingDirectory();
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile() {
+        const error = new Error(
+          "fixture write failure",
+        ) as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "nested/my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "WRITE_FAILED", exitCode: 1 });
+    expect(existsSync(join(cwd, "nested"))).toBe(false);
+  });
+});

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -85,6 +85,30 @@ describe("createStarterProject", () => {
     expect(result.projectName).toBe("current-engine");
   });
 
+  it("accepts the inclusive project-name limit", async () => {
+    const cwd = createWorkingDirectory();
+    const projectName = "a".repeat(214);
+
+    const result = await createProject(cwd, projectName);
+
+    expect(result.projectName).toBe(projectName);
+    expect(existsSync(join(result.directory, "package.json"))).toBe(true);
+  });
+
+  it("accepts the inclusive path-scalar and segment limits", async () => {
+    const cwd = createWorkingDirectory();
+    const target = [
+      ...Array.from({ length: 31 }, () => "a".repeat(31)),
+      "b".repeat(32),
+    ].join("/");
+    expect([...target]).toHaveLength(1_024);
+
+    const result = await createProject(cwd, target);
+
+    expect(result.projectName).toBe("b".repeat(32));
+    expect(existsSync(join(result.directory, "package.json"))).toBe(true);
+  });
+
   it("rejects a non-empty target without changing it", async () => {
     const cwd = createWorkingDirectory();
     const target = join(cwd, "my-engine");
@@ -105,6 +129,7 @@ describe("createStarterProject", () => {
     ["a nested parent segment", "engines/../my-engine"],
     ["an invalid package name", "My Engine"],
     ["an empty name segment", "engines//my-engine"],
+    ["a project name over 214 characters", "a".repeat(215)],
     ["too many segments", `${"nested/".repeat(32)}my-engine`],
     ["too many scalars", `${"a".repeat(1_025)}-engine`],
   ])("rejects %s before creating a target", async (_label, target) => {
@@ -127,6 +152,17 @@ describe("createStarterProject", () => {
       exitCode: 1,
     });
     expect(readdirSync(outside)).toEqual([]);
+  });
+
+  it("rejects a non-directory target without replacing it", async () => {
+    const cwd = createWorkingDirectory();
+    writeFileSync(join(cwd, "my-engine"), "mine\n", "utf8");
+
+    await expect(createProject(cwd)).rejects.toMatchObject({
+      code: "TARGET_UNSAFE",
+      exitCode: 1,
+    });
+    expect(readFileSync(join(cwd, "my-engine"), "utf8")).toBe("mine\n");
   });
 
   it("rejects a symbolic-link parent without following it", async () => {

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -51,7 +51,7 @@ describe("createStarterProject", () => {
 
     expect(result.projectName).toBe("my-engine");
     expect(result.directory).toBe(join(cwd, "engines/my-engine"));
-    expect(result.files).toHaveLength(11);
+    expect(result.files).toHaveLength(12);
     expect(
       JSON.parse(readFileSync(join(result.directory, "package.json"), "utf8")),
     ).toMatchObject({ name: "my-engine", private: true });
@@ -66,6 +66,7 @@ describe("createStarterProject", () => {
     expect(readdirSync(join(cwd, "my-engine")).sort()).toEqual([
       ".gitignore",
       "README.md",
+      "invokta.mcp.json",
       "package.json",
       "src",
       "test",

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { createStarterFiles } from "../src/starter.js";
+
+const expectedPaths = [
+  ".gitignore",
+  "README.md",
+  "package.json",
+  "src/capabilities/create-welcome-message.ts",
+  "src/cli.ts",
+  "src/direct.ts",
+  "src/engine.ts",
+  "src/mcp-stdio.ts",
+  "test/engine.test.ts",
+  "tsconfig.json",
+  "tsconfig.test.json",
+] as const;
+
+describe("createStarterFiles", () => {
+  it("renders the fixed standalone starter in lexicographic path order", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+
+    expect(files.map((file) => file.path)).toEqual(expectedPaths);
+    expect(files).toEqual(
+      createStarterFiles({
+        projectName: "customer-support-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    );
+    for (const file of files) {
+      expect(file.contents).not.toContain("\r");
+      expect(file.contents).not.toContain("\u0000");
+      expect(file.contents.endsWith("\n")).toBe(true);
+      expect(file.contents.endsWith("\n\n")).toBe(false);
+    }
+  });
+
+  it("pins Invokta packages to the creator version in a private ESM project", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3-beta.1",
+      packageManager: "npm",
+    });
+    const manifestFile = files.find((file) => file.path === "package.json");
+    const manifest = JSON.parse(manifestFile?.contents ?? "") as Record<
+      string,
+      unknown
+    >;
+
+    expect(manifest).toMatchObject({
+      name: "customer-support-engine",
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      engines: { node: ">=22.20.0" },
+      dependencies: {
+        "@invokta/cli": "1.2.3-beta.1",
+        "@invokta/core": "1.2.3-beta.1",
+        "@invokta/mcp": "1.2.3-beta.1",
+        zod: "4.4.3",
+      },
+      devDependencies: {
+        "@types/node": "26.1.2",
+        typescript: "7.0.2",
+        vitest: "4.1.10",
+      },
+    });
+  });
+
+  it("uses one public capability through direct, CLI, and MCP stdio entry points", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+    const contents = new Map(files.map((file) => [file.path, file.contents]));
+
+    expect(
+      contents.get("src/capabilities/create-welcome-message.ts"),
+    ).toContain('access: "public"');
+    expect(contents.get("src/engine.ts")).toContain(
+      '"onboarding.create-welcome-message": createWelcomeMessage',
+    );
+    expect(contents.get("src/engine.ts")).toContain(
+      'name: "customer-support-engine"',
+    );
+    expect(contents.get("src/direct.ts")).toContain("engine.invoke(");
+    expect(contents.get("src/cli.ts")).toContain("runCli(engine");
+    expect(contents.get("src/mcp-stdio.ts")).toContain("serveMcpStdio(engine");
+    expect([...contents.keys()]).not.toContain("src/mcp-http.ts");
+  });
+
+  it.each([
+    ["npm", "npm run check"],
+    ["pnpm", "pnpm run check"],
+    ["yarn", "yarn check"],
+  ] as const)(
+    "renders %s commands in the generated README",
+    (manager, command) => {
+      const files = createStarterFiles({
+        projectName: "customer-support-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: manager,
+      });
+
+      expect(
+        files.find((file) => file.path === "README.md")?.contents,
+      ).toContain(command);
+    },
+  );
+});

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -5,6 +5,7 @@ import { createStarterFiles } from "../src/starter.js";
 const expectedPaths = [
   ".gitignore",
   "README.md",
+  "invokta.mcp.json",
   "package.json",
   "src/capabilities/create-welcome-message.ts",
   "src/cli.ts",
@@ -65,9 +66,39 @@ describe("createStarterFiles", () => {
         zod: "4.4.3",
       },
       devDependencies: {
+        "@invokta/installer": "1.2.3-beta.1",
         "@types/node": "26.1.2",
         typescript: "7.0.2",
         vitest: "4.1.10",
+      },
+    });
+  });
+
+  it("declares a deterministic local MCP installation source", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+    const contents = new Map(files.map((file) => [file.path, file.contents]));
+    const packageManifest = JSON.parse(contents.get("package.json") ?? "") as {
+      readonly scripts: Readonly<Record<string, string>>;
+    };
+
+    expect(packageManifest.scripts["mcp:install"]).toBe(
+      "tsc -p tsconfig.json --pretty false && invokta-installer install --engine .",
+    );
+    expect(JSON.parse(contents.get("invokta.mcp.json") ?? "")).toEqual({
+      schemaVersion: 1,
+      id: "customer-support-engine",
+      version: "0.1.0",
+      title: "customer-support-engine",
+      description: "MCP access to the customer-support-engine Action Engine.",
+      capabilityIds: ["onboarding.create-welcome-message"],
+      server: {
+        name: "customer-support-engine",
+        entrypoint: "dist/mcp-stdio.js",
+        forwardEnv: [],
       },
     });
   });

--- a/packages/create-invokta-engine/tsconfig.json
+++ b/packages/create-invokta-engine/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@invokta/installer",
   "version": "0.1.0",
-  "description": "Read-only local MCP client inventory for Invokta.",
+  "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
   "repository": {

--- a/packages/installer/src/engine-manifest.ts
+++ b/packages/installer/src/engine-manifest.ts
@@ -1,0 +1,369 @@
+import { isAbsolute, join, resolve } from "node:path";
+import { evaluate, parse, type ValueNode } from "@humanwhocodes/momoa";
+
+import {
+  type InstallerFileStat,
+  type InstallerReadHandle,
+  type InstallerTransactionFileSystem,
+  isInstallerFileSystemError,
+} from "./file-system.js";
+import { InstallerError } from "./installer-error.js";
+import {
+  capturePathIdentity,
+  capturePathRoot,
+  type InstallerPathIdentity,
+  type InstallerPathRootIdentity,
+} from "./path-identity.js";
+import type { CapabilityInstallDescriptor } from "./registry.js";
+
+const manifestByteLimit = 1_048_576;
+const generalStringLimit = 4_096;
+const entrypointScalarLimit = 1_024;
+const entrypointSegmentLimit = 32;
+const idPattern = /^[a-z][a-z0-9-]{0,127}$/u;
+const serverNamePattern = /^[a-z][a-z0-9_-]{0,63}$/u;
+const environmentNamePattern = /^[A-Z_][A-Z0-9_]{0,127}$/u;
+const rootKeys = new Set([
+  "schemaVersion",
+  "id",
+  "version",
+  "title",
+  "description",
+  "capabilityIds",
+  "server",
+]);
+const serverKeys = new Set(["name", "entrypoint", "forwardEnv"]);
+
+type JsonRecord = Record<string, unknown>;
+
+interface ValidatedEngineManifest {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly version: string;
+  readonly title: string;
+  readonly description: string;
+  readonly capabilityIds: readonly string[];
+  readonly server: {
+    readonly name: string;
+    readonly entrypoint: string;
+    readonly forwardEnv: readonly string[];
+  };
+}
+
+export interface LoadEngineInstallManifestOptions {
+  readonly currentUserId: number;
+  readonly fileSystem: InstallerTransactionFileSystem;
+  readonly nodeExecutable: string;
+  readonly projectDirectory: string;
+}
+
+export interface EngineInstallSource {
+  readonly manifestPath: string;
+  readonly entrypointPath: string;
+  readonly descriptor: CapabilityInstallDescriptor;
+}
+
+function manifestInvalid(cause?: unknown): never {
+  throw new InstallerError("ENGINE_MANIFEST_INVALID", cause);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: JsonRecord,
+  allowed: ReadonlySet<string>,
+  required: readonly string[],
+): boolean {
+  const keys = Object.keys(value);
+  return (
+    keys.every((key) => allowed.has(key)) &&
+    required.every((key) => Object.hasOwn(value, key))
+  );
+}
+
+function scalarLength(value: string): number | undefined {
+  let count = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const following = value.charCodeAt(index + 1);
+      if (!(following >= 0xdc00 && following <= 0xdfff)) return undefined;
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return undefined;
+    }
+    count += 1;
+  }
+  return count;
+}
+
+function validString(
+  value: unknown,
+  options: { readonly limit?: number; readonly nonempty?: boolean } = {},
+): value is string {
+  if (typeof value !== "string" || value.includes("\0")) return false;
+  const length = scalarLength(value);
+  if (length === undefined || length > (options.limit ?? generalStringLimit)) {
+    return false;
+  }
+  return options.nonempty !== true || value.trim() !== "";
+}
+
+function validUniqueStringArray(
+  value: unknown,
+  options: {
+    readonly maximum: number;
+    readonly minimum?: number;
+    readonly environmentNames?: boolean;
+  },
+): value is string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length < (options.minimum ?? 0) ||
+    value.length > options.maximum
+  ) {
+    return false;
+  }
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!validString(item, { nonempty: true }) || seen.has(item)) return false;
+    if (
+      options.environmentNames === true &&
+      !environmentNamePattern.test(item)
+    ) {
+      return false;
+    }
+    seen.add(item);
+  }
+  return true;
+}
+
+function validEntrypoint(value: unknown): value is string {
+  if (
+    !validString(value, { limit: entrypointScalarLimit, nonempty: true }) ||
+    value.startsWith("/") ||
+    value.includes("\\")
+  ) {
+    return false;
+  }
+  const segments = value.split("/");
+  return (
+    segments.length <= entrypointSegmentLimit &&
+    segments.every(
+      (segment) => segment !== "" && segment !== "." && segment !== "..",
+    )
+  );
+}
+
+function hasDuplicateObjectKey(node: ValueNode): boolean {
+  if (node.type === "Object") {
+    const names = new Set<string>();
+    for (const member of node.members) {
+      const name =
+        member.name.type === "String" ? member.name.value : member.name.name;
+      if (names.has(name) || hasDuplicateObjectKey(member.value)) return true;
+      names.add(name);
+    }
+  } else if (node.type === "Array") {
+    return node.elements.some((element) =>
+      hasDuplicateObjectKey(element.value),
+    );
+  }
+  return false;
+}
+
+function validateParsedManifest(value: unknown): ValidatedEngineManifest {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, rootKeys, [
+      "schemaVersion",
+      "id",
+      "version",
+      "title",
+      "description",
+      "capabilityIds",
+      "server",
+    ]) ||
+    value.schemaVersion !== 1 ||
+    !validString(value.id) ||
+    !idPattern.test(value.id) ||
+    !validString(value.version, { nonempty: true }) ||
+    !validString(value.title, { limit: 120, nonempty: true }) ||
+    !validString(value.description, { limit: 1_000, nonempty: true }) ||
+    !validUniqueStringArray(value.capabilityIds, {
+      maximum: 100,
+      minimum: 1,
+    }) ||
+    !isRecord(value.server) ||
+    !hasExactKeys(value.server, serverKeys, [
+      "name",
+      "entrypoint",
+      "forwardEnv",
+    ]) ||
+    !validString(value.server.name) ||
+    !serverNamePattern.test(value.server.name) ||
+    !validEntrypoint(value.server.entrypoint) ||
+    !validUniqueStringArray(value.server.forwardEnv, {
+      maximum: 64,
+      environmentNames: true,
+    })
+  ) {
+    return manifestInvalid();
+  }
+
+  return Object.freeze({
+    schemaVersion: 1,
+    id: value.id,
+    version: value.version,
+    title: value.title,
+    description: value.description,
+    capabilityIds: Object.freeze([...value.capabilityIds]),
+    server: Object.freeze({
+      name: value.server.name,
+      entrypoint: value.server.entrypoint,
+      forwardEnv: Object.freeze([...value.server.forwardEnv]),
+    }),
+  });
+}
+
+export function validateEngineInstallManifestBytes(
+  bytes: Uint8Array,
+): ValidatedEngineManifest {
+  if (
+    bytes.byteLength > manifestByteLimit ||
+    (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf)
+  ) {
+    return manifestInvalid();
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+      bytes,
+    );
+  } catch (cause) {
+    return manifestInvalid(cause);
+  }
+
+  try {
+    const document = parse(text, { mode: "json" });
+    if (hasDuplicateObjectKey(document.body)) return manifestInvalid();
+    return validateParsedManifest(evaluate(document));
+  } catch (cause) {
+    if (cause instanceof InstallerError) throw cause;
+    return manifestInvalid(cause);
+  }
+}
+
+function sameStat(
+  expected: InstallerFileStat | undefined,
+  actual: InstallerFileStat,
+): boolean {
+  return (
+    expected !== undefined &&
+    expected.kind === actual.kind &&
+    expected.dev === actual.dev &&
+    expected.ino === actual.ino &&
+    expected.uid === actual.uid &&
+    expected.gid === actual.gid
+  );
+}
+
+async function readCapturedManifest(
+  fileSystem: InstallerTransactionFileSystem,
+  identity: InstallerPathIdentity,
+): Promise<Uint8Array> {
+  let handle: InstallerReadHandle | undefined;
+  try {
+    handle = await fileSystem.openReadNoFollow(identity.targetPath);
+    const stat = await handle.stat();
+    if (!sameStat(identity.components.at(-1), stat)) {
+      throw new InstallerError("ENGINE_PATH_UNSAFE");
+    }
+    return await handle.readAll(manifestByteLimit);
+  } catch (cause) {
+    if (cause instanceof InstallerError) throw cause;
+    if (isInstallerFileSystemError(cause, "SYMBOLIC_LINK")) {
+      throw new InstallerError("ENGINE_PATH_UNSAFE", cause);
+    }
+    throw new InstallerError("ENGINE_MANIFEST_INVALID", cause);
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+export async function loadEngineInstallManifest(
+  options: LoadEngineInstallManifestOptions,
+): Promise<EngineInstallSource> {
+  if (
+    !Number.isSafeInteger(options.currentUserId) ||
+    options.currentUserId < 0 ||
+    !isAbsolute(options.nodeExecutable) ||
+    options.nodeExecutable.includes("\0") ||
+    !isAbsolute(resolve(options.projectDirectory)) ||
+    options.projectDirectory.includes("\0")
+  ) {
+    throw new InstallerError("ENGINE_PATH_UNSAFE");
+  }
+  const projectDirectory = resolve(options.projectDirectory);
+  let root: InstallerPathRootIdentity;
+  let manifestIdentity: InstallerPathIdentity;
+  try {
+    root = await capturePathRoot(options.fileSystem, {
+      rootKind: "engine",
+      rootPath: projectDirectory,
+      currentUserId: options.currentUserId,
+    });
+    manifestIdentity = await capturePathIdentity(options.fileSystem, {
+      root,
+      targetPath: join(projectDirectory, "invokta.mcp.json"),
+      targetKind: "regular-file",
+    });
+  } catch (cause) {
+    throw new InstallerError("ENGINE_PATH_UNSAFE", cause);
+  }
+  if (manifestIdentity.missingPaths.length > 0) {
+    throw new InstallerError("ENGINE_MANIFEST_INVALID");
+  }
+  const manifest = validateEngineInstallManifestBytes(
+    await readCapturedManifest(options.fileSystem, manifestIdentity),
+  );
+  const entrypointPath = join(
+    projectDirectory,
+    ...manifest.server.entrypoint.split("/"),
+  );
+  let entrypointIdentity: InstallerPathIdentity;
+  try {
+    entrypointIdentity = await capturePathIdentity(options.fileSystem, {
+      root,
+      targetPath: entrypointPath,
+      targetKind: "regular-file",
+    });
+  } catch (cause) {
+    throw new InstallerError("ENGINE_PATH_UNSAFE", cause);
+  }
+  if (entrypointIdentity.missingPaths.length > 0) {
+    throw new InstallerError("ENGINE_ENTRYPOINT_MISSING");
+  }
+
+  const transport = Object.freeze({
+    type: "stdio" as const,
+    command: options.nodeExecutable,
+    args: Object.freeze([entrypointPath]),
+    forwardEnv: manifest.server.forwardEnv,
+  });
+  const descriptor: CapabilityInstallDescriptor = Object.freeze({
+    id: manifest.id,
+    version: manifest.version,
+    title: manifest.title,
+    description: manifest.description,
+    capabilityIds: manifest.capabilityIds,
+    server: Object.freeze({ name: manifest.server.name, transport }),
+  });
+  return Object.freeze({
+    manifestPath: manifestIdentity.targetPath,
+    entrypointPath,
+    descriptor,
+  });
+}

--- a/packages/installer/src/harness-catalog.ts
+++ b/packages/installer/src/harness-catalog.ts
@@ -5,13 +5,15 @@ export interface HarnessSurfaceDefinition {
     | "antigravity-cli"
     | "antigravity-ide"
     | "claude-code"
+    | "claude-desktop"
     | "codex"
     | "cursor"
     | "grok-build"
     | "hermes"
     | "kimi-code"
     | "openclaw"
-    | "opencode-v2";
+    | "opencode-v2"
+    | "vscode";
   readonly displayName: string;
   readonly executableCandidates: readonly string[];
   readonly targetId: ConfigurationTargetId;
@@ -58,6 +60,12 @@ export const harnessSurfaceCatalog = Object.freeze([
     targetId: "claude-code",
   }),
   surface({
+    id: "claude-desktop",
+    displayName: "Claude Desktop",
+    executableCandidates: ["Claude"],
+    targetId: "claude-desktop",
+  }),
+  surface({
     id: "codex",
     displayName: "Codex",
     executableCandidates: ["codex"],
@@ -99,6 +107,12 @@ export const harnessSurfaceCatalog = Object.freeze([
     executableCandidates: ["opencode2"],
     targetId: "opencode-v2",
   }),
+  surface({
+    id: "vscode",
+    displayName: "Visual Studio Code",
+    executableCandidates: ["code"],
+    targetId: "vscode",
+  }),
 ] as const satisfies readonly HarnessSurfaceDefinition[]);
 
 export type HarnessSurfaceId = (typeof harnessSurfaceCatalog)[number]["id"];
@@ -114,6 +128,11 @@ export const configurationTargetCatalog = Object.freeze([
     id: "claude-code",
     displayName: "Claude Code",
     reloadHint: "Start a new Claude Code session and inspect with /mcp.",
+  }),
+  target({
+    id: "claude-desktop",
+    displayName: "Claude Desktop",
+    reloadHint: "Restart Claude Desktop, then inspect its MCP integrations.",
   }),
   target({
     id: "codex",
@@ -150,5 +169,10 @@ export const configurationTargetCatalog = Object.freeze([
     id: "opencode-v2",
     displayName: "OpenCode v2",
     reloadHint: "Start a new OpenCode v2 session.",
+  }),
+  target({
+    id: "vscode",
+    displayName: "Visual Studio Code",
+    reloadHint: "Run MCP: List Servers and restart the configured server.",
   }),
 ] as const satisfies readonly ConfigurationTargetDefinition[]);

--- a/packages/installer/src/install-session.ts
+++ b/packages/installer/src/install-session.ts
@@ -1,0 +1,99 @@
+import type {
+  ExecutableResolver,
+  HarnessDetectionSnapshot,
+} from "./harness-detection.js";
+import { InstallerError, installerErrorMessages } from "./installer-error.js";
+import type { InteractivePrompter } from "./interactive-prompter.js";
+import {
+  installDescriptorAcrossTargets,
+  type MutationCoordinatorDependencies,
+} from "./mutation-coordinator.js";
+import type {
+  CapabilityInstallDescriptor,
+  ConfigurationTargetId,
+} from "./registry.js";
+import type { InstallerExitCode } from "./run-installer-cli.js";
+import { resolveRuntimeRequirements } from "./runtime-requirements.js";
+
+export interface RunInstallSessionOptions {
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly descriptor: CapabilityInstallDescriptor;
+  readonly prompter: InteractivePrompter;
+  readonly resolveExecutable: ExecutableResolver;
+  readonly snapshot: HarnessDetectionSnapshot;
+}
+
+function cancelled(prompter: InteractivePrompter): 130 {
+  prompter.cancel(installerErrorMessages.CANCELLED);
+  return 130;
+}
+
+export async function runInstallSession(
+  options: RunInstallSessionOptions,
+): Promise<InstallerExitCode> {
+  const ready = await resolveRuntimeRequirements({
+    action: "install",
+    descriptor: options.descriptor.server,
+    resolveExecutable: options.resolveExecutable,
+    environment: options.dependencies.environment,
+  });
+  if (ready.kind === "blocked") throw new InstallerError(ready.code);
+
+  const targets = options.snapshot.targets.filter(
+    (target) =>
+      target.eligible &&
+      target.configuration.kind !== "blocked" &&
+      options.dependencies.adapters[target.id].compatibility(options.descriptor)
+        .supported,
+  );
+  if (targets.length === 0) throw new InstallerError("NO_SUPPORTED_HARNESS");
+  const targetIds = targets.map(({ id }) => id);
+  const selection = await options.prompter.multiselect<ConfigurationTargetId>({
+    message: `Install ${options.descriptor.title} in which MCP clients?`,
+    options: targets.map((target) => ({
+      value: target.id,
+      label: target.displayName,
+      hint: target.evidence,
+    })),
+    initialValues: targetIds,
+  });
+  if (selection.kind === "cancelled") return cancelled(options.prompter);
+  const confirmed = await options.prompter.confirm(
+    `Update ${String(selection.value.length)} MCP client configuration${selection.value.length === 1 ? "" : "s"}?`,
+  );
+  if (confirmed.kind === "cancelled") return cancelled(options.prompter);
+  if (!confirmed.value) {
+    options.prompter.outro("No changes were made.");
+    return 0;
+  }
+
+  const results = await installDescriptorAcrossTargets({
+    dependencies: options.dependencies,
+    descriptor: options.descriptor,
+    snapshot: options.snapshot,
+    targetIds: selection.value,
+  });
+  let failed = false;
+  for (const result of results) {
+    const target = targets.find(({ id }) => id === result.targetId);
+    const name = target?.displayName ?? result.targetId;
+    if (result.outcome === "failed") {
+      failed = true;
+      options.prompter.log(
+        "error",
+        `${name}: ${result.code}: ${installerErrorMessages[result.code]}`,
+      );
+    } else {
+      options.prompter.log(
+        "success",
+        `${name}: ${result.outcome === "installed" ? "installed" : "already installed"}.`,
+      );
+    }
+  }
+  options.prompter.outro(
+    failed
+      ? "Installation completed with errors."
+      : "Action Engine installed. Restart or reload the selected MCP clients.",
+  );
+  return failed ? 1 : 0;
+}

--- a/packages/installer/src/install-session.ts
+++ b/packages/installer/src/install-session.ts
@@ -58,6 +58,10 @@ export async function runInstallSession(
     initialValues: targetIds,
   });
   if (selection.kind === "cancelled") return cancelled(options.prompter);
+  if (selection.value.length === 0) {
+    options.prompter.outro("No changes were made.");
+    return 0;
+  }
   const confirmed = await options.prompter.confirm(
     `Update ${String(selection.value.length)} MCP client configuration${selection.value.length === 1 ? "" : "s"}?`,
   );

--- a/packages/installer/src/installer-error.ts
+++ b/packages/installer/src/installer-error.ts
@@ -1,5 +1,10 @@
 export const installerErrorMessages = Object.freeze({
   REGISTRY_INVALID: "The local capability registry is invalid.",
+  ENGINE_MANIFEST_INVALID: "The Action Engine manifest is invalid.",
+  ENGINE_PATH_UNSAFE: "The Action Engine path is unsafe.",
+  ENGINE_ENTRYPOINT_MISSING: "The Action Engine entry point was not found.",
+  REMOTE_INVALID: "The remote MCP server definition is invalid.",
+  INSTALLATION_UNAVAILABLE: "The managed installation is unavailable.",
   INSTALLER_INITIALIZATION_FAILED: "The installer could not be initialized.",
   NO_TTY: "The installer requires an interactive terminal.",
   NO_SUPPORTED_HARNESS: "No supported AI harness was detected.",

--- a/packages/installer/src/installer-state-transition.ts
+++ b/packages/installer/src/installer-state-transition.ts
@@ -178,12 +178,42 @@ function applyUpdate(
 } {
   if (
     plan.stateEffect !== "update" ||
-    (plan.action !== "enable" && plan.action !== "disable")
+    (plan.action !== "install" &&
+      plan.action !== "enable" &&
+      plan.action !== "disable")
   ) {
     return invalidState();
   }
   if (!isInstallerTimestampAfter(occurredAt, installation.updatedAt)) {
     return invalidState();
+  }
+  if (plan.action === "install") {
+    if (plan.definitionSource !== "registry") return invalidState();
+    const suspendedDescriptor =
+      planning.target.toggleStrategy === "detached" &&
+      planning.currentServer.kind === "absent"
+        ? planning.descriptor.server
+        : undefined;
+    return {
+      installation: {
+        entryId: planning.descriptor.id,
+        registryVersion: planning.descriptor.version,
+        targetId: planning.targetId,
+        configPath: planning.target.configPath,
+        serverName: planning.descriptor.server.name,
+        definitionSha256: fingerprintNormalizedDefinition(
+          planning.registryDefinition,
+          planning.target.toggleStrategy,
+        ),
+        targetContractVersion: planning.target.targetContractVersion,
+        toggleStrategy: planning.target.toggleStrategy,
+        launchDescriptor: planning.descriptor.server,
+        ...(suspendedDescriptor === undefined ? {} : { suspendedDescriptor }),
+        adopted: false,
+        installedAt: installation.installedAt,
+        updatedAt: occurredAt,
+      },
+    };
   }
   if (planning.target.toggleStrategy !== "detached") {
     if (plan.definitionSource !== "managed") return invalidState();

--- a/packages/installer/src/installer-state-transition.ts
+++ b/packages/installer/src/installer-state-transition.ts
@@ -1,7 +1,7 @@
 import { InstallerError } from "./installer-error.js";
 import {
-  installationKey,
   type InstallerState,
+  installationKey,
   isInstallerTimestampAfter,
   type ManagedInstallation,
   type StateTargetContracts,
@@ -135,6 +135,7 @@ function createInstallation(
     ),
     targetContractVersion: planning.target.targetContractVersion,
     toggleStrategy: planning.target.toggleStrategy,
+    launchDescriptor: planning.descriptor.server,
     adopted: plan.action === "adopt",
     installedAt: occurredAt,
     updatedAt: occurredAt,
@@ -155,6 +156,9 @@ function updatedInstallation(
     definitionSha256: installation.definitionSha256,
     targetContractVersion: installation.targetContractVersion,
     toggleStrategy: installation.toggleStrategy,
+    ...(installation.launchDescriptor === undefined
+      ? {}
+      : { launchDescriptor: installation.launchDescriptor }),
     ...(suspendedDescriptor === undefined ? {} : { suspendedDescriptor }),
     adopted: installation.adopted,
     installedAt: installation.installedAt,

--- a/packages/installer/src/installer-state.ts
+++ b/packages/installer/src/installer-state.ts
@@ -94,6 +94,7 @@ export type InstallerStateValidationResult =
   | { readonly ok: false; readonly issues: readonly StateIssue[] };
 
 export interface LoadInstallerStateOptions {
+  readonly allowUnavailableTargetContracts?: boolean;
   readonly currentUserId: number | undefined;
   readonly environment: InstallerEnvironment;
   readonly fileSystem: InstallerFileSystem;
@@ -662,6 +663,7 @@ function validateInstallation(
   value: unknown,
   pointer: string,
   targetContracts: StateTargetContracts,
+  allowUnavailableTargetContracts: boolean,
   seenPairs: Set<string>,
   issues: StateIssue[],
 ): value is JsonRecord {
@@ -814,7 +816,9 @@ function validateInstallation(
 
   if (validTargetId) {
     const contract = targetContracts[value.targetId as ConfigurationTargetId];
-    if (!isRecord(contract) || contract.targetContractVersion !== 1) {
+    if (contract === undefined && allowUnavailableTargetContracts) {
+      // Status still validates intrinsic state when a target cannot be detected.
+    } else if (!isRecord(contract) || contract.targetContractVersion !== 1) {
       addIssue(
         issues,
         childPointer(pointer, "targetId"),
@@ -1006,6 +1010,7 @@ export function createEmptyInstallerState(): InstallerState {
 export function validateInstallerStateBytes(
   bytes: Uint8Array,
   targetContracts: StateTargetContracts,
+  options: { readonly allowUnavailableTargetContracts?: boolean } = {},
 ): InstallerStateValidationResult {
   if (bytes.byteLength > stateByteLimit) {
     return invalid([{ pointer: "", code: "STATE_TOO_LARGE" }]);
@@ -1064,6 +1069,7 @@ export function validateInstallerStateBytes(
         value,
         recordPointer,
         targetContracts,
+        options.allowUnavailableTargetContracts === true,
         seenPairs,
         issues,
       )
@@ -1203,7 +1209,10 @@ export async function loadInstallerState(
   } catch (cause) {
     throw new InstallerError("STATE_READ_FAILED", cause);
   }
-  const result = validateInstallerStateBytes(bytes, options.targetContracts);
+  const result = validateInstallerStateBytes(bytes, options.targetContracts, {
+    allowUnavailableTargetContracts:
+      options.allowUnavailableTargetContracts === true,
+  });
   if (!result.ok) {
     throw new InstallerError(
       "STATE_INVALID",

--- a/packages/installer/src/installer-state.ts
+++ b/packages/installer/src/installer-state.ts
@@ -109,7 +109,7 @@ export interface LoadedInstallerState {
 type JsonRecord = Record<string, unknown>;
 
 const stateByteLimit = 16_777_216;
-const installationLimit = 9_000;
+const installationLimit = 11_000;
 const stringLimit = 4_096;
 const idPattern = /^[a-z][a-z0-9-]{0,127}$/u;
 const serverNamePattern = /^[a-z][a-z0-9_-]{0,63}$/u;

--- a/packages/installer/src/installer-state.ts
+++ b/packages/installer/src/installer-state.ts
@@ -39,6 +39,7 @@ export interface ManagedInstallation {
   readonly definitionSha256: string;
   readonly targetContractVersion: 1;
   readonly toggleStrategy: ToggleStrategy;
+  readonly launchDescriptor?: SuspendedDescriptor;
   readonly suspendedDescriptor?: SuspendedDescriptor;
   readonly adopted: boolean;
   readonly installedAt: string;
@@ -127,6 +128,7 @@ const installationKeys = new Set([
   "definitionSha256",
   "targetContractVersion",
   "toggleStrategy",
+  "launchDescriptor",
   "suspendedDescriptor",
   "adopted",
   "installedAt",
@@ -595,6 +597,14 @@ function normalizeTransport(
 }
 
 function normalizeInstallation(value: JsonRecord): ManagedInstallation {
+  const rawLaunch = value.launchDescriptor as JsonRecord | undefined;
+  const launchDescriptor =
+    rawLaunch === undefined
+      ? undefined
+      : Object.freeze({
+          name: rawLaunch.name as string,
+          transport: normalizeTransport(rawLaunch.transport as JsonRecord),
+        });
   const rawSuspended = value.suspendedDescriptor as JsonRecord | undefined;
   const suspendedDescriptor =
     rawSuspended === undefined
@@ -612,6 +622,7 @@ function normalizeInstallation(value: JsonRecord): ManagedInstallation {
     definitionSha256: value.definitionSha256 as string,
     targetContractVersion: 1,
     toggleStrategy: value.toggleStrategy as ToggleStrategy,
+    ...(launchDescriptor === undefined ? {} : { launchDescriptor }),
     ...(suspendedDescriptor === undefined ? {} : { suspendedDescriptor }),
     adopted: value.adopted as boolean,
     installedAt: value.installedAt as string,
@@ -848,6 +859,14 @@ function validateInstallation(
     validateSuspendedDescriptor(
       value.suspendedDescriptor,
       childPointer(pointer, "suspendedDescriptor"),
+      value.serverName,
+      issues,
+    );
+  }
+  if (value.launchDescriptor !== undefined) {
+    validateSuspendedDescriptor(
+      value.launchDescriptor,
+      childPointer(pointer, "launchDescriptor"),
       value.serverName,
       issues,
     );

--- a/packages/installer/src/interactive-session.ts
+++ b/packages/installer/src/interactive-session.ts
@@ -52,6 +52,7 @@ export interface RunInteractiveSessionOptions {
   readonly resolveExecutable?: ExecutableResolver;
   readonly configEvidenceProbes?: TargetConfigEvidenceProbes;
   readonly environment?: InstallerEnvironment;
+  readonly platform?: NodeJS.Platform;
 }
 
 export async function runInteractiveSession(
@@ -89,6 +90,9 @@ export async function runInteractiveSession(
         createNodeTargetConfigEvidenceProbes({
           environment,
           fileSystem,
+          ...(options.platform === undefined
+            ? {}
+            : { platform: options.platform }),
         }),
     });
     progress.stop("Harness detection complete");

--- a/packages/installer/src/interactive-session.ts
+++ b/packages/installer/src/interactive-session.ts
@@ -15,6 +15,8 @@ import {
 import { runInstallSession } from "./install-session.js";
 import { InstallerError } from "./installer-error.js";
 import type { InteractivePrompter } from "./interactive-prompter.js";
+import { runManagementSession } from "./management-session.js";
+import type { MutationCoordinatorDependencies } from "./mutation-coordinator.js";
 import { createNodeFileSystem } from "./node-file-system.js";
 import {
   createNodeExecutableResolver,
@@ -62,12 +64,17 @@ export async function runInteractiveSession(
     const command = options.command ?? { kind: "inventory" as const };
     const nodeFileSystem = createNodeFileSystem();
     const fileSystem = options.fileSystem ?? nodeFileSystem;
-    if (command.kind === "inventory") {
-      await loadBundledRegistry(
-        fileSystem,
-        options.compatibilityAdapters ?? registryCompatibilityAdapters,
-      );
-    }
+    const registry =
+      command.kind === "inventory" ||
+      command.kind === "status" ||
+      command.kind === "enable" ||
+      command.kind === "disable" ||
+      command.kind === "remove"
+        ? await loadBundledRegistry(
+            fileSystem,
+            options.compatibilityAdapters ?? registryCompatibilityAdapters,
+          )
+        : undefined;
     const environment =
       options.environment ?? createProcessInstallerEnvironment();
     const resolveExecutable =
@@ -96,7 +103,44 @@ export async function runInteractiveSession(
         nodeExecutable: process.execPath,
         projectDirectory: command.projectDirectory,
       });
+      const dependencies: MutationCoordinatorDependencies = {
+        adapters: configurationTargetAdapters,
+        currentUserId: process.getuid?.() ?? -1,
+        environment,
+        fileSystem: transactionFileSystem,
+        lock: {
+          clock: {
+            monotonicNow: () => performance.now(),
+            now: () => Date.now(),
+            wait: (milliseconds) =>
+              new Promise((resolveWait) =>
+                setTimeout(resolveWait, milliseconds),
+              ),
+          },
+          processId: process.pid,
+          randomBytes: (length) => randomBytes(length),
+        },
+        now: () => new Date().toISOString(),
+      };
       return await runInstallSession({
+        dependencies,
+        descriptor: source.descriptor,
+        prompter,
+        resolveExecutable,
+        snapshot,
+      });
+    }
+    if (
+      (command.kind === "status" ||
+        command.kind === "enable" ||
+        command.kind === "disable" ||
+        command.kind === "remove") &&
+      registry !== undefined
+    ) {
+      const transactionFileSystem =
+        options.transactionFileSystem ?? nodeFileSystem;
+      return await runManagementSession({
+        action: command.kind,
         dependencies: {
           adapters: configurationTargetAdapters,
           currentUserId: process.getuid?.() ?? -1,
@@ -116,8 +160,8 @@ export async function runInteractiveSession(
           },
           now: () => new Date().toISOString(),
         },
-        descriptor: source.descriptor,
         prompter,
+        registry,
         resolveExecutable,
         snapshot,
       });

--- a/packages/installer/src/interactive-session.ts
+++ b/packages/installer/src/interactive-session.ts
@@ -27,6 +27,7 @@ import {
   loadBundledRegistry,
   type RegistryCompatibilityAdapters,
 } from "./registry.js";
+import { createRemoteInstallDescriptor } from "./remote-install-source.js";
 import type {
   InstallerCommand,
   InstallerExitCode,
@@ -94,15 +95,20 @@ export async function runInteractiveSession(
     if (command.kind === "inventory") {
       return await runReadOnlyInventory(snapshot, prompter);
     }
-    if (command.kind === "install-engine") {
+    if (command.kind === "install-engine" || command.kind === "install-http") {
       const transactionFileSystem =
         options.transactionFileSystem ?? nodeFileSystem;
-      const source = await loadEngineInstallManifest({
-        currentUserId: process.getuid?.() ?? -1,
-        fileSystem: transactionFileSystem,
-        nodeExecutable: process.execPath,
-        projectDirectory: command.projectDirectory,
-      });
+      const descriptor =
+        command.kind === "install-engine"
+          ? (
+              await loadEngineInstallManifest({
+                currentUserId: process.getuid?.() ?? -1,
+                fileSystem: transactionFileSystem,
+                nodeExecutable: process.execPath,
+                projectDirectory: command.projectDirectory,
+              })
+            ).descriptor
+          : createRemoteInstallDescriptor(command);
       const dependencies: MutationCoordinatorDependencies = {
         adapters: configurationTargetAdapters,
         currentUserId: process.getuid?.() ?? -1,
@@ -124,7 +130,7 @@ export async function runInteractiveSession(
       };
       return await runInstallSession({
         dependencies,
-        descriptor: source.descriptor,
+        descriptor,
         prompter,
         resolveExecutable,
         snapshot,

--- a/packages/installer/src/interactive-session.ts
+++ b/packages/installer/src/interactive-session.ts
@@ -1,24 +1,38 @@
+import { randomBytes } from "node:crypto";
+
 import { createClackInteractivePrompter } from "./clack-interactive-prompter.js";
-import type { InstallerFileSystem } from "./file-system.js";
+import { loadEngineInstallManifest } from "./engine-manifest.js";
+import type {
+  InstallerFileSystem,
+  InstallerTransactionFileSystem,
+} from "./file-system.js";
 import {
   detectHarnesses,
   type ExecutableResolver,
   type OperatingSystemHomeResolver,
   type TargetConfigEvidenceProbes,
 } from "./harness-detection.js";
+import { runInstallSession } from "./install-session.js";
+import { InstallerError } from "./installer-error.js";
 import type { InteractivePrompter } from "./interactive-prompter.js";
+import { createNodeFileSystem } from "./node-file-system.js";
 import {
   createNodeExecutableResolver,
   resolveNodeOperatingSystemHome,
 } from "./node-harness-environment.js";
-import { createNodeFileSystem } from "./node-file-system.js";
 import { runReadOnlyInventory } from "./read-only-inventory.js";
 import {
   loadBundledRegistry,
   type RegistryCompatibilityAdapters,
 } from "./registry.js";
-import type { InstallerExitCode } from "./run-installer-cli.js";
-import { registryCompatibilityAdapters } from "./target-adapters.js";
+import type {
+  InstallerCommand,
+  InstallerExitCode,
+} from "./run-installer-cli.js";
+import {
+  configurationTargetAdapters,
+  registryCompatibilityAdapters,
+} from "./target-adapters.js";
 import {
   createNodeTargetConfigEvidenceProbes,
   createProcessInstallerEnvironment,
@@ -26,8 +40,10 @@ import {
 } from "./target-config-evidence.js";
 
 export interface RunInteractiveSessionOptions {
+  readonly command?: InstallerCommand;
   readonly prompter?: InteractivePrompter;
   readonly fileSystem?: InstallerFileSystem;
+  readonly transactionFileSystem?: InstallerTransactionFileSystem;
   readonly compatibilityAdapters?: RegistryCompatibilityAdapters;
   readonly resolveHomeDirectory?: OperatingSystemHomeResolver;
   readonly resolveExecutable?: ExecutableResolver;
@@ -43,26 +59,70 @@ export async function runInteractiveSession(
   const progress = prompter.spinner();
   progress.start("Detecting supported AI harnesses");
   try {
-    const fileSystem = options.fileSystem ?? createNodeFileSystem();
-    await loadBundledRegistry(
-      fileSystem,
-      options.compatibilityAdapters ?? registryCompatibilityAdapters,
-    );
+    const command = options.command ?? { kind: "inventory" as const };
+    const nodeFileSystem = createNodeFileSystem();
+    const fileSystem = options.fileSystem ?? nodeFileSystem;
+    if (command.kind === "inventory") {
+      await loadBundledRegistry(
+        fileSystem,
+        options.compatibilityAdapters ?? registryCompatibilityAdapters,
+      );
+    }
+    const environment =
+      options.environment ?? createProcessInstallerEnvironment();
+    const resolveExecutable =
+      options.resolveExecutable ?? createNodeExecutableResolver();
     const snapshot = await detectHarnesses({
       resolveHomeDirectory:
         options.resolveHomeDirectory ?? resolveNodeOperatingSystemHome,
-      resolveExecutable:
-        options.resolveExecutable ?? createNodeExecutableResolver(),
+      resolveExecutable,
       configEvidenceProbes:
         options.configEvidenceProbes ??
         createNodeTargetConfigEvidenceProbes({
-          environment:
-            options.environment ?? createProcessInstallerEnvironment(),
+          environment,
           fileSystem,
         }),
     });
     progress.stop("Harness detection complete");
-    return await runReadOnlyInventory(snapshot, prompter);
+    if (command.kind === "inventory") {
+      return await runReadOnlyInventory(snapshot, prompter);
+    }
+    if (command.kind === "install-engine") {
+      const transactionFileSystem =
+        options.transactionFileSystem ?? nodeFileSystem;
+      const source = await loadEngineInstallManifest({
+        currentUserId: process.getuid?.() ?? -1,
+        fileSystem: transactionFileSystem,
+        nodeExecutable: process.execPath,
+        projectDirectory: command.projectDirectory,
+      });
+      return await runInstallSession({
+        dependencies: {
+          adapters: configurationTargetAdapters,
+          currentUserId: process.getuid?.() ?? -1,
+          environment,
+          fileSystem: transactionFileSystem,
+          lock: {
+            clock: {
+              monotonicNow: () => performance.now(),
+              now: () => Date.now(),
+              wait: (milliseconds) =>
+                new Promise((resolveWait) =>
+                  setTimeout(resolveWait, milliseconds),
+                ),
+            },
+            processId: process.pid,
+            randomBytes: (length) => randomBytes(length),
+          },
+          now: () => new Date().toISOString(),
+        },
+        descriptor: source.descriptor,
+        prompter,
+        resolveExecutable,
+        snapshot,
+      });
+    }
+    throw new InstallerError("INSTALLER_INITIALIZATION_FAILED");
   } catch (error) {
     progress.error("Harness detection failed");
     throw error;

--- a/packages/installer/src/json-target-adapter.ts
+++ b/packages/installer/src/json-target-adapter.ts
@@ -780,6 +780,14 @@ function constructPatch(
     }
     validateMappedDefinition(request.definition, options.dialect);
     insertedDefinition = request.definition;
+  } else if (request.action === "remove") {
+    if (
+      request.inspection.currentServer.kind !== "present" ||
+      state.servers === undefined ||
+      state.serverMember === undefined
+    ) {
+      invalid();
+    }
   } else if (options.toggleStrategy === "detached") {
     if (request.action === "disable") {
       if (request.inspection.currentServer.kind === "absent") {
@@ -874,6 +882,16 @@ function constructPatch(
         state.tokens,
       );
     }
+  } else if (request.action === "remove") {
+    if (state.servers === undefined || state.serverMember === undefined) {
+      invalid();
+    }
+    postText = removeMember(
+      source.text,
+      state,
+      state.servers,
+      state.serverMember,
+    );
   } else if (options.toggleStrategy === "detached") {
     if (
       state.servers === undefined ||

--- a/packages/installer/src/json-target-adapter.ts
+++ b/packages/installer/src/json-target-adapter.ts
@@ -41,7 +41,13 @@ import {
   unsupportedDefinition,
 } from "./target-adapter.js";
 
-type JsonDialect = "antigravity" | "claude" | "cursor" | "kimi" | "opencode";
+type JsonDialect =
+  | "antigravity"
+  | "claude"
+  | "cursor"
+  | "kimi"
+  | "opencode"
+  | "vscode";
 
 interface JsonInspectionState {
   readonly dialect: JsonDialect;
@@ -65,7 +71,13 @@ interface AstInspection {
 interface JsonTargetOptions {
   readonly targetId: Extract<
     ConfigurationTargetId,
-    "antigravity" | "claude-code" | "cursor" | "kimi-code" | "opencode-v2"
+    | "antigravity"
+    | "claude-code"
+    | "claude-desktop"
+    | "cursor"
+    | "kimi-code"
+    | "opencode-v2"
+    | "vscode"
   >;
   readonly dialect: JsonDialect;
   readonly toggleStrategy: ToggleStrategy;
@@ -127,7 +139,9 @@ function serverPath(
 ): readonly string[] {
   return dialect === "opencode"
     ? ["mcp", "servers", serverName]
-    : ["mcpServers", serverName];
+    : dialect === "vscode"
+      ? ["servers", serverName]
+      : ["mcpServers", serverName];
 }
 
 function inspectAst(
@@ -319,7 +333,10 @@ function finalizationOptions(
     httpHeadersField: "headers",
     rawTransportPolicy: "reject" as const,
     toggleStrategy,
-    typePolicy: dialect === "claude" ? ("claude" as const) : ("none" as const),
+    typePolicy:
+      dialect === "claude" || dialect === "vscode"
+        ? ("claude" as const)
+        : ("none" as const),
   };
 }
 
@@ -368,10 +385,15 @@ function parseAndInspect(
   let astInspection: AstInspection;
   try {
     document = parse(source.text, {
-      mode: options.dialect === "opencode" ? "jsonc" : "json",
+      mode:
+        options.dialect === "opencode" || options.dialect === "vscode"
+          ? "jsonc"
+          : "json",
       ranges: true,
       tokens: true,
-      ...(options.dialect === "opencode" ? { allowTrailingCommas: true } : {}),
+      ...(options.dialect === "opencode" || options.dialect === "vscode"
+        ? { allowTrailingCommas: true }
+        : {}),
     });
     astInspection = inspectAst(document, serverName, options.dialect);
   } catch (cause) {
@@ -389,7 +411,9 @@ function parseAndInspect(
     objectValue(
       memberState,
       options.dialect === "opencode" ? mcp : root,
-      options.dialect === "opencode" ? "servers" : "mcpServers",
+      options.dialect === "opencode" || options.dialect === "vscode"
+        ? "servers"
+        : "mcpServers",
     ),
   );
   const serverMember = objectMember(memberState, servers, serverName);
@@ -521,7 +545,7 @@ function mappedConfigDefinition(
       ? stdio
         ? ["command", "args", "disabled"]
         : ["serverUrl", "disabled"]
-      : dialect === "claude"
+      : dialect === "claude" || dialect === "vscode"
         ? stdio
           ? ["type", "command", "args", "env"]
           : ["type", "url", "headers"]
@@ -590,7 +614,7 @@ const reservedHeaderNames: ReadonlySet<string> = new Set([
 
 function validEnvironmentPlaceholders(
   value: unknown,
-  dialect: Extract<JsonDialect, "claude" | "cursor" | "opencode">,
+  dialect: Extract<JsonDialect, "claude" | "cursor" | "opencode" | "vscode">,
 ): boolean {
   if (!stringRecord(value)) return false;
   return Object.entries(value as Record<string, string>).every(
@@ -599,7 +623,7 @@ function validEnvironmentPlaceholders(
       placeholder ===
         (dialect === "claude"
           ? `\${${name}}`
-          : dialect === "cursor"
+          : dialect === "cursor" || dialect === "vscode"
             ? `\${env:${name}}`
             : `{env:${name}}`),
   );
@@ -607,19 +631,19 @@ function validEnvironmentPlaceholders(
 
 function validHeaderPlaceholders(
   value: unknown,
-  dialect: Extract<JsonDialect, "claude" | "cursor" | "opencode">,
+  dialect: Extract<JsonDialect, "claude" | "cursor" | "opencode" | "vscode">,
 ): boolean {
   if (!stringRecord(value)) return false;
   const barePattern =
     dialect === "claude"
       ? /^\$\{[A-Z_][A-Z0-9_]{0,127}\}$/u
-      : dialect === "cursor"
+      : dialect === "cursor" || dialect === "vscode"
         ? /^\$\{env:[A-Z_][A-Z0-9_]{0,127}\}$/u
         : /^\{env:[A-Z_][A-Z0-9_]{0,127}\}$/u;
   const bearerPattern =
     dialect === "claude"
       ? /^Bearer \$\{[A-Z_][A-Z0-9_]{0,127}\}$/u
-      : dialect === "cursor"
+      : dialect === "cursor" || dialect === "vscode"
         ? /^Bearer \$\{env:[A-Z_][A-Z0-9_]{0,127}\}$/u
         : /^Bearer \{env:[A-Z_][A-Z0-9_]{0,127}\}$/u;
   return Object.entries(value as Record<string, string>).every(
@@ -653,7 +677,7 @@ function validateMappedDefinition(
       ? stdio
         ? ["transport", "command", "args", "disabled"]
         : ["transport", "serverUrl", "disabled"]
-      : dialect === "claude"
+      : dialect === "claude" || dialect === "vscode"
         ? stdio
           ? ["transport", "type", "command", "args", "env"]
           : ["transport", "type", "url", "headers"]
@@ -687,9 +711,15 @@ function validateMappedDefinition(
     ) {
       invalid();
     }
-    if (dialect === "claude" && definition.type !== "stdio") invalid();
+    if (
+      (dialect === "claude" || dialect === "vscode") &&
+      definition.type !== "stdio"
+    ) {
+      invalid();
+    }
     if (
       (dialect === "claude" ||
+        dialect === "vscode" ||
         dialect === "cursor" ||
         dialect === "opencode") &&
       !validEnvironmentPlaceholders(
@@ -707,7 +737,12 @@ function validateMappedDefinition(
     ) {
       invalid();
     }
-    if (dialect === "claude" && definition.type !== "http") invalid();
+    if (
+      (dialect === "claude" || dialect === "vscode") &&
+      definition.type !== "http"
+    ) {
+      invalid();
+    }
     if (
       dialect === "opencode" &&
       (definition.type !== "remote" || definition.oauth !== false)
@@ -716,6 +751,7 @@ function validateMappedDefinition(
     }
     if (
       (dialect === "claude" ||
+        dialect === "vscode" ||
         dialect === "cursor" ||
         dialect === "opencode") &&
       !validHeaderPlaceholders(definition.headers, dialect)
@@ -843,7 +879,7 @@ function constructPatch(
               },
             }
           : {
-              mcpServers: {
+              [options.dialect === "vscode" ? "servers" : "mcpServers"]: {
                 [state.serverName]: mappedConfigDefinition(
                   insertedDefinition,
                   options.dialect,
@@ -867,7 +903,9 @@ function constructPatch(
       postText = insertProperty(
         source.text,
         options.dialect === "opencode" ? (state.mcp as ObjectNode) : state.root,
-        options.dialect === "opencode" ? "servers" : "mcpServers",
+        options.dialect === "opencode" || options.dialect === "vscode"
+          ? "servers"
+          : "mcpServers",
         `{${JSON.stringify(state.serverName)}:${entry}}`,
         source.newline,
         state.tokens,
@@ -956,9 +994,16 @@ export function createJsonTargetAdapter(
     metadata: Object.freeze({
       targetId: options.targetId,
       targetContractVersion: 1,
-      format: options.dialect === "opencode" ? "jsonc" : "json",
+      format:
+        options.dialect === "opencode" || options.dialect === "vscode"
+          ? "jsonc"
+          : "json",
       parentPath: Object.freeze(
-        options.dialect === "opencode" ? ["mcp", "servers"] : ["mcpServers"],
+        options.dialect === "opencode"
+          ? ["mcp", "servers"]
+          : options.dialect === "vscode"
+            ? ["servers"]
+            : ["mcpServers"],
       ),
       toggleStrategy: options.toggleStrategy,
     }),

--- a/packages/installer/src/json5-target-adapter.ts
+++ b/packages/installer/src/json5-target-adapter.ts
@@ -1,9 +1,9 @@
 import {
-  parse,
   type ArrayNode,
   type DocumentNode,
   type MemberNode,
   type ObjectNode,
+  parse,
   type Token,
   type ValueNode,
 } from "@humanwhocodes/momoa";
@@ -14,25 +14,25 @@ import {
   assertPostImageDefinition,
   assertServerName,
   assertTargetInspectionConsistency,
+  type DecodedTargetSource,
   decodeTargetSource,
   encodeTargetPostImage,
   finalizeInspectedMcpDefinition,
   freezeDefinition,
   frozenTargetInspection,
+  type InspectedJsonValue,
   inspectedJsonArray,
   inspectedJsonRecord,
   inspectedJsonScalar,
   inspectionPass,
   parsePass,
   patchPass,
-  targetInspectionStateFor,
-  type DecodedTargetSource,
   type TargetAdapter,
   type TargetAdapterCounters,
   type TargetConfigInspection,
   type TargetPatch,
   type TargetPatchRequest,
-  type InspectedJsonValue,
+  targetInspectionStateFor,
   unsupportedDefinition,
 } from "./target-adapter.js";
 
@@ -42,6 +42,7 @@ interface Json5InspectionState {
   readonly root: ObjectNode | undefined;
   readonly mcp: ObjectNode | undefined;
   readonly servers: ObjectNode | undefined;
+  readonly serverMember: MemberNode | undefined;
   readonly server: ObjectNode | undefined;
   readonly enabled: ValueNode | undefined;
   readonly members: ReadonlyMap<ObjectNode, ReadonlyMap<string, MemberNode>>;
@@ -272,6 +273,7 @@ function parseAndInspect(
         root: undefined,
         mcp: undefined,
         servers: undefined,
+        serverMember: undefined,
         server: undefined,
         enabled: undefined,
         members: new Map(),
@@ -302,7 +304,8 @@ function parseAndInspect(
   };
   const mcp = objectNode(objectValue(state, root, "mcp"));
   const servers = objectNode(objectValue(state, mcp, "servers"));
-  const server = objectNode(objectValue(state, servers, serverName));
+  const serverMember = objectMember(state, servers, serverName);
+  const server = objectNode(serverMember?.value);
 
   const inspectedServer =
     server === undefined ? undefined : astInspection.values.get(server);
@@ -328,6 +331,7 @@ function parseAndInspect(
       root,
       mcp,
       servers,
+      serverMember,
       server,
       enabled,
       members: astInspection.members,
@@ -403,6 +407,34 @@ function replaceRange(
   return `${text.slice(0, start)}${replacement}${text.slice(end)}`;
 }
 
+function removeMember(
+  text: string,
+  state: Json5InspectionState,
+  object: ObjectNode,
+  member: MemberNode,
+): string {
+  const index = object.members.indexOf(member);
+  if (index < 0) invalid();
+  const [memberStart, memberEnd] = range(member);
+  if (object.members.length === 1) {
+    return `${text.slice(0, memberStart)}${text.slice(memberEnd)}`;
+  }
+  if (index < object.members.length - 1) {
+    const [nextStart] = range(object.members[index + 1] as MemberNode);
+    return `${text.slice(0, memberStart)}${text.slice(nextStart)}`;
+  }
+  const previous = object.members[index - 1] as MemberNode;
+  const [, previousEnd] = range(previous);
+  const comma = state.tokens.find((token) => {
+    if (token.type !== "Comma") return false;
+    const [start, end] = range(token);
+    return start >= previousEnd && end <= memberStart;
+  });
+  if (comma === undefined) invalid();
+  const [commaStart] = range(comma);
+  return `${text.slice(0, commaStart)}${text.slice(memberEnd)}`;
+}
+
 function jsonConfigDefinition(
   definition: Readonly<Record<string, unknown>>,
 ): Readonly<Record<string, unknown>> {
@@ -456,6 +488,14 @@ function constructPatch(
   if (request.action === "install") {
     if (request.inspection.currentServer.kind === "present") {
       throw new InstallerError("CONFIG_CONFLICT");
+    }
+  } else if (request.action === "remove") {
+    if (
+      request.inspection.currentServer.kind !== "present" ||
+      state.servers === undefined ||
+      state.serverMember === undefined
+    ) {
+      invalid();
     }
   } else {
     if (
@@ -516,6 +556,16 @@ function constructPatch(
         source.newline,
       );
     }
+  } else if (request.action === "remove") {
+    if (state.servers === undefined || state.serverMember === undefined) {
+      invalid();
+    }
+    postText = removeMember(
+      source.text,
+      state,
+      state.servers,
+      state.serverMember,
+    );
   } else {
     const desired = request.action === "enable";
     postText =

--- a/packages/installer/src/managed-installations.ts
+++ b/packages/installer/src/managed-installations.ts
@@ -119,6 +119,7 @@ export async function inspectManagedInstallations(
     fileSystem: options.dependencies.fileSystem,
     homeDirectory: options.snapshot.homeDirectory,
     targetContracts: contracts,
+    allowUnavailableTargetContracts: true,
   });
   const homeRoot = await capturePathRoot(options.dependencies.fileSystem, {
     rootKind: "home",
@@ -136,9 +137,11 @@ export async function inspectManagedInstallations(
     const target = options.snapshot.targets.find(
       ({ id }) => id === installation.targetId,
     );
+    const adapter = options.dependencies.adapters[installation.targetId];
     const displayName = target?.displayName ?? installation.targetId;
     if (
       descriptor === undefined ||
+      !adapter.compatibility(descriptor).supported ||
       target === undefined ||
       target.configuration.kind === "blocked" ||
       target.configuration.path !== installation.configPath ||
@@ -157,7 +160,6 @@ export async function inspectManagedInstallations(
     ).catch((cause) => {
       throw new InstallerError("HARNESS_CONFIG_UNSAFE", cause);
     });
-    const adapter = options.dependencies.adapters[installation.targetId];
     const inspection = adapter.inspect({
       source: await readConfig(options, identity),
       serverName: installation.serverName,

--- a/packages/installer/src/managed-installations.ts
+++ b/packages/installer/src/managed-installations.ts
@@ -1,0 +1,193 @@
+import type { InstallerFileStat, InstallerReadHandle } from "./file-system.js";
+import type { HarnessDetectionSnapshot } from "./harness-detection.js";
+import { InstallerError } from "./installer-error.js";
+import {
+  loadInstallerState,
+  type ManagedInstallation,
+} from "./installer-state.js";
+import {
+  buildStateTargetContracts,
+  type MutationCoordinatorDependencies,
+} from "./mutation-coordinator.js";
+import { type OwnershipPlan, planOwnership } from "./ownership-planner.js";
+import {
+  capturePathIdentity,
+  capturePathRoot,
+  type InstallerPathIdentity,
+} from "./path-identity.js";
+import type {
+  CapabilityInstallDescriptor,
+  ValidatedRegistry,
+} from "./registry.js";
+import { targetConfigByteLimit } from "./target-adapter.js";
+
+export interface ManagedInstallationView {
+  readonly key: string;
+  readonly installation: ManagedInstallation;
+  readonly descriptor?: CapabilityInstallDescriptor;
+  readonly displayName: string;
+  readonly status: OwnershipPlan["status"] | "unavailable";
+  readonly actions: OwnershipPlan["actions"];
+}
+
+export interface InspectManagedInstallationsOptions {
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly registry: ValidatedRegistry;
+  readonly snapshot: HarnessDetectionSnapshot;
+}
+
+function sameStat(
+  expected: InstallerFileStat | undefined,
+  actual: InstallerFileStat,
+): boolean {
+  return (
+    expected !== undefined &&
+    expected.kind === actual.kind &&
+    expected.dev === actual.dev &&
+    expected.ino === actual.ino &&
+    expected.uid === actual.uid &&
+    expected.gid === actual.gid
+  );
+}
+
+async function readConfig(
+  options: InspectManagedInstallationsOptions,
+  identity: InstallerPathIdentity,
+): Promise<Uint8Array | undefined> {
+  if (identity.missingPaths.length > 0) return undefined;
+  let handle: InstallerReadHandle | undefined;
+  try {
+    handle = await options.dependencies.fileSystem.openReadNoFollow(
+      identity.targetPath,
+    );
+    if (!sameStat(identity.components.at(-1), await handle.stat())) {
+      throw new InstallerError("CONFIG_CHANGED");
+    }
+    return await handle.readAll(targetConfigByteLimit);
+  } catch (cause) {
+    if (cause instanceof InstallerError) throw cause;
+    throw new InstallerError("HARNESS_CONFIG_READ_FAILED", cause);
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function descriptorFor(
+  installation: ManagedInstallation,
+  registry: ValidatedRegistry,
+): CapabilityInstallDescriptor | undefined {
+  const registered = registry.entries.find(
+    ({ descriptor }) => descriptor.id === installation.entryId,
+  )?.descriptor;
+  if (installation.launchDescriptor === undefined) return registered;
+  return Object.freeze({
+    id: installation.entryId,
+    version: installation.registryVersion,
+    title: installation.serverName,
+    description: `Managed ${installation.serverName} MCP server.`,
+    capabilityIds: Object.freeze([installation.entryId]),
+    server: installation.launchDescriptor,
+  });
+}
+
+function unavailable(
+  key: string,
+  installation: ManagedInstallation,
+  descriptor: CapabilityInstallDescriptor | undefined,
+  displayName: string,
+): ManagedInstallationView {
+  return Object.freeze({
+    key,
+    installation,
+    ...(descriptor === undefined ? {} : { descriptor }),
+    displayName,
+    status: "unavailable",
+    actions: Object.freeze([] as []),
+  });
+}
+
+export async function inspectManagedInstallations(
+  options: InspectManagedInstallationsOptions,
+): Promise<readonly ManagedInstallationView[]> {
+  const contracts = buildStateTargetContracts(
+    options.snapshot,
+    options.dependencies.adapters,
+  );
+  const loaded = await loadInstallerState({
+    currentUserId: options.dependencies.currentUserId,
+    environment: options.dependencies.environment,
+    fileSystem: options.dependencies.fileSystem,
+    homeDirectory: options.snapshot.homeDirectory,
+    targetContracts: contracts,
+  });
+  const homeRoot = await capturePathRoot(options.dependencies.fileSystem, {
+    rootKind: "home",
+    rootPath: options.snapshot.homeDirectory,
+    currentUserId: options.dependencies.currentUserId,
+  }).catch((cause) => {
+    throw new InstallerError("HARNESS_CONFIG_UNSAFE", cause);
+  });
+  const views: ManagedInstallationView[] = [];
+  const entries = Object.entries(loaded.state.installations).sort(
+    ([left], [right]) => left.localeCompare(right),
+  );
+  for (const [key, installation] of entries) {
+    const descriptor = descriptorFor(installation, options.registry);
+    const target = options.snapshot.targets.find(
+      ({ id }) => id === installation.targetId,
+    );
+    const displayName = target?.displayName ?? installation.targetId;
+    if (
+      descriptor === undefined ||
+      target === undefined ||
+      target.configuration.kind === "blocked" ||
+      target.configuration.path !== installation.configPath ||
+      contracts[installation.targetId] === undefined
+    ) {
+      views.push(unavailable(key, installation, descriptor, displayName));
+      continue;
+    }
+    const identity = await capturePathIdentity(
+      options.dependencies.fileSystem,
+      {
+        root: homeRoot,
+        targetPath: installation.configPath,
+        targetKind: "regular-file",
+      },
+    ).catch((cause) => {
+      throw new InstallerError("HARNESS_CONFIG_UNSAFE", cause);
+    });
+    const adapter = options.dependencies.adapters[installation.targetId];
+    const inspection = adapter.inspect({
+      source: await readConfig(options, identity),
+      serverName: installation.serverName,
+    });
+    const ownership = planOwnership({
+      descriptor,
+      targetId: installation.targetId,
+      target: contracts[installation.targetId],
+      state: loaded.state,
+      registryDefinition: adapter.descriptorToDefinition(descriptor),
+      ...(installation.suspendedDescriptor === undefined
+        ? {}
+        : {
+            normalizedSuspendedDefinition:
+              adapter.suspendedDescriptorToDefinition(
+                installation.suspendedDescriptor,
+              ),
+          }),
+      currentServer: inspection.currentServer,
+    });
+    views.push(
+      Object.freeze({
+        key,
+        installation,
+        descriptor,
+        displayName,
+        status: ownership.status,
+        actions: ownership.actions,
+      }),
+    );
+  }
+  return Object.freeze(views);
+}

--- a/packages/installer/src/management-session.ts
+++ b/packages/installer/src/management-session.ts
@@ -39,7 +39,8 @@ function cancel(prompter: InteractivePrompter): 130 {
 }
 
 function statusLine(view: ManagedInstallationView, runtime?: string): string {
-  return `${view.installation.serverName} · ${view.displayName}: ${view.status}${runtime === undefined ? "" : ` (${runtime})`}`;
+  const status = runtime === undefined ? view.status : "missing-runtime";
+  return `${view.installation.serverName} · ${view.displayName}: ${status}${runtime === undefined ? "" : ` (${runtime})`}`;
 }
 
 async function showStatus(

--- a/packages/installer/src/management-session.ts
+++ b/packages/installer/src/management-session.ts
@@ -1,0 +1,148 @@
+import type {
+  ExecutableResolver,
+  HarnessDetectionSnapshot,
+} from "./harness-detection.js";
+import { InstallerError, installerErrorMessages } from "./installer-error.js";
+import type { InteractivePrompter } from "./interactive-prompter.js";
+import {
+  inspectManagedInstallations,
+  type ManagedInstallationView,
+} from "./managed-installations.js";
+import {
+  type MutationCoordinatorDependencies,
+  mutateDescriptorAcrossTargets,
+} from "./mutation-coordinator.js";
+import type { ValidatedRegistry } from "./registry.js";
+import type {
+  InstallerCommand,
+  InstallerExitCode,
+} from "./run-installer-cli.js";
+import { resolveRuntimeRequirements } from "./runtime-requirements.js";
+
+type ManagementAction = Extract<
+  InstallerCommand["kind"],
+  "disable" | "enable" | "remove" | "status"
+>;
+
+export interface RunManagementSessionOptions {
+  readonly action: ManagementAction;
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly prompter: InteractivePrompter;
+  readonly registry: ValidatedRegistry;
+  readonly resolveExecutable: ExecutableResolver;
+  readonly snapshot: HarnessDetectionSnapshot;
+}
+
+function cancel(prompter: InteractivePrompter): 130 {
+  prompter.cancel(installerErrorMessages.CANCELLED);
+  return 130;
+}
+
+function statusLine(view: ManagedInstallationView, runtime?: string): string {
+  return `${view.installation.serverName} · ${view.displayName}: ${view.status}${runtime === undefined ? "" : ` (${runtime})`}`;
+}
+
+async function showStatus(
+  options: RunManagementSessionOptions,
+  views: readonly ManagedInstallationView[],
+): Promise<0> {
+  if (views.length === 0) {
+    options.prompter.note("No managed MCP installations.", "Status");
+    options.prompter.outro("Nothing is installed by Invokta.");
+    return 0;
+  }
+  const lines: string[] = [];
+  for (const view of views) {
+    let runtime: string | undefined;
+    if (
+      view.descriptor !== undefined &&
+      (view.status === "enabled" || view.status === "outdated")
+    ) {
+      const requirements = await resolveRuntimeRequirements({
+        action: "install",
+        descriptor: view.descriptor.server,
+        resolveExecutable: options.resolveExecutable,
+        environment: options.dependencies.environment,
+      });
+      if (requirements.kind === "blocked") runtime = requirements.code;
+    }
+    lines.push(statusLine(view, runtime));
+  }
+  options.prompter.note(lines.join("\n"), "Managed MCP installations");
+  options.prompter.outro("Status inspection complete. No changes were made.");
+  return 0;
+}
+
+export async function runManagementSession(
+  options: RunManagementSessionOptions,
+): Promise<InstallerExitCode> {
+  const views = await inspectManagedInstallations({
+    dependencies: options.dependencies,
+    registry: options.registry,
+    snapshot: options.snapshot,
+  });
+  if (options.action === "status") return showStatus(options, views);
+  const candidates = views.filter(
+    (view) =>
+      view.descriptor !== undefined &&
+      (options.action === "remove"
+        ? view.status === "enabled" ||
+          view.status === "disabled" ||
+          view.status === "outdated"
+        : view.actions.some((action) => action === options.action)),
+  );
+  if (candidates.length === 0) {
+    throw new InstallerError("INSTALLATION_UNAVAILABLE");
+  }
+  const choices = new Map(
+    candidates.map((view, index) => [String(index), view] as const),
+  );
+  const selection = await options.prompter.select({
+    message: `Select an installation to ${options.action}.`,
+    options: candidates.map((view, index) => ({
+      value: String(index),
+      label: `${view.installation.serverName} · ${view.displayName}`,
+      hint: view.status,
+    })),
+  });
+  if (selection.kind === "cancelled") return cancel(options.prompter);
+  const selected = choices.get(selection.value);
+  if (selected?.descriptor === undefined) {
+    throw new InstallerError("INSTALLATION_UNAVAILABLE");
+  }
+  if (options.action === "enable") {
+    const requirements = await resolveRuntimeRequirements({
+      action: "enable",
+      descriptor: selected.descriptor.server,
+      resolveExecutable: options.resolveExecutable,
+      environment: options.dependencies.environment,
+    });
+    if (requirements.kind === "blocked") {
+      throw new InstallerError(requirements.code);
+    }
+  }
+  const confirmation = await options.prompter.confirm(
+    `${options.action === "enable" ? "Enable" : options.action === "disable" ? "Disable" : "Remove"} ${selected.installation.serverName} in ${selected.displayName}?`,
+  );
+  if (confirmation.kind === "cancelled") return cancel(options.prompter);
+  if (!confirmation.value) {
+    options.prompter.outro("No changes were made.");
+    return 0;
+  }
+  const [result] = await mutateDescriptorAcrossTargets({
+    action: options.action,
+    dependencies: options.dependencies,
+    descriptor: selected.descriptor,
+    snapshot: options.snapshot,
+    targetIds: [selected.installation.targetId],
+  });
+  if (result === undefined || result.outcome === "failed") {
+    throw new InstallerError(
+      result?.outcome === "failed" ? result.code : "INSTALLATION_UNAVAILABLE",
+    );
+  }
+  options.prompter.outro(
+    `${selected.installation.serverName} ${result.outcome}. Reload ${selected.displayName}.`,
+  );
+  return 0;
+}

--- a/packages/installer/src/mutation-coordinator.ts
+++ b/packages/installer/src/mutation-coordinator.ts
@@ -16,6 +16,8 @@ import {
   type InstallerLockDependencies,
 } from "./installer-lock.js";
 import {
+  installationKey,
+  isInstallerTimestampAfter,
   loadInstallerState,
   type StateTargetContracts,
 } from "./installer-state.js";
@@ -23,7 +25,11 @@ import {
   applyInstallerStatePlan,
   serializeInstallerState,
 } from "./installer-state-transition.js";
-import { planInstallerAction } from "./ownership-planner.js";
+import {
+  type InstallerAction,
+  planInstallerAction,
+  planOwnership,
+} from "./ownership-planner.js";
 import {
   bootstrapPrivateDirectory,
   capturePathIdentity,
@@ -35,7 +41,11 @@ import type {
   CapabilityInstallDescriptor,
   ConfigurationTargetId,
 } from "./registry.js";
-import { type TargetAdapter, targetConfigByteLimit } from "./target-adapter.js";
+import {
+  type TargetAdapter,
+  type TargetPatch,
+  targetConfigByteLimit,
+} from "./target-adapter.js";
 import type { InstallerEnvironment } from "./target-config-evidence.js";
 
 export interface MutationCoordinatorDependencies {
@@ -50,7 +60,12 @@ export interface MutationCoordinatorDependencies {
 export type TargetMutationResult =
   | {
       readonly targetId: ConfigurationTargetId;
-      readonly outcome: "installed" | "unchanged";
+      readonly outcome:
+        | "disabled"
+        | "enabled"
+        | "installed"
+        | "removed"
+        | "unchanged";
     }
   | {
       readonly targetId: ConfigurationTargetId;
@@ -65,6 +80,13 @@ export interface InstallDescriptorAcrossTargetsInput {
   readonly targetIds: readonly ConfigurationTargetId[];
 }
 
+export interface MutateDescriptorAcrossTargetsInput
+  extends InstallDescriptorAcrossTargetsInput {
+  readonly action:
+    | Extract<InstallerAction, "disable" | "enable" | "install">
+    | "remove";
+}
+
 const temporaryTokenBytes = 12;
 
 function inside(root: string, candidate: string): boolean {
@@ -77,7 +99,7 @@ function inside(root: string, candidate: string): boolean {
   );
 }
 
-function targetContracts(
+export function buildStateTargetContracts(
   snapshot: HarnessDetectionSnapshot,
   adapters: MutationCoordinatorDependencies["adapters"],
 ): StateTargetContracts {
@@ -254,11 +276,26 @@ function findTarget(
   };
 }
 
-async function installTarget(
-  input: InstallDescriptorAcrossTargetsInput,
+function nextTimestamp(
+  candidate: string,
+  previous: string | undefined,
+): string {
+  if (
+    previous === undefined ||
+    isInstallerTimestampAfter(candidate, previous)
+  ) {
+    return candidate;
+  }
+  const milliseconds = Date.parse(previous);
+  if (!Number.isFinite(milliseconds)) throw new InstallerError("STATE_INVALID");
+  return new Date(milliseconds + 1).toISOString();
+}
+
+async function mutateTarget(
+  input: MutateDescriptorAcrossTargetsInput,
   targetId: ConfigurationTargetId,
   contracts: StateTargetContracts,
-): Promise<"installed" | "unchanged"> {
+): Promise<"disabled" | "enabled" | "installed" | "removed" | "unchanged"> {
   const { dependencies, descriptor, snapshot } = input;
   const target = findTarget(snapshot, targetId);
   const configPath = target.configuration.path;
@@ -340,50 +377,116 @@ async function installTarget(
       serverName: descriptor.server.name,
     });
     const registryDefinition = adapter.descriptorToDefinition(descriptor);
+    const managedInstallation =
+      loaded.state.installations[
+        installationKey(descriptor.id, targetId, configPath)
+      ];
     const planning = {
       descriptor,
       targetId,
       target: contracts[targetId],
       state: loaded.state,
       registryDefinition,
+      ...(managedInstallation?.suspendedDescriptor === undefined
+        ? {}
+        : {
+            normalizedSuspendedDefinition:
+              adapter.suspendedDescriptorToDefinition(
+                managedInstallation.suspendedDescriptor,
+              ),
+          }),
       currentServer: inspection.currentServer,
     } as const;
-    const plan = planInstallerAction(planning, "install");
-    if (plan.outcome === "blocked") throw new InstallerError(plan.code);
-    if (plan.outcome === "unchanged") return "unchanged";
-    const transition = applyInstallerStatePlan({
-      adapter,
-      occurredAt: dependencies.now(),
-      plan,
-      planning,
-      targetContracts: contracts,
-    });
-    if (transition === undefined) throw new InstallerError("STATE_INVALID");
-    const patch = adapter.constructPatch({
-      action: "install",
-      definition: registryDefinition,
-      inspection,
-    });
-    if (patch.kind !== "changed") throw new InstallerError("STATE_INVALID");
+    let stateBytes: Uint8Array;
+    let patch: TargetPatch;
+    if (input.action === "remove") {
+      if (managedInstallation === undefined) {
+        throw new InstallerError("INSTALLATION_UNAVAILABLE");
+      }
+      const ownership = planOwnership(planning);
+      if (ownership.status === "drifted") {
+        throw new InstallerError("CONFIG_DRIFT");
+      }
+      if (ownership.status === "conflict") {
+        throw new InstallerError("CONFIG_CONFLICT");
+      }
+      const nextInstallations = { ...loaded.state.installations };
+      delete nextInstallations[
+        installationKey(descriptor.id, targetId, configPath)
+      ];
+      stateBytes = serializeInstallerState(
+        { schemaVersion: 1, installations: nextInstallations },
+        contracts,
+      );
+      patch =
+        inspection.currentServer.kind === "absent"
+          ? ({ kind: "unchanged" } as const)
+          : adapter.constructPatch({ action: "remove", inspection });
+    } else {
+      const plan = planInstallerAction(planning, input.action);
+      if (plan.outcome === "blocked") throw new InstallerError(plan.code);
+      if (plan.outcome === "unchanged") return "unchanged";
+      const transition = applyInstallerStatePlan({
+        adapter,
+        occurredAt: nextTimestamp(
+          dependencies.now(),
+          managedInstallation?.updatedAt,
+        ),
+        plan,
+        planning,
+        targetContracts: contracts,
+      });
+      if (transition === undefined) throw new InstallerError("STATE_INVALID");
+      stateBytes = serializeInstallerState(transition.state, contracts);
+      patch =
+        input.action === "install"
+          ? adapter.constructPatch({
+              action: "install",
+              definition: registryDefinition,
+              inspection,
+            })
+          : input.action === "enable"
+            ? adapter.constructPatch({
+                action: "enable",
+                ...(transition.restoreDefinition === undefined
+                  ? {}
+                  : { restoreDefinition: transition.restoreDefinition }),
+                inspection,
+              })
+            : adapter.constructPatch({ action: "disable", inspection });
+      if (patch.kind !== "changed") throw new InstallerError("STATE_INVALID");
+    }
 
-    await atomicReplace(
-      dependencies,
-      configIdentity,
-      patch.postImage,
-      "CONFIG_WRITE_FAILED",
-    );
+    const configPostImage =
+      patch.kind === "changed" ? patch.postImage : undefined;
+    if (configPostImage !== undefined) {
+      await atomicReplace(
+        dependencies,
+        configIdentity,
+        configPostImage,
+        "CONFIG_WRITE_FAILED",
+      );
+    }
     try {
       await atomicReplace(
         dependencies,
         stateIdentity,
-        serializeInstallerState(transition.state, contracts),
+        stateBytes,
         "STATE_WRITE_FAILED",
       );
     } catch (cause) {
-      await rollbackConfig(dependencies, homeRoot, configPath, source);
+      if (configPostImage !== undefined) {
+        await rollbackConfig(dependencies, homeRoot, configPath, source);
+      }
       throw cause;
     }
-    return "installed";
+    return input.action === "remove"
+      ? "removed"
+      : input.action === "install"
+        ? "installed"
+        : input.action === "enable"
+          ? "enabled"
+          : "disabled";
   } catch (cause) {
     primaryError = cause;
     throw cause;
@@ -395,7 +498,13 @@ async function installTarget(
 export async function installDescriptorAcrossTargets(
   input: InstallDescriptorAcrossTargetsInput,
 ): Promise<readonly TargetMutationResult[]> {
-  const contracts = targetContracts(
+  return mutateDescriptorAcrossTargets({ ...input, action: "install" });
+}
+
+export async function mutateDescriptorAcrossTargets(
+  input: MutateDescriptorAcrossTargetsInput,
+): Promise<readonly TargetMutationResult[]> {
+  const contracts = buildStateTargetContracts(
     input.snapshot,
     input.dependencies.adapters,
   );
@@ -405,7 +514,7 @@ export async function installDescriptorAcrossTargets(
     if (seen.has(targetId)) continue;
     seen.add(targetId);
     try {
-      const outcome = await installTarget(input, targetId, contracts);
+      const outcome = await mutateTarget(input, targetId, contracts);
       results.push(Object.freeze({ targetId, outcome }));
     } catch (cause) {
       const error =

--- a/packages/installer/src/mutation-coordinator.ts
+++ b/packages/installer/src/mutation-coordinator.ts
@@ -1,0 +1,421 @@
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import type {
+  InstallerFileStat,
+  InstallerReadHandle,
+  InstallerTransactionFileSystem,
+  InstallerWriteHandle,
+} from "./file-system.js";
+import type {
+  ConfigurationTargetSnapshot,
+  HarnessDetectionSnapshot,
+} from "./harness-detection.js";
+import { InstallerError } from "./installer-error.js";
+import {
+  acquireInstallerLocks,
+  type InstallerLockDependencies,
+} from "./installer-lock.js";
+import {
+  loadInstallerState,
+  type StateTargetContracts,
+} from "./installer-state.js";
+import {
+  applyInstallerStatePlan,
+  serializeInstallerState,
+} from "./installer-state-transition.js";
+import { planInstallerAction } from "./ownership-planner.js";
+import {
+  bootstrapPrivateDirectory,
+  capturePathIdentity,
+  capturePathRoot,
+  type InstallerPathIdentity,
+  revalidatePathIdentity,
+} from "./path-identity.js";
+import type {
+  CapabilityInstallDescriptor,
+  ConfigurationTargetId,
+} from "./registry.js";
+import { type TargetAdapter, targetConfigByteLimit } from "./target-adapter.js";
+import type { InstallerEnvironment } from "./target-config-evidence.js";
+
+export interface MutationCoordinatorDependencies {
+  readonly adapters: Readonly<Record<ConfigurationTargetId, TargetAdapter>>;
+  readonly currentUserId: number;
+  readonly environment: InstallerEnvironment;
+  readonly fileSystem: InstallerTransactionFileSystem;
+  readonly lock: Omit<InstallerLockDependencies, "fileSystem">;
+  readonly now: () => string;
+}
+
+export type TargetMutationResult =
+  | {
+      readonly targetId: ConfigurationTargetId;
+      readonly outcome: "installed" | "unchanged";
+    }
+  | {
+      readonly targetId: ConfigurationTargetId;
+      readonly outcome: "failed";
+      readonly code: InstallerError["code"];
+    };
+
+export interface InstallDescriptorAcrossTargetsInput {
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly descriptor: CapabilityInstallDescriptor;
+  readonly snapshot: HarnessDetectionSnapshot;
+  readonly targetIds: readonly ConfigurationTargetId[];
+}
+
+const temporaryTokenBytes = 12;
+
+function inside(root: string, candidate: string): boolean {
+  const difference = relative(resolve(root), resolve(candidate));
+  return (
+    difference === "" ||
+    (difference !== ".." &&
+      !difference.startsWith(`..${sep}`) &&
+      !isAbsolute(difference))
+  );
+}
+
+function targetContracts(
+  snapshot: HarnessDetectionSnapshot,
+  adapters: MutationCoordinatorDependencies["adapters"],
+): StateTargetContracts {
+  return Object.freeze(
+    Object.fromEntries(
+      snapshot.targets.flatMap((target) => {
+        if (target.configuration.kind === "blocked") return [];
+        const metadata = adapters[target.id].metadata;
+        return [
+          [
+            target.id,
+            Object.freeze({
+              configPath: target.configuration.path,
+              targetContractVersion: metadata.targetContractVersion,
+              toggleStrategy: metadata.toggleStrategy,
+            }),
+          ],
+        ];
+      }),
+    ) as unknown as StateTargetContracts,
+  );
+}
+
+function sameStat(
+  expected: InstallerFileStat | undefined,
+  actual: InstallerFileStat,
+): boolean {
+  return (
+    expected !== undefined &&
+    expected.kind === actual.kind &&
+    expected.dev === actual.dev &&
+    expected.ino === actual.ino &&
+    expected.uid === actual.uid &&
+    expected.gid === actual.gid
+  );
+}
+
+async function readCapturedFile(
+  fileSystem: InstallerTransactionFileSystem,
+  identity: InstallerPathIdentity,
+  maximumBytes: number,
+  errorCode: "HARNESS_CONFIG_READ_FAILED" | "STATE_READ_FAILED",
+): Promise<Uint8Array | undefined> {
+  if (identity.missingPaths.length > 0) return undefined;
+  let handle: InstallerReadHandle | undefined;
+  try {
+    handle = await fileSystem.openReadNoFollow(identity.targetPath);
+    if (!sameStat(identity.components.at(-1), await handle.stat())) {
+      throw new InstallerError(
+        errorCode === "STATE_READ_FAILED" ? "STATE_CHANGED" : "CONFIG_CHANGED",
+      );
+    }
+    return await handle.readAll(maximumBytes);
+  } catch (cause) {
+    if (cause instanceof InstallerError) throw cause;
+    throw new InstallerError(errorCode, cause);
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function ensureParentDirectory(
+  dependencies: MutationCoordinatorDependencies,
+  root: Awaited<ReturnType<typeof capturePathRoot>>,
+  targetPath: string,
+  unsafeCode: "HARNESS_CONFIG_UNSAFE" | "STATE_INVALID",
+): Promise<void> {
+  const parentPath = resolve(targetPath, "..");
+  if (!inside(root.path, parentPath)) {
+    throw new InstallerError(unsafeCode);
+  }
+  try {
+    const identity = await capturePathIdentity(dependencies.fileSystem, {
+      root,
+      targetPath: parentPath,
+      targetKind: "directory",
+    });
+    await bootstrapPrivateDirectory(dependencies.fileSystem, {
+      expected: identity,
+    });
+  } catch (cause) {
+    throw new InstallerError(unsafeCode, cause);
+  }
+}
+
+function randomToken(randomBytes: (length: number) => Uint8Array): string {
+  const bytes = randomBytes(temporaryTokenBytes);
+  if (bytes.byteLength !== temporaryTokenBytes) {
+    throw new InstallerError("CONFIG_WRITE_FAILED");
+  }
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function atomicReplace(
+  dependencies: MutationCoordinatorDependencies,
+  identity: InstallerPathIdentity,
+  bytes: Uint8Array,
+  failureCode: "CONFIG_WRITE_FAILED" | "STATE_WRITE_FAILED",
+): Promise<void> {
+  const { fileSystem } = dependencies;
+  const temporaryPath = `${identity.targetPath}.tmp.${randomToken(dependencies.lock.randomBytes)}`;
+  let created = false;
+  let handle: InstallerWriteHandle | undefined;
+  try {
+    handle = await fileSystem.createExclusiveNoFollow(temporaryPath, 0o600);
+    created = true;
+    await handle.writeAll(bytes);
+    await handle.chmod(0o600);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await revalidatePathIdentity(fileSystem, identity);
+    await fileSystem.rename(temporaryPath, identity.targetPath);
+    created = false;
+  } catch (cause) {
+    await handle?.close().catch(() => undefined);
+    if (created) await fileSystem.unlink(temporaryPath).catch(() => undefined);
+    if (cause instanceof InstallerError) throw cause;
+    throw new InstallerError(failureCode, cause);
+  }
+}
+
+async function rollbackConfig(
+  dependencies: MutationCoordinatorDependencies,
+  root: Awaited<ReturnType<typeof capturePathRoot>>,
+  configPath: string,
+  original: Uint8Array | undefined,
+): Promise<void> {
+  try {
+    const current = await capturePathIdentity(dependencies.fileSystem, {
+      root,
+      targetPath: configPath,
+      targetKind: "regular-file",
+    });
+    if (original === undefined) {
+      if (current.missingPaths.length === 0) {
+        await dependencies.fileSystem.unlink(configPath);
+      }
+    } else {
+      await atomicReplace(
+        dependencies,
+        current,
+        original,
+        "CONFIG_WRITE_FAILED",
+      );
+    }
+  } catch (cause) {
+    throw new InstallerError("CONFIG_ROLLBACK_FAILED", cause);
+  }
+}
+
+function findTarget(
+  snapshot: HarnessDetectionSnapshot,
+  targetId: ConfigurationTargetId,
+): ConfigurationTargetSnapshot & {
+  readonly configuration: Exclude<
+    ConfigurationTargetSnapshot["configuration"],
+    { readonly kind: "blocked" }
+  >;
+} {
+  const target = snapshot.targets.find(({ id }) => id === targetId);
+  if (
+    target === undefined ||
+    !target.eligible ||
+    target.configuration.kind === "blocked"
+  ) {
+    throw new InstallerError("TARGET_UNSUPPORTED");
+  }
+  return target as ConfigurationTargetSnapshot & {
+    readonly configuration: Exclude<
+      ConfigurationTargetSnapshot["configuration"],
+      { readonly kind: "blocked" }
+    >;
+  };
+}
+
+async function installTarget(
+  input: InstallDescriptorAcrossTargetsInput,
+  targetId: ConfigurationTargetId,
+  contracts: StateTargetContracts,
+): Promise<"installed" | "unchanged"> {
+  const { dependencies, descriptor, snapshot } = input;
+  const target = findTarget(snapshot, targetId);
+  const configPath = target.configuration.path;
+  const adapter = dependencies.adapters[targetId];
+  const compatibility = adapter.compatibility(descriptor);
+  if (!compatibility.supported) throw new InstallerError("TARGET_UNSUPPORTED");
+
+  const loadedBeforeLock = await loadInstallerState({
+    currentUserId: dependencies.currentUserId,
+    environment: dependencies.environment,
+    fileSystem: dependencies.fileSystem,
+    homeDirectory: snapshot.homeDirectory,
+    targetContracts: contracts,
+  });
+  const homeRoot = await capturePathRoot(dependencies.fileSystem, {
+    rootKind: "home",
+    rootPath: snapshot.homeDirectory,
+    currentUserId: dependencies.currentUserId,
+  }).catch((cause) => {
+    throw new InstallerError("HARNESS_CONFIG_UNSAFE", cause);
+  });
+  await ensureParentDirectory(
+    dependencies,
+    homeRoot,
+    configPath,
+    "HARNESS_CONFIG_UNSAFE",
+  );
+  const stateRoot = inside(homeRoot.path, loadedBeforeLock.path)
+    ? homeRoot
+    : await capturePathRoot(dependencies.fileSystem, {
+        rootKind: "state",
+        rootPath: resolve(loadedBeforeLock.path, "../.."),
+        currentUserId: dependencies.currentUserId,
+      }).catch((cause) => {
+        throw new InstallerError("STATE_INVALID", cause);
+      });
+  await ensureParentDirectory(
+    dependencies,
+    stateRoot,
+    loadedBeforeLock.path,
+    "STATE_INVALID",
+  );
+
+  const locks = await acquireInstallerLocks({
+    configPath,
+    statePath: loadedBeforeLock.path,
+    dependencies: { ...dependencies.lock, fileSystem: dependencies.fileSystem },
+  });
+  let primaryError: unknown;
+  try {
+    const loaded = await loadInstallerState({
+      currentUserId: dependencies.currentUserId,
+      environment: dependencies.environment,
+      fileSystem: dependencies.fileSystem,
+      homeDirectory: snapshot.homeDirectory,
+      targetContracts: contracts,
+    });
+    if (loaded.path !== loadedBeforeLock.path) {
+      throw new InstallerError("STATE_CHANGED");
+    }
+    const configIdentity = await capturePathIdentity(dependencies.fileSystem, {
+      root: homeRoot,
+      targetPath: configPath,
+      targetKind: "regular-file",
+    });
+    const stateIdentity = await capturePathIdentity(dependencies.fileSystem, {
+      root: stateRoot,
+      targetPath: loaded.path,
+      targetKind: "regular-file",
+    });
+    const source = await readCapturedFile(
+      dependencies.fileSystem,
+      configIdentity,
+      targetConfigByteLimit,
+      "HARNESS_CONFIG_READ_FAILED",
+    );
+    const inspection = adapter.inspect({
+      source,
+      serverName: descriptor.server.name,
+    });
+    const registryDefinition = adapter.descriptorToDefinition(descriptor);
+    const planning = {
+      descriptor,
+      targetId,
+      target: contracts[targetId],
+      state: loaded.state,
+      registryDefinition,
+      currentServer: inspection.currentServer,
+    } as const;
+    const plan = planInstallerAction(planning, "install");
+    if (plan.outcome === "blocked") throw new InstallerError(plan.code);
+    if (plan.outcome === "unchanged") return "unchanged";
+    const transition = applyInstallerStatePlan({
+      adapter,
+      occurredAt: dependencies.now(),
+      plan,
+      planning,
+      targetContracts: contracts,
+    });
+    if (transition === undefined) throw new InstallerError("STATE_INVALID");
+    const patch = adapter.constructPatch({
+      action: "install",
+      definition: registryDefinition,
+      inspection,
+    });
+    if (patch.kind !== "changed") throw new InstallerError("STATE_INVALID");
+
+    await atomicReplace(
+      dependencies,
+      configIdentity,
+      patch.postImage,
+      "CONFIG_WRITE_FAILED",
+    );
+    try {
+      await atomicReplace(
+        dependencies,
+        stateIdentity,
+        serializeInstallerState(transition.state, contracts),
+        "STATE_WRITE_FAILED",
+      );
+    } catch (cause) {
+      await rollbackConfig(dependencies, homeRoot, configPath, source);
+      throw cause;
+    }
+    return "installed";
+  } catch (cause) {
+    primaryError = cause;
+    throw cause;
+  } finally {
+    await locks.release(primaryError);
+  }
+}
+
+export async function installDescriptorAcrossTargets(
+  input: InstallDescriptorAcrossTargetsInput,
+): Promise<readonly TargetMutationResult[]> {
+  const contracts = targetContracts(
+    input.snapshot,
+    input.dependencies.adapters,
+  );
+  const results: TargetMutationResult[] = [];
+  const seen = new Set<ConfigurationTargetId>();
+  for (const targetId of input.targetIds) {
+    if (seen.has(targetId)) continue;
+    seen.add(targetId);
+    try {
+      const outcome = await installTarget(input, targetId, contracts);
+      results.push(Object.freeze({ targetId, outcome }));
+    } catch (cause) {
+      const error =
+        cause instanceof InstallerError
+          ? cause
+          : new InstallerError("INSTALLER_INITIALIZATION_FAILED", cause);
+      results.push(
+        Object.freeze({ targetId, outcome: "failed", code: error.code }),
+      );
+    }
+  }
+  return Object.freeze(results);
+}

--- a/packages/installer/src/mutation-coordinator.ts
+++ b/packages/installer/src/mutation-coordinator.ts
@@ -203,11 +203,17 @@ async function atomicReplace(
   const temporaryPath = `${identity.targetPath}.tmp.${randomToken(dependencies.lock.randomBytes)}`;
   let created = false;
   let handle: InstallerWriteHandle | undefined;
+  const existing =
+    identity.missingPaths.length === 0 ? identity.components.at(-1) : undefined;
+  const targetMode = existing === undefined ? 0o600 : existing.mode & 0o7777;
   try {
     handle = await fileSystem.createExclusiveNoFollow(temporaryPath, 0o600);
     created = true;
     await handle.writeAll(bytes);
-    await handle.chmod(0o600);
+    if (existing !== undefined) {
+      await handle.chown(existing.uid, existing.gid);
+    }
+    await handle.chmod(targetMode);
     await handle.sync();
     await handle.close();
     handle = undefined;
@@ -220,6 +226,35 @@ async function atomicReplace(
     if (cause instanceof InstallerError) throw cause;
     throw new InstallerError(failureCode, cause);
   }
+}
+
+function installReplacementPatch(
+  adapter: TargetAdapter,
+  inspection: ReturnType<TargetAdapter["inspect"]>,
+  serverName: string,
+  definition: Readonly<Record<string, unknown>>,
+  disabled: boolean,
+): TargetPatch {
+  if (inspection.currentServer.kind !== "present") {
+    throw new InstallerError("STATE_INVALID");
+  }
+  const removed = adapter.constructPatch({ action: "remove", inspection });
+  if (removed.kind !== "changed") throw new InstallerError("STATE_INVALID");
+  const absent = adapter.inspect({
+    source: removed.postImage,
+    serverName,
+  });
+  const installed = adapter.constructPatch({
+    action: "install",
+    definition,
+    inspection: absent,
+  });
+  if (installed.kind !== "changed" || !disabled) return installed;
+  const enabled = adapter.inspect({
+    source: installed.postImage,
+    serverName,
+  });
+  return adapter.constructPatch({ action: "disable", inspection: enabled });
 }
 
 async function rollbackConfig(
@@ -439,22 +474,35 @@ async function mutateTarget(
       if (transition === undefined) throw new InstallerError("STATE_INVALID");
       stateBytes = serializeInstallerState(transition.state, contracts);
       patch =
-        input.action === "install"
-          ? adapter.constructPatch({
-              action: "install",
-              definition: registryDefinition,
-              inspection,
-            })
-          : input.action === "enable"
-            ? adapter.constructPatch({
-                action: "enable",
-                ...(transition.restoreDefinition === undefined
-                  ? {}
-                  : { restoreDefinition: transition.restoreDefinition }),
+        plan.configEffect === "none"
+          ? ({ kind: "unchanged" } as const)
+          : plan.configEffect === "replace" ||
+              plan.configEffect === "replace-disabled"
+            ? installReplacementPatch(
+                adapter,
                 inspection,
-              })
-            : adapter.constructPatch({ action: "disable", inspection });
-      if (patch.kind !== "changed") throw new InstallerError("STATE_INVALID");
+                descriptor.server.name,
+                registryDefinition,
+                plan.configEffect === "replace-disabled",
+              )
+            : input.action === "install"
+              ? adapter.constructPatch({
+                  action: "install",
+                  definition: registryDefinition,
+                  inspection,
+                })
+              : input.action === "enable"
+                ? adapter.constructPatch({
+                    action: "enable",
+                    ...(transition.restoreDefinition === undefined
+                      ? {}
+                      : { restoreDefinition: transition.restoreDefinition }),
+                    inspection,
+                  })
+                : adapter.constructPatch({ action: "disable", inspection });
+      if (patch.kind !== "changed" && plan.configEffect !== "none") {
+        throw new InstallerError("STATE_INVALID");
+      }
     }
 
     const configPostImage =

--- a/packages/installer/src/ownership-planner.ts
+++ b/packages/installer/src/ownership-planner.ts
@@ -72,6 +72,8 @@ export type InstallerActionPlan =
       readonly configEffect:
         | "none"
         | "install"
+        | "replace"
+        | "replace-disabled"
         | "set-enabled"
         | "set-disabled"
         | "detach"
@@ -369,9 +371,23 @@ export function planInstallerAction(
       : status === "enabled"
         ? "enabled"
         : "disabled";
+  if (status === "outdated" && action === "install") {
+    return freezePlan({
+      outcome: "write",
+      action,
+      configEffect:
+        enablement === "enabled"
+          ? "replace"
+          : input.target.toggleStrategy === "detached"
+            ? "none"
+            : "replace-disabled",
+      stateEffect: "update",
+      definitionSource: "registry",
+    });
+  }
   if (
     action === "adopt" ||
-    (action === "install" && enablement === "enabled") ||
+    action === "install" ||
     (action === "enable" && enablement === "enabled") ||
     (action === "disable" && enablement === "disabled")
   ) {

--- a/packages/installer/src/path-identity.ts
+++ b/packages/installer/src/path-identity.ts
@@ -2,8 +2,8 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import {
   type InstallerFileStat,
-  isInstallerFileSystemError,
   type InstallerTransactionFileSystem,
+  isInstallerFileSystemError,
 } from "./file-system.js";
 
 export type InstallerPathIdentityErrorCode =
@@ -38,7 +38,7 @@ export class InstallerPathIdentityError extends Error {
   }
 }
 
-export type InstallerPathRootKind = "home" | "state";
+export type InstallerPathRootKind = "engine" | "home" | "state";
 export type InstallerPathTargetKind = "directory" | "regular-file";
 
 export interface InstallerPathNodeIdentity extends InstallerFileStat {

--- a/packages/installer/src/registry.ts
+++ b/packages/installer/src/registry.ts
@@ -4,6 +4,7 @@ import { InstallerError } from "./installer-error.js";
 export const configurationTargetIds = Object.freeze([
   "antigravity",
   "claude-code",
+  "claude-desktop",
   "codex",
   "cursor",
   "grok-build",
@@ -11,6 +12,7 @@ export const configurationTargetIds = Object.freeze([
   "kimi-code",
   "openclaw",
   "opencode-v2",
+  "vscode",
 ] as const);
 
 export type ConfigurationTargetId = (typeof configurationTargetIds)[number];

--- a/packages/installer/src/remote-install-source.ts
+++ b/packages/installer/src/remote-install-source.ts
@@ -1,0 +1,149 @@
+import { InstallerError } from "./installer-error.js";
+import type { CapabilityInstallDescriptor } from "./registry.js";
+
+export interface CreateRemoteInstallDescriptorOptions {
+  readonly serverName: string;
+  readonly url: string;
+  readonly bearerTokenEnvironment?: string;
+  readonly headerEnvironment?: readonly string[];
+}
+
+const serverNamePattern = /^[a-z][a-z0-9_-]{0,63}$/u;
+const environmentNamePattern = /^[A-Z_][A-Z0-9_]{0,127}$/u;
+const httpFieldNamePattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/u;
+const reservedHeaderNames = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function invalid(cause?: unknown): never {
+  throw new InstallerError("REMOTE_INVALID", cause);
+}
+
+function canonicalUrl(value: string): string {
+  if (value.includes("\0")) return invalid();
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (cause) {
+    return invalid(cause);
+  }
+  const schemeSeparator = value.indexOf("://");
+  if (schemeSeparator <= 0) return invalid();
+  const authorityTail = value.slice(schemeSeparator + 3);
+  const authorityEnd = authorityTail.search(/[/?#]/u);
+  const authority = authorityTail.slice(
+    0,
+    authorityEnd === -1 ? undefined : authorityEnd,
+  );
+  const rawTarget =
+    authorityEnd === -1 ? "" : authorityTail.slice(authorityEnd);
+  const queryOrFragment = rawTarget.search(/[?#]/u);
+  const rawPath = rawTarget.slice(
+    0,
+    queryOrFragment === -1 ? undefined : queryOrFragment,
+  );
+  const rawHost = authority.startsWith("[")
+    ? authority.slice(0, authority.indexOf("]") + 1)
+    : authority.split(":", 1)[0];
+  if (
+    (url.protocol !== "https:" && url.protocol !== "http:") ||
+    authority === "" ||
+    authority.includes("@") ||
+    url.hostname === "" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    rawPath !== "/mcp" ||
+    url.pathname !== "/mcp" ||
+    value.includes("?") ||
+    value.includes("#")
+  ) {
+    return invalid();
+  }
+  if (
+    url.protocol === "http:" &&
+    rawHost !== "127.0.0.1" &&
+    rawHost !== "[::1]"
+  ) {
+    return invalid();
+  }
+  return url.href;
+}
+
+function headersFromEnvironment(
+  values: readonly string[],
+  hasBearerAuthentication: boolean,
+): Readonly<Record<string, string>> {
+  if (values.length > 64) return invalid();
+  const headers = new Map<string, string>();
+  for (const value of values) {
+    const separator = value.indexOf("=");
+    if (separator <= 0 || separator === value.length - 1) return invalid();
+    const rawName = value.slice(0, separator);
+    const environmentName = value.slice(separator + 1);
+    const name = rawName.toLowerCase();
+    if (
+      !httpFieldNamePattern.test(rawName) ||
+      !environmentNamePattern.test(environmentName) ||
+      reservedHeaderNames.has(name) ||
+      (hasBearerAuthentication && name === "authorization") ||
+      headers.has(name)
+    ) {
+      return invalid();
+    }
+    headers.set(name, environmentName);
+  }
+  return Object.freeze(
+    Object.fromEntries(
+      [...headers.entries()].sort(([left], [right]) =>
+        left < right ? -1 : left === right ? 0 : 1,
+      ),
+    ),
+  );
+}
+
+export function createRemoteInstallDescriptor(
+  options: CreateRemoteInstallDescriptorOptions,
+): CapabilityInstallDescriptor {
+  if (!serverNamePattern.test(options.serverName)) return invalid();
+  if (
+    options.bearerTokenEnvironment !== undefined &&
+    !environmentNamePattern.test(options.bearerTokenEnvironment)
+  ) {
+    return invalid();
+  }
+  const url = canonicalUrl(options.url);
+  const authentication =
+    options.bearerTokenEnvironment === undefined
+      ? Object.freeze({ type: "none" as const })
+      : Object.freeze({
+          type: "bearer-env" as const,
+          variable: options.bearerTokenEnvironment,
+        });
+  const headersFromEnv = headersFromEnvironment(
+    options.headerEnvironment ?? [],
+    authentication.type === "bearer-env",
+  );
+  const transport = Object.freeze({
+    type: "streamable-http" as const,
+    url,
+    authentication,
+    headersFromEnv,
+  });
+  return Object.freeze({
+    id: `remote-${options.serverName.replaceAll("_", "-")}`,
+    version: "remote",
+    title: options.serverName,
+    description: `Remote ${options.serverName} MCP server.`,
+    capabilityIds: Object.freeze([`remote.${options.serverName}`]),
+    server: Object.freeze({ name: options.serverName, transport }),
+  });
+}

--- a/packages/installer/src/run-installer-cli.ts
+++ b/packages/installer/src/run-installer-cli.ts
@@ -8,6 +8,13 @@ export type InstallerExitCode = 0 | 1 | 2 | 130;
 export type InstallerCommand =
   | { readonly kind: "inventory" }
   | { readonly kind: "install-engine"; readonly projectDirectory: string }
+  | {
+      readonly kind: "install-http";
+      readonly serverName: string;
+      readonly url: string;
+      readonly bearerTokenEnvironment?: string;
+      readonly headerEnvironment: readonly string[];
+    }
   | { readonly kind: "disable" | "enable" | "remove" | "status" };
 
 export interface InstallerCliIo {
@@ -29,6 +36,7 @@ export interface RunInstallerCliOptions {
 const helpText = `Usage:
   invokta-installer
   invokta-installer install --engine <project-directory>
+  invokta-installer install --http <server-name> <url> [--bearer-token-env <NAME>] [--header-env <HEADER=NAME>]...
   invokta-installer status
   invokta-installer enable
   invokta-installer disable
@@ -72,6 +80,35 @@ function parseCommand(argv: readonly string[]): InstallerCommand | undefined {
     return Object.freeze({
       kind: "install-engine",
       projectDirectory: argv[2] as string,
+    });
+  }
+  if (argv[0] === "install" && argv[1] === "--http") {
+    const serverName = argv[2];
+    const url = argv[3];
+    if (serverName === undefined || url === undefined) return undefined;
+    let bearerTokenEnvironment: string | undefined;
+    const headerEnvironment: string[] = [];
+    for (let index = 4; index < argv.length; index += 2) {
+      const flag = argv[index];
+      const value = argv[index + 1];
+      if (value === undefined) return undefined;
+      if (flag === "--bearer-token-env") {
+        if (bearerTokenEnvironment !== undefined) return undefined;
+        bearerTokenEnvironment = value;
+      } else if (flag === "--header-env") {
+        headerEnvironment.push(value);
+      } else {
+        return undefined;
+      }
+    }
+    return Object.freeze({
+      kind: "install-http",
+      serverName,
+      url,
+      ...(bearerTokenEnvironment === undefined
+        ? {}
+        : { bearerTokenEnvironment }),
+      headerEnvironment: Object.freeze(headerEnvironment),
     });
   }
   if (

--- a/packages/installer/src/run-installer-cli.ts
+++ b/packages/installer/src/run-installer-cli.ts
@@ -88,14 +88,18 @@ function parseCommand(argv: readonly string[]): InstallerCommand | undefined {
     if (serverName === undefined || url === undefined) return undefined;
     let bearerTokenEnvironment: string | undefined;
     const headerEnvironment: string[] = [];
+    let headerOptionSeen = false;
     for (let index = 4; index < argv.length; index += 2) {
       const flag = argv[index];
       const value = argv[index + 1];
       if (value === undefined) return undefined;
       if (flag === "--bearer-token-env") {
-        if (bearerTokenEnvironment !== undefined) return undefined;
+        if (bearerTokenEnvironment !== undefined || headerOptionSeen) {
+          return undefined;
+        }
         bearerTokenEnvironment = value;
       } else if (flag === "--header-env") {
+        headerOptionSeen = true;
         headerEnvironment.push(value);
       } else {
         return undefined;

--- a/packages/installer/src/run-installer-cli.ts
+++ b/packages/installer/src/run-installer-cli.ts
@@ -5,6 +5,10 @@ import {
 
 export type InstallerExitCode = 0 | 1 | 2 | 130;
 
+export type InstallerCommand =
+  | { readonly kind: "inventory" }
+  | { readonly kind: "install-engine"; readonly projectDirectory: string };
+
 export interface InstallerCliIo {
   readonly inputIsTTY: () => boolean;
   readonly outputIsTTY: () => boolean;
@@ -15,12 +19,15 @@ export interface InstallerCliIo {
 export interface RunInstallerCliOptions {
   readonly argv?: readonly string[];
   readonly io?: Partial<InstallerCliIo>;
-  readonly loadInteractiveSession?: () => Promise<InstallerExitCode>;
+  readonly loadInteractiveSession?: (
+    command: InstallerCommand,
+  ) => Promise<InstallerExitCode>;
   readonly loadPackageVersion?: () => Promise<string>;
 }
 
 const helpText = `Usage:
   invokta-installer
+  invokta-installer install --engine <project-directory>
   invokta-installer --help
   invokta-installer --version
 `;
@@ -47,9 +54,22 @@ function resolveIo(overrides: Partial<InstallerCliIo> | undefined) {
   } satisfies InstallerCliIo;
 }
 
-async function loadDefaultInteractiveSession(): Promise<InstallerExitCode> {
+async function loadDefaultInteractiveSession(
+  command: InstallerCommand,
+): Promise<InstallerExitCode> {
   const { runInteractiveSession } = await import("./interactive-session.js");
-  return runInteractiveSession();
+  return runInteractiveSession({ command });
+}
+
+function parseCommand(argv: readonly string[]): InstallerCommand | undefined {
+  if (argv.length === 0) return Object.freeze({ kind: "inventory" });
+  if (argv.length === 3 && argv[0] === "install" && argv[1] === "--engine") {
+    return Object.freeze({
+      kind: "install-engine",
+      projectDirectory: argv[2] as string,
+    });
+  }
+  return undefined;
 }
 
 function asRecord(
@@ -116,7 +136,8 @@ export async function runInstallerCli(
       return writeInitializationFailure(io, error);
     }
   }
-  if (argv.length !== 0) {
+  const command = parseCommand(argv);
+  if (command === undefined) {
     await writeStderr(io, invalidUsageText);
     return 2;
   }
@@ -131,8 +152,21 @@ export async function runInstallerCli(
     }
     return await (
       options.loadInteractiveSession ?? loadDefaultInteractiveSession
-    )();
+    )(command);
   } catch (error) {
+    if (error instanceof InstallerError) {
+      if (error.code === "CANCELLED") {
+        await writeStderr(io, renderInstallerDiagnostic(error));
+        return 130;
+      }
+      if (
+        error.code !== "INSTALLER_INITIALIZATION_FAILED" &&
+        error.code !== "REGISTRY_INVALID"
+      ) {
+        await writeStderr(io, renderInstallerDiagnostic(error));
+        return 1;
+      }
+    }
     return writeInitializationFailure(io, error);
   }
 }

--- a/packages/installer/src/run-installer-cli.ts
+++ b/packages/installer/src/run-installer-cli.ts
@@ -7,7 +7,8 @@ export type InstallerExitCode = 0 | 1 | 2 | 130;
 
 export type InstallerCommand =
   | { readonly kind: "inventory" }
-  | { readonly kind: "install-engine"; readonly projectDirectory: string };
+  | { readonly kind: "install-engine"; readonly projectDirectory: string }
+  | { readonly kind: "disable" | "enable" | "remove" | "status" };
 
 export interface InstallerCliIo {
   readonly inputIsTTY: () => boolean;
@@ -28,6 +29,10 @@ export interface RunInstallerCliOptions {
 const helpText = `Usage:
   invokta-installer
   invokta-installer install --engine <project-directory>
+  invokta-installer status
+  invokta-installer enable
+  invokta-installer disable
+  invokta-installer remove
   invokta-installer --help
   invokta-installer --version
 `;
@@ -68,6 +73,15 @@ function parseCommand(argv: readonly string[]): InstallerCommand | undefined {
       kind: "install-engine",
       projectDirectory: argv[2] as string,
     });
+  }
+  if (
+    argv.length === 1 &&
+    (argv[0] === "status" ||
+      argv[0] === "enable" ||
+      argv[0] === "disable" ||
+      argv[0] === "remove")
+  ) {
+    return Object.freeze({ kind: argv[0] });
   }
   return undefined;
 }

--- a/packages/installer/src/target-adapter.ts
+++ b/packages/installer/src/target-adapter.ts
@@ -128,6 +128,11 @@ export type TargetPatchRequest =
       readonly action: "disable";
       readonly inspection: TargetConfigInspection;
       readonly counters?: TargetAdapterCounters;
+    }
+  | {
+      readonly action: "remove";
+      readonly inspection: TargetConfigInspection;
+      readonly counters?: TargetAdapterCounters;
     };
 
 export type TargetPatch =
@@ -634,7 +639,10 @@ export function assertPostImageDefinition(
   toggleStrategy: ToggleStrategy = "native-enabled",
 ): void {
   const postCanonicals = assertTargetInspectionConsistency(postInspection);
-  if (toggleStrategy === "detached" && request.action === "disable") {
+  if (
+    request.action === "remove" ||
+    (toggleStrategy === "detached" && request.action === "disable")
+  ) {
     if (
       postInspection.currentServer.kind !== "absent" ||
       postCanonicals !== undefined

--- a/packages/installer/src/target-adapters.ts
+++ b/packages/installer/src/target-adapters.ts
@@ -667,9 +667,17 @@ function definitionToSuspendedDescriptor(
             : targetId === "antigravity" || targetId === "kimi-code"
               ? undefined
               : "env";
-        const typeField = targetId === "claude-code" ? "type" : undefined;
+        const typeField =
+          targetId === "claude-code" ||
+          targetId === "claude-desktop" ||
+          targetId === "vscode"
+            ? "type"
+            : undefined;
         const toggleField =
-          targetId === "claude-code" || targetId === "cursor"
+          targetId === "claude-code" ||
+          targetId === "claude-desktop" ||
+          targetId === "cursor" ||
+          targetId === "vscode"
             ? undefined
             : targetId === "antigravity"
               ? "disabled"
@@ -703,7 +711,7 @@ function definitionToSuspendedDescriptor(
         } else {
           forwardEnv = inverseEnvironmentObject(
             inverseOwn(record, environmentField),
-            targetId === "cursor" ? "cursor" : "plain",
+            targetId === "cursor" || targetId === "vscode" ? "cursor" : "plain",
           );
         }
         if (toggleField !== undefined) {
@@ -777,12 +785,18 @@ function definitionToSuspendedDescriptor(
       } else {
         const headersField = "headers";
         const typeField =
-          targetId === "claude-code" || targetId === "opencode-v2"
+          targetId === "claude-code" ||
+          targetId === "claude-desktop" ||
+          targetId === "vscode" ||
+          targetId === "opencode-v2"
             ? "type"
             : undefined;
         const oauthField = targetId === "opencode-v2" ? "oauth" : undefined;
         const toggleField =
-          targetId === "claude-code" || targetId === "cursor"
+          targetId === "claude-code" ||
+          targetId === "claude-desktop" ||
+          targetId === "cursor" ||
+          targetId === "vscode"
             ? undefined
             : targetId === "opencode-v2"
               ? "disabled"
@@ -811,7 +825,7 @@ function definitionToSuspendedDescriptor(
         url = inverseString(record, "url");
         const headers = inversePlaceholderHeaders(
           inverseOwn(record, headersField),
-          targetId === "cursor"
+          targetId === "cursor" || targetId === "vscode"
             ? "cursor"
             : targetId === "opencode-v2"
               ? "opencode"
@@ -1055,6 +1069,37 @@ function cursorDefinition(
   );
 }
 
+function vscodeDefinition(
+  descriptor:
+    | CapabilityInstallDescriptor
+    | { readonly server: SuspendedDescriptor },
+): Readonly<Record<string, unknown>> {
+  const transport = descriptor.server.transport;
+  if (transport.type === "stdio") {
+    return jsonDefinition(
+      {
+        transport: "stdio",
+        type: "stdio",
+        command: transport.command,
+        args: [...transport.args],
+        env: Object.fromEntries(
+          transport.forwardEnv.map((name) => [name, `\${env:${name}}`]),
+        ),
+      },
+      "detached",
+    );
+  }
+  return jsonDefinition(
+    {
+      transport: "streamable-http",
+      type: "http",
+      url: transport.url,
+      headers: cursorPlaceholderHeaders(descriptor),
+    },
+    "detached",
+  );
+}
+
 function antigravityCompatibility(descriptor: CapabilityInstallDescriptor) {
   const transport = descriptor.server.transport;
   if (transport.type === "stdio") {
@@ -1283,6 +1328,26 @@ const claudeCode = createJsonTargetAdapter({
     definitionToSuspendedDescriptor("claude-code", serverName, definition),
 });
 
+const claudeDesktop = createJsonTargetAdapter({
+  targetId: "claude-desktop",
+  dialect: "claude",
+  toggleStrategy: "detached",
+  compatibility: portableCompatibility,
+  descriptorToDefinition: claudeDefinition,
+  definitionToSuspendedDescriptor: (serverName, definition) =>
+    definitionToSuspendedDescriptor("claude-desktop", serverName, definition),
+});
+
+const vscode = createJsonTargetAdapter({
+  targetId: "vscode",
+  dialect: "vscode",
+  toggleStrategy: "detached",
+  compatibility: portableCompatibility,
+  descriptorToDefinition: vscodeDefinition,
+  definitionToSuspendedDescriptor: (serverName, definition) =>
+    definitionToSuspendedDescriptor("vscode", serverName, definition),
+});
+
 const cursor = createJsonTargetAdapter({
   targetId: "cursor",
   dialect: "cursor",
@@ -1330,6 +1395,7 @@ const grokBuild = createTomlTargetAdapter({
 export const configurationTargetAdapters = Object.freeze({
   antigravity,
   "claude-code": claudeCode,
+  "claude-desktop": claudeDesktop,
   codex,
   cursor,
   "grok-build": grokBuild,
@@ -1337,12 +1403,14 @@ export const configurationTargetAdapters = Object.freeze({
   "kimi-code": kimiCode,
   openclaw,
   "opencode-v2": openCode,
+  vscode,
 } as const);
 
 export const registryCompatibilityAdapters: RegistryCompatibilityAdapters =
   Object.freeze({
     antigravity: antigravity.compatibility,
     "claude-code": claudeCode.compatibility,
+    "claude-desktop": claudeDesktop.compatibility,
     codex: codex.compatibility,
     cursor: cursor.compatibility,
     "grok-build": grokBuild.compatibility,
@@ -1350,6 +1418,7 @@ export const registryCompatibilityAdapters: RegistryCompatibilityAdapters =
     "kimi-code": kimiCode.compatibility,
     openclaw: openclaw.compatibility,
     "opencode-v2": openCode.compatibility,
+    vscode: vscode.compatibility,
   } satisfies Record<
     ConfigurationTargetId,
     RegistryCompatibilityAdapters[ConfigurationTargetId]

--- a/packages/installer/src/target-adapters.ts
+++ b/packages/installer/src/target-adapters.ts
@@ -1040,6 +1040,22 @@ function claudeDefinition(
   );
 }
 
+function claudeDesktopCompatibility(descriptor: CapabilityInstallDescriptor) {
+  const transport = descriptor.server.transport;
+  if (transport.type === "streamable-http") {
+    return {
+      supported: false as const,
+      reason: "claude-desktop-http-config-unsupported",
+    };
+  }
+  return transport.forwardEnv.length === 0
+    ? ({ supported: true } as const)
+    : ({
+        supported: false,
+        reason: "claude-desktop-forward-env-unsupported",
+      } as const);
+}
+
 function cursorDefinition(
   descriptor:
     | CapabilityInstallDescriptor
@@ -1332,8 +1348,13 @@ const claudeDesktop = createJsonTargetAdapter({
   targetId: "claude-desktop",
   dialect: "claude",
   toggleStrategy: "detached",
-  compatibility: portableCompatibility,
-  descriptorToDefinition: claudeDefinition,
+  compatibility: claudeDesktopCompatibility,
+  descriptorToDefinition: (descriptor) => {
+    if (!claudeDesktopCompatibility(descriptor).supported) {
+      throw new InstallerError("TARGET_UNSUPPORTED");
+    }
+    return claudeDefinition(descriptor);
+  },
   definitionToSuspendedDescriptor: (serverName, definition) =>
     definitionToSuspendedDescriptor("claude-desktop", serverName, definition),
 });

--- a/packages/installer/src/target-config-evidence.ts
+++ b/packages/installer/src/target-config-evidence.ts
@@ -15,11 +15,16 @@ export interface CreateNodeTargetConfigEvidenceProbesOptions {
   readonly environment: InstallerEnvironment;
   readonly fileSystem: InstallerFileSystem;
   readonly currentUserId?: number;
+  readonly platform?: NodeJS.Platform;
 }
 
 interface ResolvedTargetConfigEvidenceProbeOptions
-  extends Omit<CreateNodeTargetConfigEvidenceProbesOptions, "currentUserId"> {
+  extends Omit<
+    CreateNodeTargetConfigEvidenceProbesOptions,
+    "currentUserId" | "platform"
+  > {
   readonly currentUserId: number | undefined;
+  readonly platform: NodeJS.Platform;
 }
 
 type ConfigEvidenceCode = Extract<
@@ -432,7 +437,26 @@ export function createNodeTargetConfigEvidenceProbes(
     currentUserId:
       options.currentUserId ??
       (typeof process.getuid === "function" ? process.getuid() : undefined),
+    platform: options.platform ?? process.platform,
   };
+  const unsupportedProbe: TargetConfigEvidenceProbe = async () =>
+    blocked("TARGET_UNSUPPORTED");
+  const claudeDesktop =
+    resolvedOptions.platform === "darwin"
+      ? singleConfigProbe(
+          resolvedOptions,
+          "Library/Application Support/Claude/claude_desktop_config.json",
+        )
+      : unsupportedProbe;
+  const vscode =
+    resolvedOptions.platform === "win32"
+      ? unsupportedProbe
+      : singleConfigProbe(
+          resolvedOptions,
+          resolvedOptions.platform === "darwin"
+            ? "Library/Application Support/Code/User/mcp.json"
+            : ".config/Code/User/mcp.json",
+        );
   return Object.freeze({
     antigravity: singleConfigProbe(
       resolvedOptions,
@@ -442,6 +466,7 @@ export function createNodeTargetConfigEvidenceProbes(
       name: "CLAUDE_CONFIG_DIR",
       fileName: ".claude.json",
     }),
+    "claude-desktop": claudeDesktop,
     codex: singleConfigProbe(resolvedOptions, ".codex/config.toml", {
       name: "CODEX_HOME",
       fileName: "config.toml",
@@ -461,5 +486,6 @@ export function createNodeTargetConfigEvidenceProbes(
     }),
     openclaw: openClawProbe(resolvedOptions),
     "opencode-v2": openCodeProbe(resolvedOptions),
+    vscode,
   });
 }

--- a/packages/installer/src/toml-target-adapter.ts
+++ b/packages/installer/src/toml-target-adapter.ts
@@ -43,6 +43,7 @@ interface TomlSyntax {
   readonly serverTable: AST.TOMLTable | undefined;
   readonly dottedInsertion: DottedInsertion | undefined;
   readonly enabledValue: AST.TOMLContentNode | undefined;
+  readonly serverRemovalRange: readonly [number, number] | undefined;
 }
 
 interface TomlAstInspection extends TomlSyntax {
@@ -341,6 +342,7 @@ function inspectTomlAst(
   let serverTable: AST.TOMLTable | undefined;
   let dottedInsertion: DottedInsertion | undefined;
   let enabledValue: AST.TOMLContentNode | undefined;
+  let serverRemovalRange: readonly [number, number] | undefined;
 
   const inspectPair = (
     pair: AST.TOMLKeyValue,
@@ -392,7 +394,7 @@ function inspectTomlAst(
     serverPresent = true;
   };
 
-  for (const item of ast.body[0].body) {
+  for (const [itemIndex, item] of ast.body[0].body.entries()) {
     if (item.type === "TOMLTable") {
       const tablePath = item.resolvedKey.map(String);
       checkedDepth(1 + tablePath.length);
@@ -406,6 +408,11 @@ function inspectTomlAst(
       if (samePath(tablePath, selectedPath)) {
         serverTable = item;
         serverPresent = true;
+        const following = ast.body[0].body[itemIndex + 1];
+        serverRemovalRange = [
+          item.range[0],
+          following?.range[0] ?? Number.POSITIVE_INFINITY,
+        ];
       } else if (startsWithPath(tablePath, selectedPath)) {
         serverPresent = true;
       }
@@ -475,6 +482,7 @@ function inspectTomlAst(
     serverTable,
     dottedInsertion,
     enabledValue,
+    serverRemovalRange,
   };
 }
 
@@ -501,6 +509,7 @@ function parseAndInspect(
         serverTable: undefined,
         dottedInsertion: undefined,
         enabledValue: undefined,
+        serverRemovalRange: undefined,
       } satisfies TomlInspectionState,
       undefined,
       inspectionOwner,
@@ -789,6 +798,13 @@ function constructPatch(
       throw new InstallerError("CONFIG_CONFLICT");
     }
     if (dialect === "grok") validateGrokDefinition(request.definition);
+  } else if (request.action === "remove") {
+    if (
+      request.inspection.currentServer.kind !== "present" ||
+      state.serverRemovalRange === undefined
+    ) {
+      invalid();
+    }
   } else {
     if (request.inspection.currentServer.kind !== "present") invalid();
     const desired = request.action === "enable";
@@ -817,6 +833,13 @@ function constructPatch(
         ),
       );
     }
+  } else if (request.action === "remove") {
+    if (state.serverRemovalRange === undefined) invalid();
+    const [start, rawEnd] = state.serverRemovalRange;
+    const lineStart =
+      state.source.text.lastIndexOf("\n", Math.max(0, start - 1)) + 1;
+    const end = Math.min(rawEnd, state.source.text.length);
+    postText = `${state.source.text.slice(0, lineStart)}${state.source.text.slice(end)}`;
   } else {
     const desired = request.action === "enable";
     if (state.enabledValue !== undefined) {

--- a/packages/installer/src/yaml-target-adapter.ts
+++ b/packages/installer/src/yaml-target-adapter.ts
@@ -5,9 +5,9 @@ import {
   isPair,
   isScalar,
   isSeq,
-  parseDocument,
   type Node,
   type Pair,
+  parseDocument,
   type YAMLMap,
 } from "yaml";
 
@@ -17,25 +17,25 @@ import {
   assertPostImageDefinition,
   assertServerName,
   assertTargetInspectionConsistency,
+  type DecodedTargetSource,
   decodeTargetSource,
   encodeTargetPostImage,
   finalizeInspectedMcpDefinition,
   freezeDefinition,
   frozenTargetInspection,
+  type InspectedJsonValue,
   inspectedJsonArray,
   inspectedJsonRecord,
   inspectedJsonScalar,
   inspectionPass,
   parsePass,
   patchPass,
-  targetInspectionStateFor,
-  type DecodedTargetSource,
   type TargetAdapter,
   type TargetAdapterCounters,
   type TargetConfigInspection,
   type TargetPatch,
   type TargetPatchRequest,
-  type InspectedJsonValue,
+  targetInspectionStateFor,
   unsupportedDefinition,
 } from "./target-adapter.js";
 
@@ -43,7 +43,9 @@ interface YamlInspectionState {
   readonly source: DecodedTargetSource;
   readonly serverName: string;
   readonly root: YAMLMap | undefined;
+  readonly parentPair: Pair | undefined;
   readonly parent: YAMLMap | undefined;
+  readonly serverPair: Pair | undefined;
   readonly server: YAMLMap | undefined;
   readonly enabled: Node | null | undefined;
   readonly members: ReadonlyMap<YAMLMap, ReadonlyMap<string, Pair>>;
@@ -334,7 +336,9 @@ function parseAndInspect(
         source,
         serverName,
         root: undefined,
+        parentPair: undefined,
         parent: undefined,
+        serverPair: undefined,
         server: undefined,
         enabled: undefined,
         members: new Map(),
@@ -380,7 +384,9 @@ function parseAndInspect(
         source,
         serverName,
         root: undefined,
+        parentPair: undefined,
         parent: undefined,
+        serverPair: undefined,
         server: undefined,
         enabled: undefined,
         members: new Map(),
@@ -393,11 +399,18 @@ function parseAndInspect(
   if (!isMap(document.contents)) invalid();
   const astInspection = inspectYamlAst(document.contents, serverName);
   const root = document.contents;
+  const parentPair = astInspection.members.get(root)?.get("mcp_servers");
   const parent = mapValue(astInspection.members, root, "mcp_servers");
-  const server =
+  const serverPair =
     parent === undefined
       ? undefined
-      : mapValue(astInspection.members, parent, serverName);
+      : astInspection.members.get(parent)?.get(serverName);
+  const server =
+    serverPair === undefined
+      ? undefined
+      : isMap(serverPair.value)
+        ? serverPair.value
+        : invalid();
   const inspectedServer =
     server === undefined ? undefined : astInspection.values.get(server);
   if (server !== undefined && inspectedServer?.kind !== "record") invalid();
@@ -431,7 +444,9 @@ function parseAndInspect(
       source,
       serverName,
       root,
+      parentPair,
       parent,
+      serverPair,
       server,
       enabled,
       members: astInspection.members,
@@ -603,6 +618,45 @@ function insertEmptyDocumentBlock(
   return `${prefix}${prefix.length > 0 && !prefix.endsWith("\n") ? source.newline : ""}${block}${suffix.length > 0 || source.trailingNewline ? source.newline : ""}${suffix}`;
 }
 
+function pairRange(pair: Pair): readonly [number, number] {
+  if (!isNode(pair.key) || !isNode(pair.value)) invalid();
+  const keyRange = pair.key.range;
+  const valueRange = pair.value.range;
+  if (
+    keyRange === undefined ||
+    keyRange === null ||
+    valueRange === undefined ||
+    valueRange === null
+  ) {
+    invalid();
+  }
+  return [keyRange[0], valueRange[1]];
+}
+
+function removePair(text: string, parent: YAMLMap, pair: Pair): string {
+  const [start, end] = pairRange(pair);
+  const index = parent.items.indexOf(pair);
+  if (index < 0) invalid();
+  if (!parent.flow) {
+    const lineStart = text.lastIndexOf("\n", Math.max(0, start - 1)) + 1;
+    const followingNewline = text.indexOf("\n", end);
+    const lineEnd = followingNewline < 0 ? text.length : followingNewline + 1;
+    return `${text.slice(0, lineStart)}${text.slice(lineEnd)}`;
+  }
+  if (parent.items.length === 1) {
+    return `${text.slice(0, start)}${text.slice(end)}`;
+  }
+  if (index < parent.items.length - 1) {
+    const [nextStart] = pairRange(parent.items[index + 1] as Pair);
+    return `${text.slice(0, start)}${text.slice(nextStart)}`;
+  }
+  const previous = parent.items[index - 1] as Pair;
+  const [, previousEnd] = pairRange(previous);
+  const comma = text.lastIndexOf(",", start);
+  if (comma < previousEnd) invalid();
+  return `${text.slice(0, comma)}${text.slice(end)}`;
+}
+
 function constructPatch(
   request: TargetPatchRequest,
   inspectionOwner: object,
@@ -615,6 +669,14 @@ function constructPatch(
   if (request.action === "install") {
     if (request.inspection.currentServer.kind === "present") {
       throw new InstallerError("CONFIG_CONFLICT");
+    }
+  } else if (request.action === "remove") {
+    if (
+      request.inspection.currentServer.kind !== "present" ||
+      state.parent === undefined ||
+      state.serverPair === undefined
+    ) {
+      invalid();
     }
   } else {
     if (
@@ -687,6 +749,19 @@ function constructPatch(
         ),
       );
     }
+  } else if (request.action === "remove") {
+    if (
+      state.root === undefined ||
+      state.parentPair === undefined ||
+      state.parent === undefined ||
+      state.serverPair === undefined
+    ) {
+      invalid();
+    }
+    postText =
+      state.parent.items.length === 1
+        ? removePair(state.source.text, state.root, state.parentPair)
+        : removePair(state.source.text, state.parent, state.serverPair);
   } else {
     const desired = request.action === "enable";
     if (state.enabled !== undefined && state.enabled !== null) {

--- a/packages/installer/test/cli-child-process.test.ts
+++ b/packages/installer/test/cli-child-process.test.ts
@@ -71,6 +71,7 @@ describe("invokta-installer executable", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe(`Usage:
   invokta-installer
+  invokta-installer install --engine <project-directory>
   invokta-installer --help
   invokta-installer --version
 `);

--- a/packages/installer/test/cli-child-process.test.ts
+++ b/packages/installer/test/cli-child-process.test.ts
@@ -72,6 +72,7 @@ describe("invokta-installer executable", () => {
     expect(result.stdout).toBe(`Usage:
   invokta-installer
   invokta-installer install --engine <project-directory>
+  invokta-installer install --http <server-name> <url> [--bearer-token-env <NAME>] [--header-env <HEADER=NAME>]...
   invokta-installer status
   invokta-installer enable
   invokta-installer disable

--- a/packages/installer/test/cli-child-process.test.ts
+++ b/packages/installer/test/cli-child-process.test.ts
@@ -72,6 +72,10 @@ describe("invokta-installer executable", () => {
     expect(result.stdout).toBe(`Usage:
   invokta-installer
   invokta-installer install --engine <project-directory>
+  invokta-installer status
+  invokta-installer enable
+  invokta-installer disable
+  invokta-installer remove
   invokta-installer --help
   invokta-installer --version
 `);

--- a/packages/installer/test/cli-usage.test.ts
+++ b/packages/installer/test/cli-usage.test.ts
@@ -235,6 +235,32 @@ describe("runInstallerCli", () => {
     });
   });
 
+  it("rejects remote installation options outside the documented order", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runInstallerCli({
+      argv: [
+        "install",
+        "--http",
+        "support-api",
+        "https://support.example.com/mcp",
+        "--header-env",
+        "X-Tenant=SUPPORT_TENANT",
+        "--bearer-token-env",
+        "SUPPORT_TOKEN",
+      ],
+      io: output.io,
+      loadInteractiveSession,
+    });
+
+    expect(result).toBe(2);
+    expect(loadInteractiveSession).not.toHaveBeenCalled();
+    expect(output.stderr).toEqual([
+      'Invalid arguments. Run "invokta-installer --help".\n',
+    ]);
+  });
+
   it.each(["status", "enable", "disable", "remove"] as const)(
     "parses the %s lifecycle command",
     async (kind) => {

--- a/packages/installer/test/cli-usage.test.ts
+++ b/packages/installer/test/cli-usage.test.ts
@@ -2,10 +2,12 @@ import { readFileSync } from "node:fs";
 
 import { describe, expect, it, vi } from "vitest";
 
+import { InstallerError } from "../src/installer-error.js";
 import { runInstallerCli } from "../src/run-installer-cli.js";
 
 const helpText = `Usage:
   invokta-installer
+  invokta-installer install --engine <project-directory>
   invokta-installer --help
   invokta-installer --version
 `;
@@ -177,6 +179,42 @@ describe("runInstallerCli", () => {
       expect(output.stderr).toEqual([]);
     },
   );
+
+  it("parses a project-local engine installation before lazy interactive loading", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runInstallerCli({
+      argv: ["install", "--engine", "projects/support-engine"],
+      io: output.io,
+      loadInteractiveSession,
+    });
+
+    expect(result).toBe(0);
+    expect(loadInteractiveSession).toHaveBeenCalledWith({
+      kind: "install-engine",
+      projectDirectory: "projects/support-engine",
+    });
+    expect(output.stdout).toEqual([]);
+    expect(output.stderr).toEqual([]);
+  });
+
+  it("maps a stable operational failure to exit code 1", async () => {
+    const output = createIo();
+
+    const result = await runInstallerCli({
+      argv: ["install", "--engine", "."],
+      io: output.io,
+      loadInteractiveSession: async () => {
+        throw new InstallerError("ENGINE_ENTRYPOINT_MISSING");
+      },
+    });
+
+    expect(result).toBe(1);
+    expect(output.stderr).toEqual([
+      "ENGINE_ENTRYPOINT_MISSING: The Action Engine entry point was not found.\n",
+    ]);
+  });
 
   it("sanitizes an unexpected interactive initialization failure", async () => {
     const output = createIo();

--- a/packages/installer/test/cli-usage.test.ts
+++ b/packages/installer/test/cli-usage.test.ts
@@ -8,6 +8,10 @@ import { runInstallerCli } from "../src/run-installer-cli.js";
 const helpText = `Usage:
   invokta-installer
   invokta-installer install --engine <project-directory>
+  invokta-installer status
+  invokta-installer enable
+  invokta-installer disable
+  invokta-installer remove
   invokta-installer --help
   invokta-installer --version
 `;
@@ -198,6 +202,23 @@ describe("runInstallerCli", () => {
     expect(output.stdout).toEqual([]);
     expect(output.stderr).toEqual([]);
   });
+
+  it.each(["status", "enable", "disable", "remove"] as const)(
+    "parses the %s lifecycle command",
+    async (kind) => {
+      const output = createIo();
+      const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+      const result = await runInstallerCli({
+        argv: [kind],
+        io: output.io,
+        loadInteractiveSession,
+      });
+
+      expect(result).toBe(0);
+      expect(loadInteractiveSession).toHaveBeenCalledWith({ kind });
+    },
+  );
 
   it("maps a stable operational failure to exit code 1", async () => {
     const output = createIo();

--- a/packages/installer/test/cli-usage.test.ts
+++ b/packages/installer/test/cli-usage.test.ts
@@ -8,6 +8,7 @@ import { runInstallerCli } from "../src/run-installer-cli.js";
 const helpText = `Usage:
   invokta-installer
   invokta-installer install --engine <project-directory>
+  invokta-installer install --http <server-name> <url> [--bearer-token-env <NAME>] [--header-env <HEADER=NAME>]...
   invokta-installer status
   invokta-installer enable
   invokta-installer disable
@@ -201,6 +202,37 @@ describe("runInstallerCli", () => {
     });
     expect(output.stdout).toEqual([]);
     expect(output.stderr).toEqual([]);
+  });
+
+  it("parses a remote HTTP installation with environment-only credentials", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runInstallerCli({
+      argv: [
+        "install",
+        "--http",
+        "support-api",
+        "https://support.example.com/mcp",
+        "--bearer-token-env",
+        "SUPPORT_TOKEN",
+        "--header-env",
+        "X-Tenant=SUPPORT_TENANT",
+        "--header-env",
+        "X-Key=SUPPORT_KEY",
+      ],
+      io: output.io,
+      loadInteractiveSession,
+    });
+
+    expect(result).toBe(0);
+    expect(loadInteractiveSession).toHaveBeenCalledWith({
+      kind: "install-http",
+      serverName: "support-api",
+      url: "https://support.example.com/mcp",
+      bearerTokenEnvironment: "SUPPORT_TOKEN",
+      headerEnvironment: ["X-Tenant=SUPPORT_TENANT", "X-Key=SUPPORT_KEY"],
+    });
   });
 
   it.each(["status", "enable", "disable", "remove"] as const)(

--- a/packages/installer/test/engine-manifest.test.ts
+++ b/packages/installer/test/engine-manifest.test.ts
@@ -1,0 +1,154 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  loadEngineInstallManifest,
+  validateEngineInstallManifestBytes,
+} from "../src/engine-manifest.js";
+import { createNodeFileSystem } from "../src/node-file-system.js";
+
+const temporaryDirectories: string[] = [];
+
+function createProject(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-engine-manifest-"));
+  temporaryDirectories.push(directory);
+  mkdirSync(join(directory, "dist"));
+  writeFileSync(join(directory, "dist/mcp-stdio.js"), "export {};\n");
+  writeFileSync(
+    join(directory, "invokta.mcp.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      id: "support-engine",
+      version: "1.2.3",
+      title: "Support Engine",
+      description: "Customer support actions.",
+      capabilityIds: ["tickets.summarize"],
+      server: {
+        name: "support-engine",
+        entrypoint: "dist/mcp-stdio.js",
+        forwardEnv: ["SUPPORT_TOKEN"],
+      },
+    }),
+  );
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("loadEngineInstallManifest", () => {
+  function expectInvalidManifest(operation: () => unknown): void {
+    let error: unknown;
+    try {
+      operation();
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toMatchObject({ code: "ENGINE_MANIFEST_INVALID" });
+  }
+
+  it("resolves an immutable stdio descriptor without executing the engine", async () => {
+    const projectDirectory = createProject();
+    const nodeExecutable = process.execPath;
+
+    const source = await loadEngineInstallManifest({
+      currentUserId: process.getuid?.() ?? 0,
+      fileSystem: createNodeFileSystem(),
+      nodeExecutable,
+      projectDirectory,
+    });
+
+    expect(source).toEqual({
+      manifestPath: join(projectDirectory, "invokta.mcp.json"),
+      entrypointPath: join(projectDirectory, "dist/mcp-stdio.js"),
+      descriptor: {
+        id: "support-engine",
+        version: "1.2.3",
+        title: "Support Engine",
+        description: "Customer support actions.",
+        capabilityIds: ["tickets.summarize"],
+        server: {
+          name: "support-engine",
+          transport: {
+            type: "stdio",
+            command: nodeExecutable,
+            args: [join(projectDirectory, "dist/mcp-stdio.js")],
+            forwardEnv: ["SUPPORT_TOKEN"],
+          },
+        },
+      },
+    });
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(Object.isFrozen(source.descriptor.server.transport)).toBe(true);
+  });
+
+  it.each([
+    ["a UTF-8 BOM", '\uFEFF{"schemaVersion":1}'],
+    ["a duplicate property", '{"schemaVersion":1,"id":"first","id":"second"}'],
+    ["an unknown property", '{"schemaVersion":1,"id":"x","unexpected":true}'],
+    [
+      "a parent entrypoint segment",
+      '{"schemaVersion":1,"id":"x","version":"1","title":"X","description":"X","capabilityIds":["x"],"server":{"name":"x","entrypoint":"../server.js","forwardEnv":[]}}',
+    ],
+    [
+      "a backslash entrypoint",
+      '{"schemaVersion":1,"id":"x","version":"1","title":"X","description":"X","capabilityIds":["x"],"server":{"name":"x","entrypoint":"dist\\\\server.js","forwardEnv":[]}}',
+    ],
+    [
+      "duplicate forwarded environment names",
+      '{"schemaVersion":1,"id":"x","version":"1","title":"X","description":"X","capabilityIds":["x"],"server":{"name":"x","entrypoint":"server.js","forwardEnv":["TOKEN","TOKEN"]}}',
+    ],
+  ])("rejects %s", (_label, contents) => {
+    expectInvalidManifest(() =>
+      validateEngineInstallManifestBytes(new TextEncoder().encode(contents)),
+    );
+  });
+
+  it("rejects a manifest above the one MiB byte limit", () => {
+    expectInvalidManifest(() =>
+      validateEngineInstallManifestBytes(new Uint8Array(1_048_577)),
+    );
+  });
+
+  it("distinguishes an absent entry point", async () => {
+    const projectDirectory = createProject();
+    rmSync(join(projectDirectory, "dist/mcp-stdio.js"));
+
+    await expect(
+      loadEngineInstallManifest({
+        currentUserId: process.getuid?.() ?? 0,
+        fileSystem: createNodeFileSystem(),
+        nodeExecutable: process.execPath,
+        projectDirectory,
+      }),
+    ).rejects.toMatchObject({ code: "ENGINE_ENTRYPOINT_MISSING" });
+  });
+
+  it("rejects a symbolic-link entry point", async () => {
+    const projectDirectory = createProject();
+    const entrypoint = join(projectDirectory, "dist/mcp-stdio.js");
+    rmSync(entrypoint);
+    symlinkSync(join(projectDirectory, "invokta.mcp.json"), entrypoint);
+
+    await expect(
+      loadEngineInstallManifest({
+        currentUserId: process.getuid?.() ?? 0,
+        fileSystem: createNodeFileSystem(),
+        nodeExecutable: process.execPath,
+        projectDirectory,
+      }),
+    ).rejects.toMatchObject({ code: "ENGINE_PATH_UNSAFE" });
+  });
+});

--- a/packages/installer/test/harness-detection-sentinels.test.ts
+++ b/packages/installer/test/harness-detection-sentinels.test.ts
@@ -32,6 +32,7 @@ const defaultConfigPaths = [
   ".kimi-code/mcp.json",
   ".openclaw/openclaw.json",
   ".config/opencode/opencode.json",
+  ".config/Code/User/mcp.json",
 ] as const;
 
 beforeAll(() => {
@@ -58,7 +59,9 @@ beforeAll(() => {
   for (const candidate of [
     "agy",
     "antigravity",
+    "Claude",
     "claude",
+    "code",
     "codex",
     "cursor",
     "grok",
@@ -121,7 +124,7 @@ describe("harness detection safety sentinels", () => {
     );
   }
 
-  it("detects all ten surfaces while process, network, and filesystem writes are forbidden", () => {
+  it("detects all twelve surfaces while process, network, and filesystem writes are forbidden", () => {
     const result = runScenario(executableDirectory, homeWithoutConfigs);
 
     expect(result.status, result.stderr).toBe(0);
@@ -130,6 +133,7 @@ describe("harness detection safety sentinels", () => {
         "antigravity-cli",
         "antigravity-ide",
         "claude-code",
+        "claude-desktop",
         "codex",
         "cursor",
         "grok-build",
@@ -137,6 +141,7 @@ describe("harness detection safety sentinels", () => {
         "kimi-code",
         "openclaw",
         "opencode-v2",
+        "vscode",
       ],
       eligibleTargets: [
         "antigravity",
@@ -148,6 +153,7 @@ describe("harness detection safety sentinels", () => {
         "kimi-code",
         "openclaw",
         "opencode-v2",
+        "vscode",
       ],
       configurationOnlyTargets: [],
       creationTargets: [
@@ -160,6 +166,7 @@ describe("harness detection safety sentinels", () => {
         "kimi-code",
         "openclaw",
         "opencode-v2",
+        "vscode",
       ],
     });
     expect(existsSync(marker)).toBe(false);
@@ -182,6 +189,7 @@ describe("harness detection safety sentinels", () => {
         "kimi-code",
         "openclaw",
         "opencode-v2",
+        "vscode",
       ],
       configurationOnlyTargets: [
         "antigravity",
@@ -193,6 +201,7 @@ describe("harness detection safety sentinels", () => {
         "kimi-code",
         "openclaw",
         "opencode-v2",
+        "vscode",
       ],
       creationTargets: [],
     });

--- a/packages/installer/test/harness-detection.test.ts
+++ b/packages/installer/test/harness-detection.test.ts
@@ -31,6 +31,12 @@ const expectedSurfaces = [
     targetId: "claude-code",
   },
   {
+    id: "claude-desktop",
+    displayName: "Claude Desktop",
+    executableCandidates: ["Claude"],
+    targetId: "claude-desktop",
+  },
+  {
     id: "codex",
     displayName: "Codex",
     executableCandidates: ["codex"],
@@ -72,6 +78,12 @@ const expectedSurfaces = [
     executableCandidates: ["opencode2"],
     targetId: "opencode-v2",
   },
+  {
+    id: "vscode",
+    displayName: "Visual Studio Code",
+    executableCandidates: ["code"],
+    targetId: "vscode",
+  },
 ] as const;
 
 function absentConfigProbes(
@@ -108,19 +120,19 @@ function executable(
 }
 
 describe("first-release harness catalog", () => {
-  it("defines the exact ten surfaces in deterministic surface-ID order", () => {
+  it("defines the exact twelve surfaces in deterministic surface-ID order", () => {
     expect(harnessSurfaceCatalog).toEqual(expectedSurfaces);
-    expect(harnessSurfaceCatalog).toHaveLength(10);
+    expect(harnessSurfaceCatalog).toHaveLength(12);
     expect(harnessSurfaceCatalog.map(({ id }) => id)).toEqual(
       [...harnessSurfaceCatalog.map(({ id }) => id)].sort(),
     );
   });
 
-  it("defines exactly one catalog record and reload hint for all nine targets", () => {
+  it("defines exactly one catalog record and reload hint for all eleven targets", () => {
     expect(configurationTargetCatalog.map(({ id }) => id)).toEqual(
       configurationTargetIds,
     );
-    expect(configurationTargetCatalog).toHaveLength(9);
+    expect(configurationTargetCatalog).toHaveLength(11);
     expect(
       configurationTargetCatalog.every(
         ({ displayName, reloadHint }) =>
@@ -131,7 +143,7 @@ describe("first-release harness catalog", () => {
 });
 
 describe("harness detection snapshot", () => {
-  it("reports all ten executable surfaces without executing them and coalesces them into nine targets", async () => {
+  it("reports all twelve executable surfaces without executing them and coalesces them into eleven targets", async () => {
     const candidateCalls: string[] = [];
     const probeCalls: Array<{ targetId: string; homeDirectory: string }> = [];
 
@@ -146,7 +158,7 @@ describe("harness detection snapshot", () => {
       ),
     });
 
-    expect(snapshot.surfaces).toHaveLength(10);
+    expect(snapshot.surfaces).toHaveLength(12);
     expect(snapshot.surfaces.map(({ id, evidence }) => [id, evidence])).toEqual(
       expectedSurfaces.map(({ id }) => [id, "installed"]),
     );
@@ -161,7 +173,7 @@ describe("harness detection snapshot", () => {
         homeDirectory: "/users/tester",
       })),
     );
-    expect(snapshot.targets).toHaveLength(9);
+    expect(snapshot.targets).toHaveLength(11);
     expect(snapshot.targets.map(({ id }) => id)).toEqual(
       configurationTargetIds,
     );

--- a/packages/installer/test/install-session.test.ts
+++ b/packages/installer/test/install-session.test.ts
@@ -123,4 +123,75 @@ describe("interactive install session", () => {
     expect(confirm).toHaveBeenCalledTimes(1);
     expect(prompter.outro).toHaveBeenCalledWith("No changes were made.");
   });
+
+  it("exits without confirmation or mutation when no target is selected", async () => {
+    const confirm = vi.fn(async () => ({
+      kind: "submitted" as const,
+      value: true,
+    }));
+    const prompter: InteractivePrompter = {
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      autocomplete: vi.fn(),
+      select: vi.fn(),
+      multiselect: vi.fn(async () => ({
+        kind: "submitted" as const,
+        value: [],
+      })) as InteractivePrompter["multiselect"],
+      note: vi.fn(),
+      confirm,
+      spinner: vi.fn(),
+      log: vi.fn(),
+    };
+    const target = {
+      id: "codex",
+      displayName: "Codex",
+      surfaceIds: [],
+      evidence: "installed",
+      executables: [],
+      configuration: {
+        kind: "absent",
+        path: "/users/tester/.codex/config.toml",
+      },
+      eligible: true,
+      mayCreateConfiguration: true,
+      reloadHint: "Reload Codex.",
+    } as const;
+
+    const result = await runInstallSession({
+      dependencies: {
+        adapters: configurationTargetAdapters,
+        currentUserId: 1,
+        environment: { get: () => undefined },
+        fileSystem: createNodeFileSystem(),
+        lock: {
+          clock: {
+            monotonicNow: () => 0,
+            now: () => 0,
+            wait: async () => undefined,
+          },
+          processId: 1,
+          randomBytes: (length) => new Uint8Array(length),
+        },
+        now: () => "2026-07-29T12:00:00.000Z",
+      },
+      descriptor: descriptor(),
+      prompter,
+      resolveExecutable: async (candidate) => ({
+        path: candidate,
+        identity: { device: 1, inode: 2, realPath: candidate },
+      }),
+      snapshot: {
+        homeDirectory: "/users/tester",
+        surfaces: [],
+        targets: [target],
+      },
+    });
+
+    expect(result).toBe(0);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(prompter.log).not.toHaveBeenCalled();
+    expect(prompter.outro).toHaveBeenCalledWith("No changes were made.");
+  });
 });

--- a/packages/installer/test/install-session.test.ts
+++ b/packages/installer/test/install-session.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HarnessDetectionSnapshot } from "../src/harness-detection.js";
+import { runInstallSession } from "../src/install-session.js";
+import type { InteractivePrompter } from "../src/interactive-prompter.js";
+import { createNodeFileSystem } from "../src/node-file-system.js";
+import type { CapabilityInstallDescriptor } from "../src/registry.js";
+import { configurationTargetAdapters } from "../src/target-adapters.js";
+
+function descriptor(): CapabilityInstallDescriptor {
+  return {
+    id: "support-engine",
+    version: "1.0.0",
+    title: "Support Engine",
+    description: "Support actions.",
+    capabilityIds: ["tickets.summarize"],
+    server: {
+      name: "support-engine",
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: ["/workspace/support/dist/mcp-stdio.js"],
+        forwardEnv: [],
+      },
+    },
+  };
+}
+
+describe("interactive install session", () => {
+  it("preselects every compatible eligible target and uses one confirmation", async () => {
+    let multiselectPrompt: unknown;
+    const confirm = vi.fn(async () => ({
+      kind: "submitted" as const,
+      value: false,
+    }));
+    const prompter: InteractivePrompter = {
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      autocomplete: vi.fn(),
+      select: vi.fn(),
+      multiselect: vi.fn(async (prompt) => {
+        multiselectPrompt = prompt;
+        return {
+          kind: "submitted" as const,
+          value: ["codex", "cursor"] as const,
+        };
+      }) as InteractivePrompter["multiselect"],
+      note: vi.fn(),
+      confirm,
+      spinner: vi.fn(),
+      log: vi.fn(),
+    };
+    const snapshot: HarnessDetectionSnapshot = {
+      homeDirectory: "/users/tester",
+      surfaces: [],
+      targets: [
+        {
+          id: "codex",
+          displayName: "Codex",
+          surfaceIds: [],
+          evidence: "installed",
+          executables: [],
+          configuration: {
+            kind: "absent",
+            path: "/users/tester/.codex/config.toml",
+          },
+          eligible: true,
+          mayCreateConfiguration: true,
+          reloadHint: "Reload Codex.",
+        },
+        {
+          id: "cursor",
+          displayName: "Cursor",
+          surfaceIds: [],
+          evidence: "configuration-only",
+          executables: [],
+          configuration: {
+            kind: "present",
+            path: "/users/tester/.cursor/mcp.json",
+          },
+          eligible: true,
+          mayCreateConfiguration: false,
+          reloadHint: "Reload Cursor.",
+        },
+      ],
+    };
+
+    const result = await runInstallSession({
+      dependencies: {
+        adapters: configurationTargetAdapters,
+        currentUserId: 1,
+        environment: { get: () => undefined },
+        fileSystem: createNodeFileSystem(),
+        lock: {
+          clock: {
+            monotonicNow: () => 0,
+            now: () => 0,
+            wait: async () => undefined,
+          },
+          processId: 1,
+          randomBytes: (length) => new Uint8Array(length),
+        },
+        now: () => "2026-07-29T12:00:00.000Z",
+      },
+      descriptor: descriptor(),
+      prompter,
+      resolveExecutable: async (candidate) => ({
+        path: candidate,
+        identity: { device: 1, inode: 2, realPath: candidate },
+      }),
+      snapshot,
+    });
+
+    expect(result).toBe(0);
+    expect(multiselectPrompt).toMatchObject({
+      initialValues: ["codex", "cursor"],
+      options: [
+        { value: "codex", label: "Codex" },
+        { value: "cursor", label: "Cursor" },
+      ],
+    });
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(prompter.outro).toHaveBeenCalledWith("No changes were made.");
+  });
+});

--- a/packages/installer/test/installer-error.test.ts
+++ b/packages/installer/test/installer-error.test.ts
@@ -8,6 +8,11 @@ import {
 
 const expectedErrors = {
   REGISTRY_INVALID: "The local capability registry is invalid.",
+  ENGINE_MANIFEST_INVALID: "The Action Engine manifest is invalid.",
+  ENGINE_PATH_UNSAFE: "The Action Engine path is unsafe.",
+  ENGINE_ENTRYPOINT_MISSING: "The Action Engine entry point was not found.",
+  REMOTE_INVALID: "The remote MCP server definition is invalid.",
+  INSTALLATION_UNAVAILABLE: "The managed installation is unavailable.",
   INSTALLER_INITIALIZATION_FAILED: "The installer could not be initialized.",
   NO_TTY: "The installer requires an interactive terminal.",
   NO_SUPPORTED_HARNESS: "No supported AI harness was detected.",
@@ -35,9 +40,9 @@ const expectedErrors = {
 } as const;
 
 describe("InstallerError", () => {
-  it("defines exactly the 23 stable installer codes and messages", () => {
+  it("defines exactly the 28 stable installer codes and messages", () => {
     expect(installerErrorMessages).toEqual(expectedErrors);
-    expect(Object.keys(installerErrorMessages)).toHaveLength(23);
+    expect(Object.keys(installerErrorMessages)).toHaveLength(28);
 
     for (const [code, message] of Object.entries(expectedErrors)) {
       const error = new InstallerError(

--- a/packages/installer/test/installer-state-transition.test.ts
+++ b/packages/installer/test/installer-state-transition.test.ts
@@ -261,6 +261,43 @@ describe("immutable installer state transitions", () => {
     });
   });
 
+  it.each(configurationTargetIds)(
+    "updates an outdated %s installation to the selected registry descriptor",
+    (targetId) => {
+      const oldDescriptor = descriptor("1.0.0", "support-engine-mcp-v1");
+      const currentDescriptor = descriptor("2.0.0", "support-engine-mcp-v2");
+      const adapter = configurationTargetAdapters[targetId];
+      if (!adapter.compatibility(currentDescriptor).supported) return;
+      const oldDefinition = adapter.descriptorToDefinition(oldDescriptor);
+      const currentDefinition =
+        adapter.descriptorToDefinition(currentDescriptor);
+      const initial = managedState(targetId, currentDescriptor, oldDefinition, {
+        adopted: true,
+        launchDescriptor: oldDescriptor.server,
+      });
+      const planning = planningInput(targetId, currentDescriptor, initial, {
+        kind: "present",
+        definition: oldDefinition,
+      });
+
+      const updated = transition(planning, "install");
+
+      expect(updated).toBeDefined();
+      if (updated === undefined) throw new Error("Expected update transition.");
+      expect(updated.installation).toEqual({
+        ...firstInstallation(initial),
+        registryVersion: currentDescriptor.version,
+        definitionSha256: fingerprintNormalizedDefinition(
+          currentDefinition,
+          adapter.metadata.toggleStrategy,
+        ),
+        launchDescriptor: currentDescriptor.server,
+        adopted: false,
+        updatedAt: occurredAt,
+      });
+    },
+  );
+
   it("snapshots and restores the historical detached descriptor", () => {
     const targetId = "cursor";
     const oldDescriptor = descriptor("1.0.0", "support-engine-mcp-v1");

--- a/packages/installer/test/installer-state-transition.test.ts
+++ b/packages/installer/test/installer-state-transition.test.ts
@@ -482,8 +482,8 @@ describe("deterministic installer state serialization", () => {
     expect(Object.isFrozen(reverse.installations)).toBe(false);
   });
 
-  it("accepts exactly 9,000 records and 16,777,216 bytes, then rejects either successor", () => {
-    const base = boundaryState(9_000);
+  it("accepts exactly 11,000 records and 16,777,216 bytes, then rejects either successor", () => {
+    const base = boundaryState(11_000);
     const baseBytes = serializeInstallerState(base, targetContracts);
     const exact = withVersionPadding(
       base,
@@ -491,7 +491,7 @@ describe("deterministic installer state serialization", () => {
     );
     const exactBytes = serializeInstallerState(exact, targetContracts);
 
-    expect(Object.keys(exact.installations)).toHaveLength(9_000);
+    expect(Object.keys(exact.installations)).toHaveLength(11_000);
     expect(exactBytes.byteLength).toBe(stateByteLimit);
 
     const firstEntry = Object.entries(exact.installations)[0];
@@ -513,7 +513,7 @@ describe("deterministic installer state serialization", () => {
       ),
     );
     expectStateInvalid(() =>
-      serializeInstallerState(boundaryState(9_001), targetContracts),
+      serializeInstallerState(boundaryState(11_001), targetContracts),
     );
   }, 60_000);
 });

--- a/packages/installer/test/installer-state-transition.test.ts
+++ b/packages/installer/test/installer-state-transition.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import { InstallerError } from "../src/installer-error.js";
 import {
   createEmptyInstallerState,
-  installationKey,
   type InstallerState,
+  installationKey,
   type ManagedInstallation,
   type StateTargetContracts,
 } from "../src/installer-state.js";
@@ -19,8 +19,8 @@ import {
 } from "../src/ownership-planner.js";
 import {
   type CapabilityInstallDescriptor,
-  configurationTargetIds,
   type ConfigurationTargetId,
+  configurationTargetIds,
 } from "../src/registry.js";
 import { configurationTargetAdapters } from "../src/target-adapters.js";
 
@@ -199,6 +199,7 @@ describe("immutable installer state transitions", () => {
           definition,
           "native-enabled",
         ),
+        launchDescriptor: selected.server,
       });
       expect(Object.isFrozen(result)).toBe(true);
       expect(Object.isFrozen(result.state)).toBe(true);

--- a/packages/installer/test/installer-state.test.ts
+++ b/packages/installer/test/installer-state.test.ts
@@ -35,6 +35,7 @@ const supportedAdapters = Object.freeze(
 const toggleStrategies = {
   antigravity: "native-disabled",
   "claude-code": "detached",
+  "claude-desktop": "detached",
   codex: "native-enabled",
   cursor: "detached",
   "grok-build": "native-enabled",
@@ -42,6 +43,7 @@ const toggleStrategies = {
   "kimi-code": "native-enabled",
   openclaw: "native-enabled",
   "opencode-v2": "native-disabled",
+  vscode: "detached",
 } as const;
 
 const targetContracts = Object.freeze(

--- a/packages/installer/test/installer-state.test.ts
+++ b/packages/installer/test/installer-state.test.ts
@@ -566,14 +566,14 @@ describe("installer state validation", () => {
     },
   );
 
-  it("accepts exactly 9,000 records and rejects record 9,001", () => {
-    const records = Array.from({ length: 9_001 }, (_, index) =>
+  it("accepts exactly 11,000 records and rejects record 11,001", () => {
+    const records = Array.from({ length: 11_001 }, (_, index) =>
       record({ entryId: `historical-${index}` }),
     );
 
     expect(
       validateInstallerStateBytes(
-        stateBytes(records.slice(0, 9_000)),
+        stateBytes(records.slice(0, 11_000)),
         targetContracts,
       ).ok,
     ).toBe(true);

--- a/packages/installer/test/interactive-session.test.ts
+++ b/packages/installer/test/interactive-session.test.ts
@@ -127,7 +127,7 @@ describe("interactive detection session", () => {
     expect(spinner.error).not.toHaveBeenCalled();
   });
 
-  it("uses the production config probes to inventory all nine config-only targets", async () => {
+  it("uses the production config probes to inventory all eleven config-only targets", async () => {
     const homeDirectory = mkdtempSync(
       join(tmpdir(), "invokta-interactive-configs-"),
     );
@@ -135,6 +135,7 @@ describe("interactive detection session", () => {
     for (const relativePath of [
       ".gemini/config/mcp_config.json",
       ".claude.json",
+      "Library/Application Support/Claude/claude_desktop_config.json",
       ".codex/config.toml",
       ".cursor/mcp.json",
       ".grok/config.toml",
@@ -142,6 +143,7 @@ describe("interactive detection session", () => {
       ".kimi-code/mcp.json",
       ".openclaw/openclaw.json",
       ".config/opencode/opencode.json",
+      "Library/Application Support/Code/User/mcp.json",
     ]) {
       const path = join(homeDirectory, relativePath);
       mkdirSync(dirname(path), { recursive: true });
@@ -175,6 +177,7 @@ describe("interactive detection session", () => {
     const exitCode = await runInteractiveSession({
       prompter,
       environment: { get: () => undefined },
+      platform: "darwin",
       resolveHomeDirectory: () => homeDirectory,
       resolveExecutable: async () => undefined,
     });

--- a/packages/installer/test/json-target-adapters.test.ts
+++ b/packages/installer/test/json-target-adapters.test.ts
@@ -167,7 +167,7 @@ describe("strict JSON target adapters", () => {
     const claudeDesktop = configurationTargetAdapters["claude-desktop"];
     const claudePatch = claudeDesktop.constructPatch({
       action: "install",
-      definition: claudeDesktop.descriptorToDefinition(stdioDescriptor()),
+      definition: claudeDesktop.descriptorToDefinition(stdioDescriptor([])),
       inspection: claudeDesktop.inspect({
         source: undefined,
         serverName: "invokta-support",
@@ -181,7 +181,6 @@ describe("strict JSON target adapters", () => {
           type: "stdio",
           command: "support-engine-mcp",
           args: ["serve", "--stdio"],
-          env: { SUPPORT_API_TOKEN: `\${SUPPORT_API_TOKEN}` },
         },
       },
     });
@@ -223,6 +222,22 @@ describe("strict JSON target adapters", () => {
     expect(vscodeText).toContain(
       `"SUPPORT_API_TOKEN":"\${env:SUPPORT_API_TOKEN}"`,
     );
+  });
+
+  it("limits Claude Desktop file installation to credential-free stdio servers", () => {
+    const adapter = configurationTargetAdapters["claude-desktop"];
+
+    expect(adapter.compatibility(stdioDescriptor([]))).toEqual({
+      supported: true,
+    });
+    expect(adapter.compatibility(stdioDescriptor(["TOKEN"]))).toEqual({
+      supported: false,
+      reason: "claude-desktop-forward-env-unsupported",
+    });
+    expect(adapter.compatibility(credentialFreeHttpDescriptor())).toEqual({
+      supported: false,
+      reason: "claude-desktop-http-config-unsupported",
+    });
   });
 
   it.each(["claude-code", "cursor"] as const)(

--- a/packages/installer/test/json-target-adapters.test.ts
+++ b/packages/installer/test/json-target-adapters.test.ts
@@ -163,6 +163,68 @@ describe("strict JSON target adapters", () => {
     ).toEqual([]);
   });
 
+  it("writes Claude Desktop and VS Code user-config shapes with native environment placeholders", () => {
+    const claudeDesktop = configurationTargetAdapters["claude-desktop"];
+    const claudePatch = claudeDesktop.constructPatch({
+      action: "install",
+      definition: claudeDesktop.descriptorToDefinition(stdioDescriptor()),
+      inspection: claudeDesktop.inspect({
+        source: undefined,
+        serverName: "invokta-support",
+      }),
+    });
+    expect(claudePatch.kind).toBe("changed");
+    if (claudePatch.kind !== "changed") return;
+    expect(JSON.parse(decoder.decode(claudePatch.postImage))).toEqual({
+      mcpServers: {
+        "invokta-support": {
+          type: "stdio",
+          command: "support-engine-mcp",
+          args: ["serve", "--stdio"],
+          env: { SUPPORT_API_TOKEN: `\${SUPPORT_API_TOKEN}` },
+        },
+      },
+    });
+
+    const vscode = configurationTargetAdapters.vscode;
+    expect(vscode.descriptorToDefinition(stdioDescriptor())).toEqual({
+      transport: "stdio",
+      type: "stdio",
+      command: "support-engine-mcp",
+      args: ["serve", "--stdio"],
+      env: { SUPPORT_API_TOKEN: `\${env:SUPPORT_API_TOKEN}` },
+    });
+    expect(vscode.descriptorToDefinition(httpDescriptor())).toEqual({
+      transport: "streamable-http",
+      type: "http",
+      url: "https://support.example.com/mcp",
+      headers: {
+        authorization: `Bearer \${env:SUPPORT_API_TOKEN}`,
+        "x-support-tenant": `\${env:SUPPORT_TENANT}`,
+      },
+    });
+
+    const vscodePatch = vscode.constructPatch({
+      action: "install",
+      definition: vscode.descriptorToDefinition(stdioDescriptor()),
+      inspection: vscode.inspect({
+        source: encoder.encode(
+          '{\n  // keep profile settings\n  "inputs": [],\n  "servers": {\n    "other": { "type": "stdio", "command": "other", },\n  },\n}\n',
+        ),
+        serverName: "invokta-support",
+      }),
+    });
+    expect(vscodePatch.kind).toBe("changed");
+    if (vscodePatch.kind !== "changed") return;
+    const vscodeText = decoder.decode(vscodePatch.postImage);
+    expect(vscodeText).toContain("// keep profile settings");
+    expect(vscodeText).toContain('"other": { "type": "stdio"');
+    expect(vscodeText).toContain('"invokta-support":');
+    expect(vscodeText).toContain(
+      `"SUPPORT_API_TOKEN":"\${env:SUPPORT_API_TOKEN}"`,
+    );
+  });
+
   it.each(["claude-code", "cursor"] as const)(
     "installs, detaches, and exactly restores %s",
     (targetId) => {

--- a/packages/installer/test/mutation-coordinator.test.ts
+++ b/packages/installer/test/mutation-coordinator.test.ts
@@ -5,9 +5,11 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { HarnessDetectionSnapshot } from "../src/harness-detection.js";
+import { inspectManagedInstallations } from "../src/managed-installations.js";
 import {
   installDescriptorAcrossTargets,
   type MutationCoordinatorDependencies,
+  mutateDescriptorAcrossTargets,
 } from "../src/mutation-coordinator.js";
 import { createNodeFileSystem } from "../src/node-file-system.js";
 import type { CapabilityInstallDescriptor } from "../src/registry.js";
@@ -127,8 +129,15 @@ describe("installer mutation coordinator", () => {
         join(homeDirectory, ".local/state/invokta/installer.json"),
         "utf8",
       ),
-    ) as { readonly installations: Readonly<Record<string, unknown>> };
+    ) as {
+      readonly installations: Readonly<
+        Record<string, { readonly launchDescriptor?: unknown }>
+      >;
+    };
     expect(Object.keys(state.installations)).toHaveLength(2);
+    expect(Object.values(state.installations)[0]?.launchDescriptor).toEqual(
+      descriptor().server,
+    );
   });
 
   it("keeps successful targets when a later target conflicts", async () => {
@@ -163,5 +172,99 @@ describe("installer mutation coordinator", () => {
 
     expect(results[0]).toMatchObject({ targetId: "codex", outcome: "failed" });
     expect(results[1]).toEqual({ targetId: "cursor", outcome: "installed" });
+  });
+
+  it("disables and re-enables native and detached installations", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    const disabled = await mutateDescriptorAcrossTargets({
+      action: "disable",
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(disabled).toEqual([
+      { targetId: "codex", outcome: "disabled" },
+      { targetId: "cursor", outcome: "disabled" },
+    ]);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("enabled = false");
+    expect(
+      JSON.parse(readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8")),
+    ).toEqual({ mcpServers: {} });
+    const views = await inspectManagedInstallations({
+      dependencies: deps,
+      registry: { schemaVersion: 1, entries: [] },
+      snapshot: detected,
+    });
+    expect(
+      views.map(({ installation, status }) => ({
+        targetId: installation.targetId,
+        status,
+      })),
+    ).toEqual([
+      { targetId: "codex", status: "disabled" },
+      { targetId: "cursor", status: "disabled" },
+    ]);
+    expect(
+      views.every(({ descriptor: selected }) => selected !== undefined),
+    ).toBe(true);
+
+    const enabled = await mutateDescriptorAcrossTargets({
+      action: "enable",
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(enabled).toEqual([
+      { targetId: "codex", outcome: "enabled" },
+      { targetId: "cursor", outcome: "enabled" },
+    ]);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("enabled = true");
+    expect(
+      JSON.parse(readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8")),
+    ).toHaveProperty("mcpServers.support-engine.command", process.execPath);
+
+    const removed = await mutateDescriptorAcrossTargets({
+      action: "remove",
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(removed).toEqual([
+      { targetId: "codex", outcome: "removed" },
+      { targetId: "cursor", outcome: "removed" },
+    ]);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).not.toContain("support-engine");
+    expect(
+      JSON.parse(readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8")),
+    ).toEqual({ mcpServers: {} });
+    const finalState = JSON.parse(
+      readFileSync(
+        join(homeDirectory, ".local/state/invokta/installer.json"),
+        "utf8",
+      ),
+    ) as { readonly installations: Readonly<Record<string, unknown>> };
+    expect(finalState.installations).toEqual({});
   });
 });

--- a/packages/installer/test/mutation-coordinator.test.ts
+++ b/packages/installer/test/mutation-coordinator.test.ts
@@ -1,11 +1,20 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessDetectionSnapshot } from "../src/harness-detection.js";
+import type { InteractivePrompter } from "../src/interactive-prompter.js";
 import { inspectManagedInstallations } from "../src/managed-installations.js";
+import { runManagementSession } from "../src/management-session.js";
 import {
   installDescriptorAcrossTargets,
   type MutationCoordinatorDependencies,
@@ -61,6 +70,22 @@ function descriptor(): CapabilityInstallDescriptor {
         type: "stdio",
         command: process.execPath,
         args: ["/workspace/support-engine/dist/mcp-stdio.js"],
+        forwardEnv: [],
+      },
+    },
+  };
+}
+
+function updatedDescriptor(): CapabilityInstallDescriptor {
+  return {
+    ...descriptor(),
+    version: "2.0.0",
+    server: {
+      name: descriptor().server.name,
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: ["/workspace/support-engine/dist/mcp-stdio-v2.js"],
         forwardEnv: [],
       },
     },
@@ -266,5 +291,207 @@ describe("installer mutation coordinator", () => {
       ),
     ) as { readonly installations: Readonly<Record<string, unknown>> };
     expect(finalState.installations).toEqual({});
+  });
+
+  it("explicitly updates enabled native and detached installations", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    const results = await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: updatedDescriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(results).toEqual([
+      { targetId: "codex", outcome: "installed" },
+      { targetId: "cursor", outcome: "installed" },
+    ]);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("mcp-stdio-v2.js");
+    expect(
+      readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8"),
+    ).toContain("mcp-stdio-v2.js");
+    const state = JSON.parse(
+      readFileSync(
+        join(homeDirectory, ".local/state/invokta/installer.json"),
+        "utf8",
+      ),
+    ) as {
+      readonly installations: Readonly<
+        Record<
+          string,
+          {
+            readonly registryVersion: string;
+            readonly launchDescriptor?: CapabilityInstallDescriptor["server"];
+          }
+        >
+      >;
+    };
+    expect(
+      Object.values(state.installations).every(
+        ({ registryVersion, launchDescriptor }) =>
+          registryVersion === "2.0.0" &&
+          launchDescriptor?.transport.type === "stdio" &&
+          launchDescriptor.transport.args[0]?.endsWith("mcp-stdio-v2.js") ===
+            true,
+      ),
+    ).toBe(true);
+  });
+
+  it("updates disabled definitions without enabling them", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+    await mutateDescriptorAcrossTargets({
+      action: "disable",
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    const results = await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: updatedDescriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(results).toEqual([
+      { targetId: "codex", outcome: "installed" },
+      { targetId: "cursor", outcome: "installed" },
+    ]);
+    const codex = readFileSync(
+      join(homeDirectory, ".codex/config.toml"),
+      "utf8",
+    );
+    expect(codex).toContain("mcp-stdio-v2.js");
+    expect(codex).toContain("enabled = false");
+    expect(
+      JSON.parse(readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8")),
+    ).toEqual({ mcpServers: {} });
+    const views = await inspectManagedInstallations({
+      dependencies: deps,
+      registry: { schemaVersion: 1, entries: [] },
+      snapshot: detected,
+    });
+    expect(views.map(({ status }) => status)).toEqual(["disabled", "disabled"]);
+    expect(
+      views.every(
+        ({ installation }) => installation.registryVersion === "2.0.0",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves the mode of an existing client configuration", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const configPath = join(homeDirectory, ".codex/config.toml");
+    mkdirSync(join(homeDirectory, ".codex"), { recursive: true });
+    writeFileSync(configPath, "# keep\n", { mode: 0o640 });
+
+    const result = await installDescriptorAcrossTargets({
+      dependencies: dependencies(),
+      descriptor: descriptor(),
+      snapshot: snapshot(homeDirectory),
+      targetIds: ["codex"],
+    });
+
+    expect(result).toEqual([{ targetId: "codex", outcome: "installed" }]);
+    expect(statSync(configPath).mode & 0o7777).toBe(0o640);
+  });
+
+  it("reports a managed target as unavailable when detection becomes blocked", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    const codex = detected.targets[0];
+    const cursor = detected.targets[1];
+    if (codex === undefined || cursor === undefined) throw new Error("fixture");
+    const blocked = {
+      ...codex,
+      evidence: "blocked",
+      configuration: {
+        kind: "blocked",
+        code: "HARNESS_CONFIG_UNSAFE",
+      },
+      eligible: false,
+      mayCreateConfiguration: false,
+    } as const;
+
+    const views = await inspectManagedInstallations({
+      dependencies: deps,
+      registry: { schemaVersion: 1, entries: [] },
+      snapshot: { ...detected, targets: [blocked, cursor] },
+    });
+
+    expect(views).toHaveLength(1);
+    expect(views[0]).toMatchObject({ status: "unavailable", actions: [] });
+  });
+
+  it("reports a missing runtime as an explicit status state", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    const note = vi.fn();
+    const prompter = {
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      autocomplete: vi.fn(),
+      select: vi.fn(),
+      multiselect: vi.fn(),
+      note,
+      confirm: vi.fn(),
+      spinner: vi.fn(),
+      log: vi.fn(),
+    } as unknown as InteractivePrompter;
+
+    const result = await runManagementSession({
+      action: "status",
+      dependencies: deps,
+      prompter,
+      registry: { schemaVersion: 1, entries: [] },
+      resolveExecutable: async () => undefined,
+      snapshot: detected,
+    });
+
+    expect(result).toBe(0);
+    expect(note).toHaveBeenCalledWith(
+      "support-engine · Codex: missing-runtime (COMMAND_NOT_FOUND)",
+      "Managed MCP installations",
+    );
   });
 });

--- a/packages/installer/test/mutation-coordinator.test.ts
+++ b/packages/installer/test/mutation-coordinator.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { HarnessDetectionSnapshot } from "../src/harness-detection.js";
+import {
+  installDescriptorAcrossTargets,
+  type MutationCoordinatorDependencies,
+} from "../src/mutation-coordinator.js";
+import { createNodeFileSystem } from "../src/node-file-system.js";
+import type { CapabilityInstallDescriptor } from "../src/registry.js";
+import { configurationTargetAdapters } from "../src/target-adapters.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function snapshot(homeDirectory: string): HarnessDetectionSnapshot {
+  const target = (
+    id: "codex" | "cursor",
+    path: string,
+  ): HarnessDetectionSnapshot["targets"][number] => ({
+    id,
+    displayName: id === "codex" ? "Codex" : "Cursor",
+    surfaceIds: [],
+    evidence: "installed",
+    executables: [],
+    configuration: { kind: "absent", path },
+    eligible: true,
+    mayCreateConfiguration: true,
+    reloadHint: `Reload ${id}.`,
+  });
+  return {
+    homeDirectory,
+    surfaces: [],
+    targets: [
+      target("codex", join(homeDirectory, ".codex/config.toml")),
+      target("cursor", join(homeDirectory, ".cursor/mcp.json")),
+    ],
+  };
+}
+
+function descriptor(): CapabilityInstallDescriptor {
+  return {
+    id: "support-engine",
+    version: "1.0.0",
+    title: "Support Engine",
+    description: "Support actions.",
+    capabilityIds: ["tickets.summarize"],
+    server: {
+      name: "support-engine",
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: ["/workspace/support-engine/dist/mcp-stdio.js"],
+        forwardEnv: [],
+      },
+    },
+  };
+}
+
+function dependencies(): MutationCoordinatorDependencies {
+  let wallTime = Date.parse("2026-07-29T12:00:00.000Z");
+  let monotonic = 0;
+  let token = 0;
+  return {
+    adapters: configurationTargetAdapters,
+    currentUserId: process.getuid?.() ?? 0,
+    environment: { get: () => undefined },
+    fileSystem: createNodeFileSystem(),
+    lock: {
+      clock: {
+        monotonicNow: () => monotonic,
+        now: () => wallTime,
+        wait: async (milliseconds) => {
+          monotonic += milliseconds;
+          wallTime += milliseconds;
+        },
+      },
+      processId: 123,
+      randomBytes: (length) => {
+        token += 1;
+        return new Uint8Array(length).fill(token);
+      },
+    },
+    now: () => new Date(wallTime).toISOString(),
+  };
+}
+
+describe("installer mutation coordinator", () => {
+  it("installs one descriptor independently in multiple targets and records ownership", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+
+    const results = await installDescriptorAcrossTargets({
+      dependencies: dependencies(),
+      descriptor: descriptor(),
+      snapshot: snapshot(homeDirectory),
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(results).toEqual([
+      { targetId: "codex", outcome: "installed" },
+      { targetId: "cursor", outcome: "installed" },
+    ]);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("[mcp_servers.support-engine]");
+    expect(
+      JSON.parse(readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8")),
+    ).toMatchObject({
+      mcpServers: {
+        "support-engine": {
+          command: process.execPath,
+          args: ["/workspace/support-engine/dist/mcp-stdio.js"],
+        },
+      },
+    });
+    const state = JSON.parse(
+      readFileSync(
+        join(homeDirectory, ".local/state/invokta/installer.json"),
+        "utf8",
+      ),
+    ) as { readonly installations: Readonly<Record<string, unknown>> };
+    expect(Object.keys(state.installations)).toHaveLength(2);
+  });
+
+  it("keeps successful targets when a later target conflicts", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const cursor = detected.targets[1];
+    if (cursor?.configuration.kind !== "absent") throw new Error("fixture");
+    const fileSystem = createNodeFileSystem();
+    const deps = { ...dependencies(), fileSystem };
+    const codex = detected.targets[0];
+    if (codex === undefined) throw new Error("fixture");
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: { ...detected, targets: [codex] },
+      targetIds: ["codex"],
+    });
+
+    const results = await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: {
+        ...descriptor(),
+        server: {
+          ...descriptor().server,
+          name: "other-engine",
+        },
+      },
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+
+    expect(results[0]).toMatchObject({ targetId: "codex", outcome: "failed" });
+    expect(results[1]).toEqual({ targetId: "cursor", outcome: "installed" });
+  });
+});

--- a/packages/installer/test/ownership-planner.test.ts
+++ b/packages/installer/test/ownership-planner.test.ts
@@ -410,6 +410,13 @@ describe("pure installer ownership planning", () => {
         enablement: "enabled",
         actions: ["disable"],
       });
+      expect(planInstallerAction(planningInput, "install")).toEqual({
+        outcome: "write",
+        action: "install",
+        configEffect: "replace",
+        stateEffect: "update",
+        definitionSource: "registry",
+      });
       expect(planInstallerAction(planningInput, "disable")).toEqual({
         outcome: "write",
         action: "disable",
@@ -458,6 +465,14 @@ describe("pure installer ownership planning", () => {
         status: "outdated",
         enablement: "disabled",
         actions: ["enable"],
+      });
+      expect(planInstallerAction(planningInput, "install")).toEqual({
+        outcome: "write",
+        action: "install",
+        configEffect:
+          toggleStrategy === "detached" ? "none" : "replace-disabled",
+        stateEffect: "update",
+        definitionSource: "registry",
       });
       expect(planInstallerAction(planningInput, "enable")).toEqual({
         outcome: "write",

--- a/packages/installer/test/registry.test.ts
+++ b/packages/installer/test/registry.test.ts
@@ -101,10 +101,11 @@ function expectIssue(
 }
 
 describe("local capability registry", () => {
-  it("defines exactly the nine first-release compatibility targets", () => {
+  it("defines exactly the eleven compatibility targets", () => {
     expect(configurationTargetIds).toEqual([
       "antigravity",
       "claude-code",
+      "claude-desktop",
       "codex",
       "cursor",
       "grok-build",
@@ -112,6 +113,7 @@ describe("local capability registry", () => {
       "kimi-code",
       "openclaw",
       "opencode-v2",
+      "vscode",
     ]);
   });
 
@@ -169,7 +171,7 @@ describe("local capability registry", () => {
     expect(Object.isFrozen(result.registry)).toBe(true);
     expect(Object.isFrozen(result.registry.entries)).toBe(true);
     expect(Object.isFrozen(result.registry.entries[1]?.descriptor)).toBe(true);
-    expect(compatibility.calls).toHaveLength(18);
+    expect(compatibility.calls).toHaveLength(22);
   });
 
   it("uses the stable id as the display-order tie breaker", () => {
@@ -189,7 +191,7 @@ describe("local capability registry", () => {
     ).toEqual(["a-engine", "z-engine"]);
   });
 
-  it("accepts exactly 1,000 entries and calls every one of nine adapters once", () => {
+  it("accepts exactly 1,000 entries and calls every one of eleven adapters once", () => {
     const entries = Array.from({ length: 1_000 }, (_, index) =>
       stdioEntry(index),
     );
@@ -209,14 +211,14 @@ describe("local capability registry", () => {
 
     expect(result.ok).toBe(true);
     expect(counters.entryValidationPasses).toBe(1_000);
-    expect(counters.compatibilityCalls).toBe(9_000);
-    expect(compatibility.calls).toHaveLength(9_000);
+    expect(counters.compatibilityCalls).toBe(11_000);
+    expect(compatibility.calls).toHaveLength(11_000);
     for (const adapter of Object.values(compatibility.adapters)) {
       expect(adapter).toHaveBeenCalledTimes(1_000);
     }
   });
 
-  it("runs the 9,000-call boundary through all nine shipping adapters", () => {
+  it("runs the 11,000-call boundary through all eleven shipping adapters", () => {
     const counters = {
       pathLinksCreated: 0,
       pathSegmentsRendered: 0,
@@ -236,7 +238,7 @@ describe("local capability registry", () => {
     expect(result.ok).toBe(true);
     expect(counters).toMatchObject({
       entryValidationPasses: 1_000,
-      compatibilityCalls: 9_000,
+      compatibilityCalls: 11_000,
     });
   });
 
@@ -793,7 +795,7 @@ describe("local capability registry", () => {
       partial.adapters,
     );
     expect(partialResult.ok).toBe(true);
-    expect(partial.calls).toHaveLength(9);
+    expect(partial.calls).toHaveLength(11);
 
     const unsupported = compatibilityAdapters(() => false);
     const unsupportedResult = validateRegistryBytes(
@@ -801,7 +803,7 @@ describe("local capability registry", () => {
       unsupported.adapters,
     );
     expect(unsupportedResult.ok).toBe(false);
-    expect(unsupported.calls).toHaveLength(9);
+    expect(unsupported.calls).toHaveLength(11);
     if (unsupportedResult.ok) throw new Error("Expected validation to fail.");
     expect(unsupportedResult.issues).toContainEqual({
       pointer: "/entries/0/server/transport",

--- a/packages/installer/test/remote-install-source.test.ts
+++ b/packages/installer/test/remote-install-source.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createRemoteInstallDescriptor } from "../src/remote-install-source.js";
+
+function expectRemoteInvalid(operation: () => unknown): void {
+  let error: unknown;
+  try {
+    operation();
+  } catch (caught) {
+    error = caught;
+  }
+  expect(error).toMatchObject({ code: "REMOTE_INVALID" });
+}
+
+describe("remote MCP installation source", () => {
+  it("normalizes an HTTPS descriptor using environment references only", () => {
+    const fetchBefore = globalThis.fetch;
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+    try {
+      const descriptor = createRemoteInstallDescriptor({
+        serverName: "support_api",
+        url: "https://support.example.com/mcp",
+        bearerTokenEnvironment: "SUPPORT_BEARER_TOKEN",
+        headerEnvironment: [
+          "X-Tenant=SUPPORT_TENANT",
+          "X-Api-Key=SUPPORT_API_KEY",
+        ],
+      });
+
+      expect(descriptor).toEqual({
+        id: "remote-support-api",
+        version: "remote",
+        title: "support_api",
+        description: "Remote support_api MCP server.",
+        capabilityIds: ["remote.support_api"],
+        server: {
+          name: "support_api",
+          transport: {
+            type: "streamable-http",
+            url: "https://support.example.com/mcp",
+            authentication: {
+              type: "bearer-env",
+              variable: "SUPPORT_BEARER_TOKEN",
+            },
+            headersFromEnv: {
+              "x-api-key": "SUPPORT_API_KEY",
+              "x-tenant": "SUPPORT_TENANT",
+            },
+          },
+        },
+      });
+      expect(Object.isFrozen(descriptor.server.transport)).toBe(true);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = fetchBefore;
+    }
+  });
+
+  it.each([
+    [
+      "an invalid server name",
+      { serverName: "Support API", url: "https://example.com/mcp" },
+    ],
+    [
+      "credentials in the URL",
+      { serverName: "api", url: "https://user:secret@example.com/mcp" },
+    ],
+    [
+      "a noncanonical path",
+      { serverName: "api", url: "https://example.com/mcp/" },
+    ],
+    ["a query", { serverName: "api", url: "https://example.com/mcp?token=x" }],
+    [
+      "insecure remote HTTP",
+      { serverName: "api", url: "http://example.com/mcp" },
+    ],
+    ["localhost HTTP", { serverName: "api", url: "http://localhost/mcp" }],
+    [
+      "an invalid bearer environment name",
+      {
+        serverName: "api",
+        url: "https://example.com/mcp",
+        bearerTokenEnvironment: "token",
+      },
+    ],
+    [
+      "a literal header value",
+      {
+        serverName: "api",
+        url: "https://example.com/mcp",
+        headerEnvironment: ["X-Api-Key=literal-secret"],
+      },
+    ],
+    [
+      "a reserved header",
+      {
+        serverName: "api",
+        url: "https://example.com/mcp",
+        headerEnvironment: ["Host=SUPPORT_HOST"],
+      },
+    ],
+    [
+      "duplicate headers",
+      {
+        serverName: "api",
+        url: "https://example.com/mcp",
+        headerEnvironment: ["X-Key=FIRST", "x-key=SECOND"],
+      },
+    ],
+  ])("rejects %s", (_label, input) => {
+    expectRemoteInvalid(() => createRemoteInstallDescriptor(input));
+  });
+
+  it.each(["http://127.0.0.1/mcp", "http://[::1]/mcp"])(
+    "accepts the explicit insecure loopback exception %s",
+    (url) => {
+      expect(
+        createRemoteInstallDescriptor({ serverName: "local-api", url }).server
+          .transport,
+      ).toMatchObject({ url });
+    },
+  );
+});

--- a/packages/installer/test/target-adapter-inverse.test.ts
+++ b/packages/installer/test/target-adapter-inverse.test.ts
@@ -79,6 +79,42 @@ function expectInstallerCode(
 
 describe("target descriptor inverse mappings", () => {
   it.each(Object.keys(configurationTargetAdapters) as ConfigurationTargetId[])(
+    "removes a generated installation for %s",
+    (targetId) => {
+      const adapter = configurationTargetAdapters[targetId];
+      const descriptor = stdioDescriptor(targetId);
+      const empty = adapter.inspect({
+        source: undefined,
+        serverName: descriptor.server.name,
+      });
+      const installed = adapter.constructPatch({
+        action: "install",
+        definition: adapter.descriptorToDefinition(descriptor),
+        inspection: empty,
+      });
+      if (installed.kind !== "changed") throw new Error("Expected install.");
+      const present = adapter.inspect({
+        source: installed.postImage,
+        serverName: descriptor.server.name,
+      });
+
+      const removed = adapter.constructPatch({
+        action: "remove",
+        inspection: present,
+      });
+
+      expect(removed.kind).toBe("changed");
+      if (removed.kind !== "changed") throw new Error("Expected removal.");
+      expect(
+        adapter.inspect({
+          source: removed.postImage,
+          serverName: descriptor.server.name,
+        }).currentServer,
+      ).toEqual({ kind: "absent" });
+    },
+  );
+
+  it.each(Object.keys(configurationTargetAdapters) as ConfigurationTargetId[])(
     "round-trips installed stdio and HTTP definitions for %s",
     (targetId) => {
       const adapter = configurationTargetAdapters[targetId];

--- a/packages/installer/test/target-adapter-inverse.test.ts
+++ b/packages/installer/test/target-adapter-inverse.test.ts
@@ -13,7 +13,9 @@ function stdioDescriptor(
   targetId: ConfigurationTargetId,
 ): CapabilityInstallDescriptor {
   const supportsEnvironment =
-    targetId !== "antigravity" && targetId !== "kimi-code";
+    targetId !== "antigravity" &&
+    targetId !== "claude-desktop" &&
+    targetId !== "kimi-code";
   return {
     id: "support-engine",
     version: "1.0.0",
@@ -122,6 +124,7 @@ describe("target descriptor inverse mappings", () => {
         stdioDescriptor(targetId),
         httpDescriptor(targetId),
       ]) {
+        if (!adapter.compatibility(descriptor).supported) continue;
         const installedDefinition = adapter.descriptorToDefinition(descriptor);
         const suspended = adapter.definitionToSuspendedDescriptor(
           descriptor.server.name,
@@ -216,9 +219,9 @@ describe("target descriptor inverse mappings", () => {
     "rejects every noncanonical or credential-bearing HTTP URL for %s",
     (targetId) => {
       const adapter = configurationTargetAdapters[targetId];
-      const definition = adapter.descriptorToDefinition(
-        httpDescriptor(targetId),
-      );
+      const descriptor = httpDescriptor(targetId);
+      if (!adapter.compatibility(descriptor).supported) return;
+      const definition = adapter.descriptorToDefinition(descriptor);
       const urlField = targetId === "antigravity" ? "serverUrl" : "url";
       const adversarialUrls = [
         `https://user:${secretSentinel}@example.com/mcp`,
@@ -251,6 +254,7 @@ describe("target descriptor inverse mappings", () => {
       const adapter = configurationTargetAdapters[targetId];
       for (const url of ["http://127.0.0.1/mcp", "http://[::1]/mcp"]) {
         const source = httpDescriptor(targetId);
+        if (!adapter.compatibility(source).supported) return;
         if (source.server.transport.type !== "streamable-http") {
           throw new Error("Expected HTTP descriptor.");
         }

--- a/packages/installer/test/target-adapters.test.ts
+++ b/packages/installer/test/target-adapters.test.ts
@@ -149,6 +149,13 @@ describe("first native-toggle target adapters", () => {
         parentPath: ["mcpServers"],
         toggleStrategy: "detached",
       },
+      "claude-desktop": {
+        targetId: "claude-desktop",
+        targetContractVersion: 1,
+        format: "json",
+        parentPath: ["mcpServers"],
+        toggleStrategy: "detached",
+      },
       codex: {
         targetId: "codex",
         targetContractVersion: 1,
@@ -197,6 +204,13 @@ describe("first native-toggle target adapters", () => {
         format: "jsonc",
         parentPath: ["mcp", "servers"],
         toggleStrategy: "native-disabled",
+      },
+      vscode: {
+        targetId: "vscode",
+        targetContractVersion: 1,
+        format: "jsonc",
+        parentPath: ["servers"],
+        toggleStrategy: "detached",
       },
     });
     expect(Object.isFrozen(configurationTargetAdapters.codex.metadata)).toBe(

--- a/packages/installer/test/target-config-evidence.test.ts
+++ b/packages/installer/test/target-config-evidence.test.ts
@@ -56,6 +56,8 @@ function fileSystemWithInspection(
 const defaultRelativePaths = {
   antigravity: ".gemini/config/mcp_config.json",
   "claude-code": ".claude.json",
+  "claude-desktop":
+    "Library/Application Support/Claude/claude_desktop_config.json",
   codex: ".codex/config.toml",
   cursor: ".cursor/mcp.json",
   "grok-build": ".grok/config.toml",
@@ -63,6 +65,7 @@ const defaultRelativePaths = {
   "kimi-code": ".kimi-code/mcp.json",
   openclaw: ".openclaw/openclaw.json",
   "opencode-v2": ".config/opencode/opencode.json",
+  vscode: "Library/Application Support/Code/User/mcp.json",
 } as const;
 
 describe("Node target configuration evidence probes", () => {
@@ -250,7 +253,7 @@ describe("Node target configuration evidence probes", () => {
     });
   });
 
-  it("reports all nine documented default user configs as present", async () => {
+  it("reports all eleven documented macOS user configs as present", async () => {
     const homeDirectory = temporaryHome();
     for (const relativePath of Object.values(defaultRelativePaths)) {
       createConfig(join(homeDirectory, relativePath));
@@ -258,6 +261,7 @@ describe("Node target configuration evidence probes", () => {
     const probes = createNodeTargetConfigEvidenceProbes({
       environment: environment(),
       fileSystem: createNodeFileSystem(),
+      platform: "darwin",
     });
 
     for (const targetId of configurationTargetIds) {
@@ -270,11 +274,12 @@ describe("Node target configuration evidence probes", () => {
     }
   });
 
-  it("reports the exact creation path for all nine absent default user configs", async () => {
+  it("reports the exact creation path for all eleven absent macOS user configs", async () => {
     const homeDirectory = temporaryHome();
     const probes = createNodeTargetConfigEvidenceProbes({
       environment: environment(),
       fileSystem: createNodeFileSystem(),
+      platform: "darwin",
     });
 
     for (const targetId of configurationTargetIds) {
@@ -284,6 +289,47 @@ describe("Node target configuration evidence probes", () => {
         kind: "absent",
         path: join(homeDirectory, defaultRelativePaths[targetId]),
       });
+    }
+  });
+
+  it("supports the VS Code Linux user config and blocks Claude Desktop", async () => {
+    const homeDirectory = temporaryHome();
+    const vscodePath = join(homeDirectory, ".config/Code/User/mcp.json");
+    const probes = createNodeTargetConfigEvidenceProbes({
+      environment: environment(),
+      fileSystem: createNodeFileSystem(),
+      platform: "linux",
+    });
+
+    await expect(
+      probes.vscode({ homeDirectory, targetId: "vscode" }),
+    ).resolves.toEqual({ kind: "absent", path: vscodePath });
+    await expect(
+      probes["claude-desktop"]({
+        homeDirectory,
+        targetId: "claude-desktop",
+      }),
+    ).resolves.toEqual({ kind: "blocked", code: "TARGET_UNSUPPORTED" });
+
+    createConfig(vscodePath);
+
+    await expect(
+      probes.vscode({ homeDirectory, targetId: "vscode" }),
+    ).resolves.toEqual({ kind: "present", path: vscodePath });
+  });
+
+  it("blocks unsupported Windows mutations for VS Code and Claude Desktop", async () => {
+    const homeDirectory = temporaryHome();
+    const probes = createNodeTargetConfigEvidenceProbes({
+      environment: environment(),
+      fileSystem: createNodeFileSystem(),
+      platform: "win32",
+    });
+
+    for (const targetId of ["claude-desktop", "vscode"] as const) {
+      await expect(
+        probes[targetId]({ homeDirectory, targetId }),
+      ).resolves.toEqual({ kind: "blocked", code: "TARGET_UNSUPPORTED" });
     }
   });
 

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -17,6 +18,7 @@ const temporaryRoot = mkdtempSync(join(tmpdir(), "invokta-release-verify-"));
 const checkoutDirectory = join(temporaryRoot, "checkout");
 const artifactDirectory = join(temporaryRoot, "artifacts");
 const consumerDirectory = join(temporaryRoot, "consumer");
+const generatedDirectory = join(temporaryRoot, "generated");
 const distEntryFiles = ["dist/index.js", "dist/index.d.ts"];
 const repositoryUrl = "git+https://github.com/vinilana/invokta.git";
 const issuesUrl = "https://github.com/vinilana/invokta/issues";
@@ -47,6 +49,12 @@ const publicPackages = [
     name: "@invokta/deploy",
     // The toolkit ships both an import API and the `invokta-deploy` executable.
     requiredFiles: [...distEntryFiles, "dist/bin.js"],
+  },
+  {
+    directory: "create-invokta-engine",
+    name: "create-invokta-engine",
+    // The creator is binary-only and ships no import API.
+    requiredFiles: ["dist/bin.js"],
   },
 ];
 
@@ -194,10 +202,102 @@ function verifyChangelog(changelog, releaseVersion) {
   }
 }
 
+function writeGeneratedMcpSmoke(projectDirectory) {
+  const program = `
+    import assert from "node:assert/strict";
+    import { spawn } from "node:child_process";
+    import { createInterface } from "node:readline";
+
+    const child = spawn(process.execPath, ["dist/mcp-stdio.js"], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+    const iterator = lines[Symbol.asyncIterator]();
+    const childError = new Promise((_, reject) => child.once("error", reject));
+    const childExit = new Promise((resolve) =>
+      child.once("exit", (code, signal) => resolve({ code, signal })),
+    );
+
+    function withTimeout(promise, label) {
+      let timer;
+      const timeout = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(label)), 5_000);
+      });
+      return Promise.race([promise, childError, timeout]).finally(() =>
+        clearTimeout(timer),
+      );
+    }
+
+    async function nextMessage() {
+      const result = await withTimeout(
+        Promise.race([
+          iterator.next(),
+          childExit.then(() => {
+            throw new Error("MCP server exited before its response");
+          }),
+        ]),
+        "MCP response timed out",
+      );
+      if (result.done) throw new Error("MCP stdout ended before its response");
+      return JSON.parse(result.value);
+    }
+
+    function send(message) {
+      child.stdin.write(\`\${JSON.stringify(message)}\\n\`);
+    }
+
+    try {
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: { name: "creator-release-smoke", version: "0.0.0-test" },
+        },
+      });
+      const initialized = await nextMessage();
+      assert.equal(initialized.id, 1);
+      assert.equal(initialized.result.serverInfo.name, "release-engine");
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "onboarding.create-welcome-message",
+          arguments: { name: "Ada" },
+        },
+      });
+      const called = await nextMessage();
+      assert.equal(called.id, 2);
+      assert.deepEqual(called.result.structuredContent, {
+        message: "Welcome, Ada!",
+      });
+      child.stdin.end();
+      const result = await withTimeout(childExit, "MCP server exit timed out");
+      assert.equal(result.code, 0);
+      assert.equal(result.signal, null);
+      assert.equal(stderr, "");
+    } finally {
+      lines.close();
+      if (child.exitCode === null && child.signalCode === null) child.kill();
+    }
+  `;
+  writeFileSync(join(projectDirectory, "mcp-smoke.mjs"), program);
+}
+
 try {
   mkdirSync(checkoutDirectory);
   mkdirSync(artifactDirectory);
   mkdirSync(consumerDirectory);
+  mkdirSync(generatedDirectory);
 
   const indexTree = execFileSync("git", ["write-tree"], {
     cwd: repositoryRoot,
@@ -227,6 +327,7 @@ try {
   );
 
   const tarballs = [];
+  const tarballsByName = new Map();
 
   for (const publicPackage of publicPackages) {
     const packageDirectory = join(
@@ -270,7 +371,9 @@ try {
       }
     }
 
-    tarballs.push(join(artifactDirectory, report.filename));
+    const tarball = join(artifactDirectory, report.filename);
+    tarballs.push(tarball);
+    tarballsByName.set(publicPackage.name, tarball);
   }
 
   writeFileSync(
@@ -332,6 +435,99 @@ try {
   const networkSentinel = pathToFileURL(
     join(sentinelDirectory, "forbid-network-access.mjs"),
   ).href;
+
+  const creatorCommand = join(
+    consumerDirectory,
+    "node_modules",
+    ".bin",
+    "create-invokta-engine",
+  );
+  const creatorVersion = run(creatorCommand, ["--version"], {
+    cwd: generatedDirectory,
+    capture: true,
+    env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+  });
+  if (creatorVersion !== `${releaseVersion}\n`) {
+    throw new Error("creator binary version smoke failed");
+  }
+  const creatorOutput = run(
+    creatorCommand,
+    ["release-engine", "--package-manager", "npm", "--no-install"],
+    {
+      cwd: generatedDirectory,
+      capture: true,
+      env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+    },
+  );
+  if (!creatorOutput.startsWith("Created release-engine without installing")) {
+    throw new Error("creator scaffold smoke failed");
+  }
+
+  const generatedProjectDirectory = join(generatedDirectory, "release-engine");
+  const generatedManifest = JSON.parse(
+    readFileSync(join(generatedProjectDirectory, "package.json"), "utf8"),
+  );
+  for (const packageName of ["@invokta/core", "@invokta/cli", "@invokta/mcp"]) {
+    if (generatedManifest.dependencies?.[packageName] !== releaseVersion) {
+      throw new Error(
+        `generated ${packageName} version is not release-aligned`,
+      );
+    }
+  }
+  if (existsSync(join(generatedProjectDirectory, "src", "mcp-http.ts"))) {
+    throw new Error("creator unexpectedly generated an HTTP entry point");
+  }
+
+  const generatedRuntimeTarballs = [
+    tarballsByName.get("@invokta/core"),
+    tarballsByName.get("@invokta/cli"),
+    tarballsByName.get("@invokta/mcp"),
+  ];
+  if (generatedRuntimeTarballs.some((tarball) => tarball === undefined)) {
+    throw new Error("generated consumer tarballs are incomplete");
+  }
+  run(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      ...generatedRuntimeTarballs,
+    ],
+    { cwd: generatedProjectDirectory },
+  );
+  run("npm", ["run", "--silent", "check"], {
+    cwd: generatedProjectDirectory,
+  });
+
+  const directResult = run("npm", ["run", "--silent", "direct", "--", "Ada"], {
+    cwd: generatedProjectDirectory,
+    capture: true,
+  });
+  if (directResult !== '{"message":"Welcome, Ada!"}\n') {
+    throw new Error("generated direct entry point smoke failed");
+  }
+  const cliResult = run(
+    "npm",
+    [
+      "run",
+      "--silent",
+      "cli",
+      "--",
+      "run",
+      "onboarding.create-welcome-message",
+      "--input",
+      '{"name":"Ada"}',
+    ],
+    { cwd: generatedProjectDirectory, capture: true },
+  );
+  if (cliResult !== '{"message":"Welcome, Ada!"}\n') {
+    throw new Error("generated CLI entry point smoke failed");
+  }
+  writeGeneratedMcpSmoke(generatedProjectDirectory);
+  run("node", ["mcp-smoke.mjs"], { cwd: generatedProjectDirectory });
+
   const installerVersion = run(installerCommand, ["--version"], {
     cwd: consumerDirectory,
     capture: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./packages/cli" },
     { "path": "./packages/mcp" },
     { "path": "./packages/deploy" },
+    { "path": "./packages/create-invokta-engine" },
     { "path": "./packages/installer" },
     { "path": "./packages/tooling" },
     { "path": "./examples/community-capabilities" },


### PR DESCRIPTION
## Summary

- add the standalone `create-invokta-engine` scaffold with a strict `invokta.mcp.json` manifest and build-first `mcp:install` script
- connect the installer mutation coordinator for confirmed, idempotent multi-client installation with per-target atomic writes and rollback
- add interactive `status`, `enable`, `disable`, and `remove` lifecycle commands
- add offline registration of explicit Streamable HTTP MCP endpoints using environment-variable credential references
- add VS Code and Claude Desktop targets, expanding the catalog to eleven configuration targets across twelve executable surfaces
- publish the installation contract, user workflow, safety boundary, and release notes

## Why

A generated Action Engine already exposes MCP stdio, but users still had to configure each client manually. This change makes the default path one command:

```sh
npm create invokta-engine@latest my-engine
cd my-engine
npm run mcp:install
```

The installer detects eligible clients, preselects them, and asks for one confirmation before updating user configuration.

## User and developer impact

Local engines are installed from a closed, project-local manifest without importing or executing project code. Existing remote Streamable HTTP endpoints can be registered without probing the network. Installer-owned entries can be inspected, disabled, restored, and removed without overwriting drifted or unrelated configuration.

The creator, CLI, MCP adapter, and installer keep engine execution on the existing `engine.invoke` path.

## Safety

- validates owned, no-follow engine and client configuration paths
- persists environment variable names, never credential values
- performs no package loading, engine execution, shell execution, or network discovery during installation
- uses bounded locks, atomic replacements, drift detection, and exact per-target rollback
- leaves Windows configuration mutation deferred until equivalent filesystem guarantees exist

## Validation

- `yarn typecheck`
- Biome lint and format checks across all tracked files
- `yarn test:run` — 3,155 passed, 2 skipped
- `yarn build`
- `yarn --cwd apps/docs validate`
- `yarn release:verify`
