### PR TITLE
chore(release): prepare 0.2.0

### DIFF
--- a/.github/workflows/security-and-release.yml
+++ b/.github/workflows/security-and-release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Dry-run public packages
         run: |
-          for package_directory in ./packages/core ./packages/cli ./packages/mcp ./packages/tooling ./packages/installer ./packages/deploy; do
+          for package_directory in ./packages/core ./packages/cli ./packages/mcp ./packages/tooling ./packages/installer ./packages/deploy ./packages/create-invokta-engine; do
             npm pack --dry-run "$package_directory"
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-29
+
 ### Added
 
 - Added `create-invokta-engine`, a non-interactive standalone engine creator with
@@ -74,5 +76,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/vinilana/invokta/releases/tag/v0.2.0
 [0.1.0]: https://github.com/vinilana/invokta/releases/tag/v0.1.0

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -17,9 +17,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.1.0",
+    "@invokta/core": "0.2.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -14,14 +14,14 @@
     "check:capabilities": "node ../../packages/tooling/dist/cli.js check-capabilities ./dist/capabilities.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/tooling": "0.1.0",
+    "@invokta/tooling": "0.2.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -15,9 +15,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -13,9 +13,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.1.0",
-    "@invokta/core": "0.1.0",
-    "@invokta/mcp": "0.1.0",
+    "@invokta/cli": "0.2.0",
+    "@invokta/core": "0.2.0",
+    "@invokta/mcp": "0.2.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.1.0"
+    "@invokta/core": "0.2.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Typed capability contracts and execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HTTP engine scaffolding, packaging, and probing tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.1.0",
+      version: "0.2.0",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP stdio and stateless HTTP adapters for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.1.0",
+    "@invokta/core": "0.2.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Development-time capability composition checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,6 +39,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.1.0"
+    "@invokta/core": "0.2.0"
   }
 }

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -474,16 +474,24 @@ try {
       );
     }
   }
+  if (
+    generatedManifest.devDependencies?.["@invokta/installer"] !== releaseVersion
+  ) {
+    throw new Error(
+      "generated @invokta/installer version is not release-aligned",
+    );
+  }
   if (existsSync(join(generatedProjectDirectory, "src", "mcp-http.ts"))) {
     throw new Error("creator unexpectedly generated an HTTP entry point");
   }
 
-  const generatedRuntimeTarballs = [
+  const generatedDependencyTarballs = [
     tarballsByName.get("@invokta/core"),
     tarballsByName.get("@invokta/cli"),
     tarballsByName.get("@invokta/mcp"),
+    tarballsByName.get("@invokta/installer"),
   ];
-  if (generatedRuntimeTarballs.some((tarball) => tarball === undefined)) {
+  if (generatedDependencyTarballs.some((tarball) => tarball === undefined)) {
     throw new Error("generated consumer tarballs are incomplete");
   }
   run(
@@ -493,7 +501,7 @@ try {
       "--ignore-scripts",
       "--no-audit",
       "--no-fund",
-      ...generatedRuntimeTarballs,
+      ...generatedDependencyTarballs,
     ],
     { cwd: generatedProjectDirectory },
   );


### PR DESCRIPTION
## Summary

- synchronize all seven public Invokta packages at version `0.2.0`
- add the `0.2.0` changelog entry and release comparison links
- include `create-invokta-engine` in CI package dry runs
- strengthen release verification for generated starter installer dependencies and local packed artifacts

## Impact

This prepares the coordinated `0.2.0` release train, including the first publication of `@invokta/installer` and `create-invokta-engine`. npm publication remains a separate manual step.

## Validation

- `corepack yarn run check`
- `corepack yarn audit`
- `corepack yarn release:verify`
- documentation validation and production build
- `npm pack --dry-run` for all seven public packages
- focused installer package-boundary tests
- npm registry version availability checks for `0.2.0`