### PR TITLE
Add capability project creators and generated development guidance

### DIFF
--- a/.github/workflows/security-and-release.yml
+++ b/.github/workflows/security-and-release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Dry-run public packages
         run: |
-          for package_directory in ./packages/core ./packages/cli ./packages/mcp ./packages/tooling ./packages/installer ./packages/deploy ./packages/create-invokta-engine; do
+          for package_directory in ./packages/core ./packages/cli ./packages/mcp ./packages/tooling ./packages/installer ./packages/deploy ./packages/create-invokta-engine ./packages/create-invokta-capability ./packages/create-invokta-capability-library; do
             npm pack --dry-run "$package_directory"
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added `create-invokta-capability` and
+  `create-invokta-capability-library`, with deterministic private ESM starters
+  that prove atomic and library composition through `engine.invoke`.
+
 ## [0.2.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Added `create-invokta-capability` and
   `create-invokta-capability-library`, with deterministic private ESM starters
   that prove atomic and library composition through `engine.invoke`.
+- Generated engine and capability-library projects now include one `AGENTS.md`
+  instruction source and a relative `CLAUDE.md` symbolic-link alias.
 
 ## [0.2.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   that prove atomic and library composition through `engine.invoke`.
 - Generated engine and capability-library projects now include one `AGENTS.md`
   instruction source and a relative `CLAUDE.md` symbolic-link alias.
+- Every generated engine, atomic capability, and capability-library project now
+  includes a valid `develop-invokta-project` skill tailored to its architecture
+  and test-first workflow.
 
 ## [0.2.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,13 @@ and delivery adapters:
 - `@invokta/installer` detects supported local MCP clients, installs local or
   remote Action Engines across selected clients, and manages those entries;
 - `@invokta/deploy` scaffolds and packages stateless HTTP engines and probes
-  deployed endpoints.
+  deployed endpoints;
 - `create-invokta-engine` creates a standalone starter with direct, CLI, and MCP
-  stdio entry points.
+  stdio entry points;
+- `create-invokta-capability` creates a standalone atomic capability package;
+  and
+- `create-invokta-capability-library` creates a standalone capability-library
+  package.
 
 Invokta does not provide identity, model routing, an agent harness, a
 workflow engine, or a production observability platform. Custom engines inject
@@ -165,6 +169,14 @@ npm run mcp:install
 preselects them, and asks for one confirmation before updating their user
 configuration. See the [installer reference](./apps/docs/src/content/docs/reference/installer.mdx)
 for remote HTTP registration and lifecycle commands.
+
+Create reusable package boundaries directly when an engine is not the owning
+project:
+
+```sh
+npm create invokta-capability@latest my-capability
+npm create invokta-capability-library@latest my-library
+```
 
 To work on Invokta itself:
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -96,6 +96,8 @@ export default defineConfig({
             { slug: "reference/installer" },
             { slug: "reference/deploy" },
             { slug: "reference/create-invokta-engine" },
+            { slug: "reference/create-invokta-capability" },
+            { slug: "reference/create-invokta-capability-library" },
             { slug: "reference/errors" },
           ],
         },

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -55,6 +55,26 @@ confirmation before writing user configuration. See the
 [installer reference](/reference/installer/) for supported clients, remote HTTP
 registration, and lifecycle management.
 
+## Create reusable capability packages
+
+Create one atomic exported capability:
+
+```sh
+npm create invokta-capability@latest my-capability
+```
+
+Create a related capability library:
+
+```sh
+npm create invokta-capability-library@latest my-library
+```
+
+Both starters are private, deterministic ESM packages. Their tests compose the
+generated exports into an engine and invoke them through `engine.invoke`. See
+the [atomic creator](/reference/create-invokta-capability/) and
+[capability-library creator](/reference/create-invokta-capability-library/)
+references for the complete contracts.
+
 ## Install the core
 
 <Tabs syncKey="package-manager">
@@ -106,6 +126,8 @@ Install the CLI or MCP adapter when the engine needs that boundary.
 | `@invokta/installer` | Install and manage local or remote Action Engine MCP servers in supported clients |
 | `@invokta/deploy` | Reviewable container packaging and endpoint probes |
 | `create-invokta-engine` | Standalone starter Action Engine creation |
+| `create-invokta-capability` | Standalone atomic capability package creation |
+| `create-invokta-capability-library` | Standalone capability-library package creation |
 
 <Aside type="note" title="ESM only">
   Invokta publishes native ESM entry points. Use `import` syntax and include file

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -88,7 +88,7 @@ the CLI, MCP stdio, and stateless MCP Streamable HTTP.
     Every adapter calls `engine.invoke`, keeping validation, authorization,
     cancellation, errors, and events in one pipeline.
   </Card>
-  <Card title="Delivery adapters" icon="transfer">
+  <Card title="Delivery paths" icon="transfer">
     Invoke the engine directly, expose a local CLI, or publish MCP tools over
     stdio and bounded stateless HTTP.
   </Card>

--- a/apps/docs/src/content/docs/reference/create-invokta-capability-library.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-capability-library.mdx
@@ -33,6 +33,8 @@ directory. Unknown, repeated, incomplete, or extra arguments produce exit code
 
 ```text
 .gitignore
+AGENTS.md
+CLAUDE.md -> AGENTS.md
 README.md
 package.json
 src/capabilities/create-farewell-message.ts
@@ -42,6 +44,13 @@ test/library.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+`AGENTS.md` records the starter's capability-contract and test-first delivery
+constraints. `CLAUDE.md` is an actual symbolic link whose stored target is the
+relative path `AGENTS.md`, so both agent discovery names use one instruction
+source and the project remains relocatable. If link creation is unsupported or
+fails, the creator reports `WRITE_FAILED` and rolls back its entries; it does
+not fall back to a copied file.
 
 The root export contains the explicit default IDs
 `onboarding.create-welcome-message` and
@@ -62,10 +71,11 @@ Symbolic-link path components, non-directory targets, and non-empty targets are
 refused before a scaffold write.
 
 The path is limited to 1,024 Unicode scalars and 32 non-dot segments. The final
-project name is limited to 214 characters. Files use deterministic UTF-8 text,
-LF endings, one trailing newline, and exclusive creation. A write failure rolls
-back only paths created by that invocation. Concurrent creation in one target
-is unsupported; neither invocation overwrites the other.
+project name is limited to 214 characters. Text files use deterministic UTF-8,
+LF endings, and one trailing newline. Files and symbolic links use exclusive
+creation. A write failure rolls back only paths created by that invocation.
+Concurrent creation in one target is unsupported; neither invocation overwrites
+the other.
 
 ## Dependency installation
 

--- a/apps/docs/src/content/docs/reference/create-invokta-capability-library.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-capability-library.mdx
@@ -1,0 +1,93 @@
+---
+title: 'create-invokta-capability-library'
+description: Complete command, generated-project, filesystem, package-manager, and diagnostic contract for the Invokta capability-library creator.
+---
+
+`create-invokta-capability-library` creates one standalone TypeScript package
+that publishes a related set of capabilities through `defineCapabilityLibrary`.
+
+## Install
+
+```sh
+npm create invokta-capability-library@latest my-library
+```
+
+The generated package is private by default. It is ready for local composition
+and testing; publishing requires explicit library identity, default-ID, and
+compatibility decisions from its author.
+
+## Commands
+
+```text
+create-invokta-capability-library <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-capability-library --help
+create-invokta-capability-library --version
+```
+
+Creation is non-interactive. Options may appear before or after the one project
+directory. Unknown, repeated, incomplete, or extra arguments produce exit code
+`2` without creating a project.
+
+## Generated project
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-farewell-message.ts
+src/capabilities/create-welcome-message.ts
+src/index.ts
+test/library.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The root export contains the explicit default IDs
+`onboarding.create-welcome-message` and
+`onboarding.create-farewell-message`. The test selects and remaps the welcome
+capability, composes it into an engine, and invokes it through `engine.invoke`.
+The creator does not add an adapter, server, engine entry point, registry, or
+publish step.
+
+The manifest pins `@invokta/core` exactly to the creator version. Generated
+files are owned by the project and are never upgraded in place.
+
+## Target safety and limits
+
+The target is relative to the current working directory. Absolute paths,
+parent-directory segments, empty segments, and invalid lowercase kebab-case
+project names are rejected. A target may be absent or an empty real directory.
+Symbolic-link path components, non-directory targets, and non-empty targets are
+refused before a scaffold write.
+
+The path is limited to 1,024 Unicode scalars and 32 non-dot segments. The final
+project name is limited to 214 characters. Files use deterministic UTF-8 text,
+LF endings, one trailing newline, and exclusive creation. A write failure rolls
+back only paths created by that invocation. Concurrent creation in one target
+is unsupported; neither invocation overwrites the other.
+
+## Dependency installation
+
+Without `--no-install`, the command starts exactly one shell-free foreground
+install: `npm install --no-audit --no-fund`, `pnpm install`, or `yarn install`.
+An explicit package manager wins; otherwise the invoking manager is inferred
+from `npm_config_user_agent`, with npm as the fallback.
+
+The creator makes no network request itself and adds no timeout or retry. An
+installation failure preserves the completed scaffold for a manual retry.
+
+## Output, errors, and exit codes
+
+Help, version, and success output use stdout. Diagnostics use stderr. Rejected
+arguments, environment values, child errors, causes, and stacks are never
+printed.
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Usage, project path, or project name was invalid |
+
+Stable diagnostics are `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, and `INSTALL_FAILED`.

--- a/apps/docs/src/content/docs/reference/create-invokta-capability-library.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-capability-library.mdx
@@ -32,6 +32,8 @@ directory. Unknown, repeated, incomplete, or extra arguments produce exit code
 ## Generated project
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 AGENTS.md
 CLAUDE.md -> AGENTS.md
@@ -44,6 +46,13 @@ test/library.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+The generated `develop-invokta-project` skill teaches an agent to preserve the
+library's literal ordered default IDs, follow RED/GREEN/REFACTOR, and prove
+selection and remapping through `importCapabilities` and `engine.invoke`. The
+skill is static project guidance; it adds no runtime discovery, registry,
+adapter, or execution path. Its metadata includes a ready-to-use
+`$develop-invokta-project` prompt.
 
 `AGENTS.md` records the starter's capability-contract and test-first delivery
 constraints. `CLAUDE.md` is an actual symbolic link whose stored target is the

--- a/apps/docs/src/content/docs/reference/create-invokta-capability.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-capability.mdx
@@ -1,0 +1,90 @@
+---
+title: 'create-invokta-capability'
+description: Complete command, generated-project, filesystem, package-manager, and diagnostic contract for the Invokta atomic capability creator.
+---
+
+`create-invokta-capability` creates one standalone TypeScript package that
+publishes an atomic capability through `defineExportedCapability`.
+
+## Install
+
+```sh
+npm create invokta-capability@latest my-capability
+```
+
+The generated package is private by default. It is ready for local composition
+and testing; publishing requires an explicit package identity and compatibility
+decision from its author.
+
+## Commands
+
+```text
+create-invokta-capability <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-capability --help
+create-invokta-capability --version
+```
+
+Creation is non-interactive. Options may appear before or after the one project
+directory. Unknown, repeated, incomplete, or extra arguments produce exit code
+`2` without creating a project.
+
+## Generated project
+
+```text
+.gitignore
+README.md
+package.json
+src/capability.ts
+src/index.ts
+test/capability.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The root export has the explicit default ID
+`onboarding.create-welcome-message`. The test imports the exported descriptor,
+composes it into an engine, and invokes it through `engine.invoke`. The creator
+does not add an adapter, server, engine entry point, registry, or publish step.
+
+The manifest pins `@invokta/core` exactly to the creator version. Generated
+files are owned by the project and are never upgraded in place.
+
+## Target safety and limits
+
+The target is relative to the current working directory. Absolute paths,
+parent-directory segments, empty segments, and invalid lowercase kebab-case
+project names are rejected. A target may be absent or an empty real directory.
+Symbolic-link path components, non-directory targets, and non-empty targets are
+refused before a scaffold write.
+
+The path is limited to 1,024 Unicode scalars and 32 non-dot segments. The final
+project name is limited to 214 characters. Files use deterministic UTF-8 text,
+LF endings, one trailing newline, and exclusive creation. A write failure rolls
+back only paths created by that invocation. Concurrent creation in one target
+is unsupported; neither invocation overwrites the other.
+
+## Dependency installation
+
+Without `--no-install`, the command starts exactly one shell-free foreground
+install: `npm install --no-audit --no-fund`, `pnpm install`, or `yarn install`.
+An explicit package manager wins; otherwise the invoking manager is inferred
+from `npm_config_user_agent`, with npm as the fallback.
+
+The creator makes no network request itself and adds no timeout or retry. An
+installation failure preserves the completed scaffold for a manual retry.
+
+## Output, errors, and exit codes
+
+Help, version, and success output use stdout. Diagnostics use stderr. Rejected
+arguments, environment values, child errors, causes, and stacks are never
+printed.
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Usage, project path, or project name was invalid |
+
+Stable diagnostics are `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, and `INSTALL_FAILED`.

--- a/apps/docs/src/content/docs/reference/create-invokta-capability.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-capability.mdx
@@ -32,6 +32,8 @@ directory. Unknown, repeated, incomplete, or extra arguments produce exit code
 ## Generated project
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 README.md
 package.json
@@ -41,6 +43,14 @@ test/capability.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+The generated `develop-invokta-project` skill teaches an agent to keep the
+atomic definition and `defineExportedCapability` descriptor separate, treat the
+default ID and source metadata as compatibility surfaces, follow
+RED/GREEN/REFACTOR, and prove consumption through `importCapability` and
+`engine.invoke`. The skill is static project guidance and adds no runtime
+behavior. Its metadata includes a ready-to-use `$develop-invokta-project`
+prompt.
 
 The root export has the explicit default ID
 `onboarding.create-welcome-message`. The test imports the exported descriptor,

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -60,6 +60,8 @@ Text files are deterministic UTF-8 with LF endings and one trailing newline.
 The fixed entries are:
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 AGENTS.md
 CLAUDE.md -> AGENTS.md
@@ -75,6 +77,13 @@ test/engine.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+The generated `develop-invokta-project` skill teaches an agent to evolve the
+Action Engine through explicit capability contracts, engine-owned dependency
+injection, RED/GREEN/REFACTOR, and the single `engine.invoke` path. The skill is
+static project guidance; it adds no runtime discovery, registry, plugin, or
+execution path. Its `agents/openai.yaml` metadata includes a ready-to-use
+`$develop-invokta-project` prompt.
 
 `AGENTS.md` records the starter's architecture and test-first delivery
 constraints. `CLAUDE.md` is an actual symbolic link whose stored target is the

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -47,18 +47,22 @@ has a valid lowercase kebab-case name and is empty.
 
 The target may be absent or an empty real directory. A symbolic-link target,
 symbolic-link path component, non-directory target, or any existing entry fails
-before scaffold writes. Every file is created exclusively; an entry that appears
-during creation is preserved and reported as `SCAFFOLD_CONFLICT`.
+before scaffold writes. Every scaffold entry is created exclusively; an entry
+that appears during creation is preserved and reported as
+`SCAFFOLD_CONFLICT`.
 
 A pre-install write failure removes only paths created by that invocation. The
 creator never overwrites a file. Concurrent creation in one target is unsupported.
 
 ## Generated project
 
-Files are deterministic UTF-8 text with LF endings and one trailing newline:
+Text files are deterministic UTF-8 with LF endings and one trailing newline.
+The fixed entries are:
 
 ```text
 .gitignore
+AGENTS.md
+CLAUDE.md -> AGENTS.md
 README.md
 invokta.mcp.json
 package.json
@@ -71,6 +75,13 @@ test/engine.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+`AGENTS.md` records the starter's architecture and test-first delivery
+constraints. `CLAUDE.md` is an actual symbolic link whose stored target is the
+relative path `AGENTS.md`, so both agent discovery names use one instruction
+source and the project remains relocatable. If link creation is unsupported or
+fails, the creator reports `WRITE_FAILED` and rolls back its entries; it does
+not fall back to a copied file.
 
 The public `onboarding.create-welcome-message` capability is deterministic and
 requires no credential or provider account. Direct, CLI, and MCP stdio entry
@@ -132,7 +143,7 @@ inherits the terminal streams.
 | `TARGET_UNSAFE` | A path component is a symlink, not a directory, or cannot be inspected safely |
 | `TARGET_NOT_EMPTY` | The target contains at least one entry |
 | `SCAFFOLD_CONFLICT` | A fixed scaffold path appeared after preflight |
-| `WRITE_FAILED` | A scaffold write or rollback failed |
+| `WRITE_FAILED` | A scaffold file or symbolic-link write, or rollback, failed |
 | `INSTALL_FAILED` | The selected package manager was unavailable or unsuccessful |
 
 Diagnostics may identify a generated project-relative path or package-manager

--- a/apps/docs/src/content/docs/reference/index.mdx
+++ b/apps/docs/src/content/docs/reference/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Overview
 ---
 
-Invokta publishes three runtime packages and four supporting packages. Each has
+Invokta publishes three runtime packages and six supporting packages. Each has
 one bounded responsibility.
 
 ## Runtime packages
@@ -27,11 +27,13 @@ API and never call capability handlers directly.
 | `@invokta/installer` | Install and manage Action Engine MCP servers in supported local clients | [Installer reference](/reference/installer/) |
 | `@invokta/deploy` | Scaffold and package HTTP deployment artifacts and probe an endpoint | [Deploy reference](/reference/deploy/) |
 | `create-invokta-engine` | Create a standalone starter engine and install its dependencies | [Creator reference](/reference/create-invokta-engine/) |
+| `create-invokta-capability` | Create a standalone atomic capability package | [Atomic creator reference](/reference/create-invokta-capability/) |
+| `create-invokta-capability-library` | Create a standalone capability-library package | [Library creator reference](/reference/create-invokta-capability-library/) |
 
-Supporting packages do not create another capability execution path. The creator
-writes a project, tooling imports a trusted composition module, the installer
-updates client configuration without invoking an engine, and deploy generates
-files or makes one probe request.
+Supporting packages do not create another capability execution path. The
+creators write projects, tooling imports a trusted composition module, the
+installer updates client configuration without invoking an engine, and deploy
+generates files or makes one probe request.
 
 ## Shared requirements
 

--- a/apps/docs/test/site-contract.node.mjs
+++ b/apps/docs/test/site-contract.node.mjs
@@ -26,6 +26,8 @@ const packageReferences = [
   ["installer", "@invokta/installer"],
   ["deploy", "@invokta/deploy"],
   ["create-invokta-engine", "create-invokta-engine"],
+  ["create-invokta-capability", "create-invokta-capability"],
+  ["create-invokta-capability-library", "create-invokta-capability-library"],
 ];
 
 const requiredRoutes = [

--- a/docs/adr/0012-standalone-invokta-engine-creator.md
+++ b/docs/adr/0012-standalone-invokta-engine-creator.md
@@ -38,18 +38,20 @@ engine name. It must be lowercase kebab-case and at most 214 characters.
 
 The target may be absent or an empty real directory. A symbolic-link target, a
 symbolic-link path component, a non-directory target, or any existing directory
-entry fails before a scaffold write. Generated files are fixed, deterministic
-UTF-8 text with LF endings and one trailing newline. Writes use exclusive
-creation and never replace an existing file. A pre-install failure rolls back
-only files and directories created by that invocation; a rollback failure is
-reported and may leave those new paths for manual inspection. Concurrent
-creation in one target is unsupported, while exclusive writes ensure neither
-invocation overwrites the other.
+entry fails before a scaffold write. Generated text files are fixed,
+deterministic UTF-8 with LF endings and one trailing newline. Files and symbolic
+links use exclusive creation and never replace an existing entry. A pre-install
+failure rolls back only entries and directories created by that invocation; a
+rollback failure is reported and may leave those new paths for manual
+inspection. Concurrent creation in one target is unsupported, while exclusive
+writes ensure neither invocation overwrites the other.
 
 The fixed starter contains these paths in lexicographic order:
 
 ```text
 .gitignore
+AGENTS.md
+CLAUDE.md -> AGENTS.md
 README.md
 invokta.mcp.json
 package.json
@@ -62,6 +64,9 @@ test/engine.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+`AGENTS.md` is a regular UTF-8 text file. `CLAUDE.md` is the relative symbolic
+link defined by ADR 0015 rather than a second text file.
 
 It defines one deterministic public capability and reuses it through direct
 invocation, `@invokta/cli`, and MCP stdio. It contains no model provider,

--- a/docs/adr/0012-standalone-invokta-engine-creator.md
+++ b/docs/adr/0012-standalone-invokta-engine-creator.md
@@ -49,6 +49,8 @@ writes ensure neither invocation overwrites the other.
 The fixed starter contains these paths in lexicographic order:
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 AGENTS.md
 CLAUDE.md -> AGENTS.md
@@ -67,6 +69,9 @@ tsconfig.test.json
 
 `AGENTS.md` is a regular UTF-8 text file. `CLAUDE.md` is the relative symbolic
 link defined by ADR 0015 rather than a second text file.
+
+The `develop-invokta-project` skill is the Action Engine development workflow
+defined by ADR 0016.
 
 It defines one deterministic public capability and reuses it through direct
 invocation, `@invokta/cli`, and MCP stdio. It contains no model provider,

--- a/docs/adr/0014-standalone-capability-project-creators.md
+++ b/docs/adr/0014-standalone-capability-project-creators.md
@@ -71,6 +71,8 @@ The library creator writes these fixed paths in lexicographic order:
 
 ```text
 .gitignore
+AGENTS.md
+CLAUDE.md -> AGENTS.md
 README.md
 package.json
 src/capabilities/create-farewell-message.ts
@@ -80,6 +82,9 @@ test/library.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+`AGENTS.md` is a regular UTF-8 text file. `CLAUDE.md` is the relative symbolic
+link defined by ADR 0015 rather than a second text file.
 
 The project root exports one `defineCapabilityLibrary` value containing the
 literal default IDs `onboarding.create-welcome-message` and

--- a/docs/adr/0014-standalone-capability-project-creators.md
+++ b/docs/adr/0014-standalone-capability-project-creators.md
@@ -51,6 +51,8 @@ entry. The commands expose the same stable diagnostic codes:
 The atomic creator writes these fixed paths in lexicographic order:
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 README.md
 package.json
@@ -70,6 +72,8 @@ effective capability through `engine.invoke`.
 The library creator writes these fixed paths in lexicographic order:
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 AGENTS.md
 CLAUDE.md -> AGENTS.md
@@ -85,6 +89,10 @@ tsconfig.test.json
 
 `AGENTS.md` is a regular UTF-8 text file. `CLAUDE.md` is the relative symbolic
 link defined by ADR 0015 rather than a second text file.
+
+Each creator renders the project-specific `develop-invokta-project` workflow
+defined by ADR 0016. The atomic and library skills keep their distinct
+publication boundaries.
 
 The project root exports one `defineCapabilityLibrary` value containing the
 literal default IDs `onboarding.create-welcome-message` and

--- a/docs/adr/0014-standalone-capability-project-creators.md
+++ b/docs/adr/0014-standalone-capability-project-creators.md
@@ -1,0 +1,120 @@
+# ADR 0014: Standalone capability project creators
+
+- Status: Accepted
+- Date: 2026-07-29
+
+## Context
+
+Invokta documents two reusable publication forms outside an Action Engine: one
+atomic exported capability and one library containing a related set of
+capabilities. Authors can copy the repository example, but that example is a
+combined workspace fixture rather than a standalone project. The engine creator
+does not address these package boundaries because its generated project owns
+execution adapters and an engine composition root.
+
+Authors need bounded bootstrap commands for both publication forms without
+adding discovery, a registry, package publishing, or another capability
+execution path.
+
+## Decision
+
+Invokta publishes two additional native ESM packages:
+`create-invokta-capability` and `create-invokta-capability-library`. Each is a
+binary-only supporting application exposing an executable of the same name.
+This decision supersedes the seven-package count established by ADR 0012 and
+ADR 0004 while preserving their dependency direction and package isolation.
+
+The public command surfaces are:
+
+```text
+create-invokta-capability <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-capability --help
+create-invokta-capability --version
+
+create-invokta-capability-library <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-capability-library --help
+create-invokta-capability-library --version
+```
+
+Both commands are non-interactive and adopt the target, path, package-manager,
+installation, stream, exit-status, diagnostic, rollback, concurrency, and
+secret-hygiene contract of `create-invokta-engine`. In particular, targets are
+relative, empty, real directories; path arguments are limited to 1,024 Unicode
+scalars and 32 non-dot segments; the final project name is lowercase kebab-case
+and at most 214 characters; and exclusive writes never replace an existing
+entry. The commands expose the same stable diagnostic codes:
+`TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`, `SCAFFOLD_CONFLICT`,
+`WRITE_FAILED`, and `INSTALL_FAILED`.
+
+The atomic creator writes these fixed paths in lexicographic order:
+
+```text
+.gitignore
+README.md
+package.json
+src/capability.ts
+src/index.ts
+test/capability.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The project root exports one `defineExportedCapability` descriptor with the
+literal default ID `onboarding.create-welcome-message`. Its source name is the
+generated package name and its source version is `0.1.0`. The test imports the
+built project value explicitly, composes it into an engine, and invokes the
+effective capability through `engine.invoke`.
+
+The library creator writes these fixed paths in lexicographic order:
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-farewell-message.ts
+src/capabilities/create-welcome-message.ts
+src/index.ts
+test/library.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The project root exports one `defineCapabilityLibrary` value containing the
+literal default IDs `onboarding.create-welcome-message` and
+`onboarding.create-farewell-message`. Its library name is the generated package
+name and its version is `0.1.0`. The test imports a selected capability with an
+explicit remap, composes it into an engine, and invokes it through
+`engine.invoke`.
+
+Both generated manifests are private by default, declare one package-root ESM
+export, set `sideEffects` to `false`, and pin `@invokta/core` exactly to the
+creator version. They use the same pinned TypeScript, Vitest, Node type, and Zod
+versions as the engine creator. Removing `private`, choosing a globally valid
+package name, changing source metadata, changing default IDs, and publishing
+are deliberate author-owned changes. Generated files are user-owned and are
+never upgraded in place.
+
+The creators import no Invokta runtime package and perform no package discovery,
+composition, capability execution, adapter startup, registry access, or publish
+operation. Their only external process is the optional foreground package
+manager install. The creators themselves perform no network request.
+
+The packed acceptance boundary is the generated consumer. Each packed creator
+must generate a project that installs from packed release artifacts, type-checks,
+tests, builds, exposes only the documented root export, and composes through the
+public `@invokta/core` API.
+
+## Consequences
+
+- `npm create invokta-capability@latest my-capability` creates one standalone
+  atomic capability project.
+- `npm create invokta-capability-library@latest my-library` creates one
+  standalone capability-library project.
+- `create-invokta-library` is intentionally not published because “library”
+  does not identify the Invokta concept being generated.
+- Local capability files inside an existing engine remain author-owned; these
+  commands do not mutate an existing project.
+- Adding templates, interactive prompting, package publication, dependency
+  discovery, or in-place generation requires another architectural decision.

--- a/docs/adr/0015-generated-agent-instruction-aliases.md
+++ b/docs/adr/0015-generated-agent-instruction-aliases.md
@@ -1,0 +1,65 @@
+# ADR 0015: Generated agent instruction aliases
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+Invokta's engine and capability-library creators produce projects that require
+the same architectural and delivery constraints after generation. Agent tools
+commonly discover project instructions from either `AGENTS.md` or `CLAUDE.md`.
+Generating two independent instruction files would create immediate drift risk,
+while omitting either discovery name makes the starter less reliable across
+tools.
+
+The atomic capability creator remains a deliberately minimal package boundary.
+The requested project-level instructions apply to generated Action Engines and
+capability libraries, where composition and architectural constraints need to
+remain visible during subsequent development.
+
+## Decision
+
+`create-invokta-engine` and `create-invokta-capability-library` each add two
+root entries to their fixed starter:
+
+```text
+AGENTS.md
+CLAUDE.md -> AGENTS.md
+```
+
+`AGENTS.md` is a deterministic UTF-8 text file with LF endings and one trailing
+newline. It records the generated project's language, architecture or
+capability-contract boundaries, test-first delivery workflow, package-manager
+validation command, and the single-source instruction-file rule.
+
+`CLAUDE.md` is an actual symbolic link whose stored target is exactly the
+relative path `AGENTS.md`. It is not a copied file and does not use an absolute
+target. The relative link keeps the generated project relocatable and gives
+both discovery names one source of truth.
+
+The creators treat text files and symbolic links as one ordered scaffold-entry
+transaction. Both entry kinds use exclusive creation and never replace an
+existing filesystem entry. An `EEXIST` race while creating the link reports
+`SCAFFOLD_CONFLICT` for `CLAUDE.md` and preserves the racing entry. Any other
+link-creation failure reports `WRITE_FAILED`. Rollback unlinks only entries
+created by the current invocation; unlinking the symbolic link itself never
+follows its target.
+
+This decision extends the fixed path lists in ADR 0012 and the
+capability-library section of ADR 0014. It does not change the atomic
+`create-invokta-capability` scaffold.
+
+Release verification must inspect the generated filesystem rather than merely
+read through the alias: `AGENTS.md` must be a regular file, `CLAUDE.md` must be
+a symbolic link, and its stored target must equal `AGENTS.md`.
+
+## Consequences
+
+- Generated engines and capability libraries expose consistent instructions to
+  agent tools without maintaining duplicate content.
+- The creator filesystem boundary now supports one fixed relative symbolic-link
+  entry in addition to deterministic text files.
+- Platforms or filesystems that cannot create symbolic links fail safely with
+  `WRITE_FAILED`; the creators do not degrade to a copied instruction file.
+- Existing generated projects are not changed in place because scaffold output
+  remains user-owned after creation.

--- a/docs/adr/0016-generated-invokta-development-skills.md
+++ b/docs/adr/0016-generated-invokta-development-skills.md
@@ -1,0 +1,79 @@
+# ADR 0016: Generated Invokta development skills
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+The three project creators produce runnable examples and short READMEs, but an
+agent changing a generated project also needs the non-obvious Invokta workflow:
+which contracts are public, where dependencies enter, how composition differs
+between project types, and which execution boundary proves behavior.
+
+A single generic guide for every project type would blur important boundaries.
+An Action Engine owns execution adapters, an atomic capability publishes one
+descriptor, and a capability library publishes an ordered set of default IDs.
+The guidance must remain available to an agent without adding a runtime skill,
+plugin system, registry, or framework dependency.
+
+## Decision
+
+`create-invokta-engine`, `create-invokta-capability`, and
+`create-invokta-capability-library` each add this valid generated skill package:
+
+```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
+```
+
+The skill name is `develop-invokta-project`. `SKILL.md` contains only the
+required `name` and `description` YAML frontmatter fields, followed by concise
+imperative workflow instructions. `agents/openai.yaml` contains deterministic
+`display_name`, `short_description`, and `default_prompt` interface metadata.
+The default prompt explicitly names `$develop-invokta-project`. The skill has no
+scripts, references, assets, tool dependencies, or network behavior.
+
+Every variant instructs the agent to establish the public contract, follow RED,
+GREEN, REFACTOR, preserve the generated project's scope, and run the selected
+package manager's `check` command before completion.
+
+The Action Engine variant additionally requires domain-oriented capabilities,
+explicit schemas and access, engine-owned dependency injection, stable
+registration IDs, and one `engine.invoke` path for direct, CLI, and MCP entry
+points. It prohibits adapter-specific business logic and framework-wide
+registries or service locators.
+
+The atomic capability variant keeps the capability definition separate from its
+`defineExportedCapability` publication descriptor. It treats the default ID,
+source metadata, schemas, access rule, and package export as compatibility
+surfaces. Its acceptance workflow composes with `importCapability` and invokes
+through `engine.invoke`; it adds no adapter or engine entry point.
+
+The capability-library variant keeps each capability definition independent and
+publishes literal, ordered default IDs through `defineCapabilityLibrary`. It
+treats the library name, version, IDs, schemas, access rules, and package export
+as compatibility surfaces. Its acceptance workflow selects or remaps through
+`importCapabilities`, composes an engine, and invokes through `engine.invoke`;
+it adds no adapter, discovery, or registry behavior.
+
+The skill and its metadata are deterministic UTF-8 text entries governed by the
+existing exclusive-write and rollback contract. They are guidance for changing
+the generated project and never execute, import the project, call a capability,
+or alter the Invokta runtime architecture. Template changes affect only future
+generated projects; all generated skill files become user-owned immediately.
+
+Release verification must inspect all three packed creator outputs, validate
+the skill structure, reject unresolved template placeholders, and confirm the
+project-type boundary named by each variant.
+
+## Consequences
+
+- An agent entering any generated project can discover a focused Invokta
+  development workflow without first knowing the framework documentation.
+- All three creators add two nested deterministic text files and their parent
+  directories to the existing scaffold transaction.
+- The shared skill name provides one invocation convention while tailored
+  content prevents execution-adapter guidance from leaking into capability
+  packages.
+- The generated skill is not an Invokta runtime primitive and creates no new
+  extension, discovery, or execution mechanism.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0011](0011-http-engine-deploy-toolkit.md) | HTTP engine deployment toolkit | Accepted | 2026-07-28 |
 | [0012](0012-standalone-invokta-engine-creator.md) | Standalone Invokta engine creator | Accepted | 2026-07-29 |
 | [0013](0013-action-engine-mcp-installation-and-management.md) | Action Engine MCP installation and management | Accepted | 2026-07-29 |
+| [0014](0014-standalone-capability-project-creators.md) | Standalone capability project creators | Accepted | 2026-07-29 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0013](0013-action-engine-mcp-installation-and-management.md) | Action Engine MCP installation and management | Accepted | 2026-07-29 |
 | [0014](0014-standalone-capability-project-creators.md) | Standalone capability project creators | Accepted | 2026-07-29 |
 | [0015](0015-generated-agent-instruction-aliases.md) | Generated agent instruction aliases | Accepted | 2026-07-30 |
+| [0016](0016-generated-invokta-development-skills.md) | Generated Invokta development skills | Accepted | 2026-07-30 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0012](0012-standalone-invokta-engine-creator.md) | Standalone Invokta engine creator | Accepted | 2026-07-29 |
 | [0013](0013-action-engine-mcp-installation-and-management.md) | Action Engine MCP installation and management | Accepted | 2026-07-29 |
 | [0014](0014-standalone-capability-project-creators.md) | Standalone capability project creators | Accepted | 2026-07-29 |
+| [0015](0015-generated-agent-instruction-aliases.md) | Generated agent instruction aliases | Accepted | 2026-07-30 |

--- a/docs/implementation-plan-and-acceptance-criteria.md
+++ b/docs/implementation-plan-and-acceptance-criteria.md
@@ -44,9 +44,10 @@ persistence, configuration field, or operational limit:
 
 Supporting packages require focused contract tests for their own authority:
 engine, atomic capability, and capability-library creator scaffolds remain
-deterministic, non-overwriting, and independently buildable; generated
-capability packages compose only through the public core API; composition
-diagnostics remain deterministic and payload-free;
+deterministic, non-overwriting, and independently buildable; every creator
+emits a valid project-specific development skill; generated capability packages
+compose only through the public core API; composition diagnostics remain
+deterministic and payload-free;
 installer writes remain confirmed, atomic, reversible, and secret-free; deploy
 outputs remain deterministic, marked, and non-destructive; and every published
 tarball passes an isolated consumer smoke test.

--- a/docs/implementation-plan-and-acceptance-criteria.md
+++ b/docs/implementation-plan-and-acceptance-criteria.md
@@ -43,8 +43,10 @@ persistence, configuration field, or operational limit:
 | `AE-SCOPE-01..04`, `AE-LIMIT-01..05` | Manifest and API review prove package roles and the absence of deferred abstractions |
 
 Supporting packages require focused contract tests for their own authority:
-creator scaffolds remain deterministic, non-overwriting, and independently
-buildable; composition diagnostics remain deterministic and payload-free;
+engine, atomic capability, and capability-library creator scaffolds remain
+deterministic, non-overwriting, and independently buildable; generated
+capability packages compose only through the public core API; composition
+diagnostics remain deterministic and payload-free;
 installer writes remain confirmed, atomic, reversible, and secret-free; deploy
 outputs remain deterministic, marked, and non-destructive; and every published
 tarball passes an isolated consumer smoke test.

--- a/docs/scope-and-limits.md
+++ b/docs/scope-and-limits.md
@@ -2,7 +2,7 @@
 
 ## Public packages
 
-**AE-SCOPE-01 — Seven packages with isolated roles.** Invokta publishes:
+**AE-SCOPE-01 — Nine packages with isolated roles.** Invokta publishes:
 
 | Package | Responsibility |
 | --- | --- |
@@ -13,6 +13,8 @@
 | `@invokta/installer` | End-user configuration of supported local MCP clients |
 | `@invokta/deploy` | Development-time HTTP engine scaffolding, packaging, and probing |
 | `create-invokta-engine` | Creation of a standalone starter Action Engine |
+| `create-invokta-capability` | Creation of a standalone atomic capability package |
+| `create-invokta-capability-library` | Creation of a standalone capability-library package |
 
 All packages are native ESM. The core has no transport dependency. Runtime
 adapters depend only on the core's public API, and supporting applications do
@@ -38,7 +40,7 @@ useful.
 | Dimension | Limit |
 | --- | --- |
 | Framework runtime packages | 3: core, CLI, and MCP |
-| Supporting packages | 4: tooling, installer, deploy, and engine creator |
+| Supporting packages | 6: tooling, installer, deploy, and three project creators |
 | Official adapters | CLI and MCP |
 | MCP transports | stdio and stateless Streamable HTTP |
 | Core primitives | Capability, Engine, Context, and Principal |

--- a/docs/scope-matrix.md
+++ b/docs/scope-matrix.md
@@ -24,14 +24,14 @@ belongs in Invokta, a custom engine, or a later evidence-driven package.
 | AI implementation | Keep implementation replaceable | Own prompts, models, retrieval, tools, evidence, and risk controls | Provider SDKs, prompt registry, RAG abstraction, or memory |
 | Quality | Validate contracts and provide testable direct execution | Own fixtures, evals, regression suites, and human review | Eval runner, automated judge, or canary platform |
 | Capability reuse | Eager explicit composition with deterministic collision detection | Choose imports, effective IDs, and trusted dependencies | Runtime plugin marketplace or remote discovery |
-| Supporting tools | Engine creator, composition checker, MCP client installer, and deployment generator | Review generated files and own local or deployment authority | Autonomous installation or deployment service |
+| Supporting tools | Engine and capability-package creators, composition checker, MCP client installer, and deployment generator | Review generated files and own local, package, or deployment authority | Autonomous publishing, installation, or deployment service |
 
 ## Fixed limits
 
 | Dimension | Limit |
 | --- | --- |
 | Framework runtime packages | 3 |
-| Supporting packages | 4 |
+| Supporting packages | 6 |
 | Official adapters | 2: CLI and MCP |
 | MCP transports | 2: stdio and stateless Streamable HTTP |
 | Core primitives | 4: Capability, Engine, Context, Principal |

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,8 +1,8 @@
 # Validation record
 
 - Last reviewed: 2026-07-29
-- Public API changes: Action Engine creator installation scaffold and installer
-  CLI commands accepted in ADR 0013
+- Public API changes: standalone atomic capability and capability-library
+  creators accepted in ADR 0014
 
 ## Reuse evidence
 
@@ -34,12 +34,15 @@ consumer can use the protocol surface without coupling to engine code.
   creates no cross-request session state.
 - Capability composition preserves explicit imports and fails deterministically
   on effective-ID collisions.
-- The installer and deploy packages remain outside the capability call graph and
-  exercise only their documented local configuration and generation authority.
+- The creators, installer, and deploy packages remain outside the capability
+  call graph and exercise only their documented project creation, local
+  configuration, and generation authority.
 - Packed creator smoke tests build a generated engine and exercise its
-  `mcp:install` path; installer tests cover local manifests, remote descriptors,
-  multi-client transactions, lifecycle management, eleven target adapters, and
-  forbidden process, network, and write sentinels.
+  `mcp:install` path. They also build generated atomic and library packages,
+  compose their public root exports through `@invokta/core`, and invoke them
+  through `engine.invoke`. Installer tests cover local manifests, remote
+  descriptors, multi-client transactions, lifecycle management, eleven target
+  adapters, and forbidden process, network, and write sentinels.
 
 ## Ownership conclusions
 

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -3,7 +3,8 @@
 - Last reviewed: 2026-07-30
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
-  instruction aliases accepted in ADR 0015
+  instruction aliases accepted in ADR 0015; generated development skills
+  accepted in ADR 0016
 
 ## Reuse evidence
 
@@ -41,12 +42,14 @@ consumer can use the protocol surface without coupling to engine code.
 - Packed creator smoke tests build a generated engine and exercise its
   `mcp:install` path. They verify that generated engine and capability-library
   projects contain a regular `AGENTS.md`, a symbolic-link `CLAUDE.md`, and the
-  exact relative target `AGENTS.md`. They also build generated atomic and
-  library packages, compose their public root exports through `@invokta/core`,
-  and invoke them through `engine.invoke`. Installer tests cover local
-  manifests, remote descriptors, multi-client transactions, lifecycle
-  management, eleven target adapters, and forbidden process, network, and
-  write sentinels.
+  exact relative target `AGENTS.md`. All three generated project types contain
+  a valid `develop-invokta-project` skill with tailored contract and composition
+  guidance and deterministic UI metadata. Packed tests also build generated
+  atomic and library packages, compose their public root exports through
+  `@invokta/core`, and invoke them through `engine.invoke`. Installer tests
+  cover local manifests, remote descriptors, multi-client transactions,
+  lifecycle management, eleven target adapters, and forbidden process,
+  network, and write sentinels.
 
 ## Ownership conclusions
 

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,8 +1,9 @@
 # Validation record
 
-- Last reviewed: 2026-07-29
+- Last reviewed: 2026-07-30
 - Public API changes: standalone atomic capability and capability-library
-  creators accepted in ADR 0014
+  creators accepted in ADR 0014; engine and capability-library agent
+  instruction aliases accepted in ADR 0015
 
 ## Reuse evidence
 
@@ -38,11 +39,14 @@ consumer can use the protocol surface without coupling to engine code.
   call graph and exercise only their documented project creation, local
   configuration, and generation authority.
 - Packed creator smoke tests build a generated engine and exercise its
-  `mcp:install` path. They also build generated atomic and library packages,
-  compose their public root exports through `@invokta/core`, and invoke them
-  through `engine.invoke`. Installer tests cover local manifests, remote
-  descriptors, multi-client transactions, lifecycle management, eleven target
-  adapters, and forbidden process, network, and write sentinels.
+  `mcp:install` path. They verify that generated engine and capability-library
+  projects contain a regular `AGENTS.md`, a symbolic-link `CLAUDE.md`, and the
+  exact relative target `AGENTS.md`. They also build generated atomic and
+  library packages, compose their public root exports through `@invokta/core`,
+  and invoke them through `engine.invoke`. Installer tests cover local
+  manifests, remote descriptors, multi-client transactions, lifecycle
+  management, eleven target adapters, and forbidden process, network, and
+  write sentinels.
 
 ## Ownership conclusions
 

--- a/packages/create-invokta-capability-library/LICENSE
+++ b/packages/create-invokta-capability-library/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vini Lana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-invokta-capability-library/README.md
+++ b/packages/create-invokta-capability-library/README.md
@@ -1,0 +1,61 @@
+# create-invokta-capability-library
+
+Create a standalone TypeScript package that publishes a related set of Invokta
+capabilities through `defineCapabilityLibrary`.
+
+## Commands
+
+```text
+create-invokta-capability-library <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-capability-library --help
+create-invokta-capability-library --version
+```
+
+The npm initializer shorthand resolves to this package:
+
+```sh
+npm create invokta-capability-library@latest my-library
+```
+
+Creation is non-interactive. The target must be a relative absent or empty real
+directory. Existing files and symbolic-link path components are refused and
+never overwritten.
+
+The invoking package manager is inferred from `npm_config_user_agent`, with npm
+as the fallback. Use `--package-manager` to choose explicitly or `--no-install`
+to generate files without starting a package manager or performing network I/O.
+
+## Generated project
+
+```text
+.gitignore
+README.md
+package.json
+src/capabilities/create-farewell-message.ts
+src/capabilities/create-welcome-message.ts
+src/index.ts
+test/library.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The private ESM starter pins `@invokta/core` to the creator version and exports
+one deterministic example library. Its test selects and remaps one capability,
+then invokes it through `engine.invoke`. Generated files are project-owned and
+are never updated in place.
+
+The creator does not publish the package, discover dependencies, start an
+adapter, or execute a capability.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Arguments, project path, or project name were invalid |
+
+Creator diagnostics use `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, or `INSTALL_FAILED`. Rejected arguments,
+environment values, child errors, stacks, and causes are not included.

--- a/packages/create-invokta-capability-library/README.md
+++ b/packages/create-invokta-capability-library/README.md
@@ -29,6 +29,8 @@ to generate files without starting a package manager or performing network I/O.
 ## Generated project
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 AGENTS.md
 CLAUDE.md -> AGENTS.md
@@ -41,6 +43,12 @@ test/library.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+The generated `develop-invokta-project` skill teaches an agent to preserve
+literal default IDs and the library publication boundary, evolve contracts with
+RED/GREEN/REFACTOR, and prove selection and remapping through
+`importCapabilities` and `engine.invoke`. Its metadata includes a ready-to-use
+`$develop-invokta-project` prompt.
 
 `AGENTS.md` documents the starter's capability-contract and test-first delivery
 constraints. `CLAUDE.md` is a real relative symbolic link to that file, keeping

--- a/packages/create-invokta-capability-library/README.md
+++ b/packages/create-invokta-capability-library/README.md
@@ -30,6 +30,8 @@ to generate files without starting a package manager or performing network I/O.
 
 ```text
 .gitignore
+AGENTS.md
+CLAUDE.md -> AGENTS.md
 README.md
 package.json
 src/capabilities/create-farewell-message.ts
@@ -40,10 +42,15 @@ tsconfig.json
 tsconfig.test.json
 ```
 
+`AGENTS.md` documents the starter's capability-contract and test-first delivery
+constraints. `CLAUDE.md` is a real relative symbolic link to that file, keeping
+agent instructions in one source of truth. If the filesystem cannot create the
+link, creation fails and rolls back instead of copying the instructions.
+
 The private ESM starter pins `@invokta/core` to the creator version and exports
 one deterministic example library. Its test selects and remaps one capability,
-then invokes it through `engine.invoke`. Generated files are project-owned and
-are never updated in place.
+then invokes it through `engine.invoke`. Generated entries are project-owned
+and are never updated in place.
 
 The creator does not publish the package, discover dependencies, start an
 adapter, or execute a capability.

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "create-invokta-capability-library",
+  "version": "0.2.0",
+  "description": "Create a standalone Invokta capability-library package.",
+  "author": "Vini Lana <vini@aicoders.academy>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vinilana/invokta.git",
+    "directory": "packages/create-invokta-capability-library"
+  },
+  "homepage": "https://docs.invokta.dev/reference/create-invokta-capability-library/",
+  "bugs": {
+    "url": "https://github.com/vinilana/invokta/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {},
+  "bin": {
+    "create-invokta-capability-library": "./dist/bin.js"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "prepack": "npm run --silent build"
+  }
+}

--- a/packages/create-invokta-capability-library/src/bin.ts
+++ b/packages/create-invokta-capability-library/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCreateCapabilityLibraryCli } from "./cli.js";
+
+// The composition root owns process status so buffered terminal output can flush.
+process.exitCode = await runCreateCapabilityLibraryCli();

--- a/packages/create-invokta-capability-library/src/cli.ts
+++ b/packages/create-invokta-capability-library/src/cli.ts
@@ -1,0 +1,210 @@
+import { CreatorError, renderCreatorDiagnostic } from "./errors.js";
+import { installProjectDependencies, selectPackageManager } from "./install.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+import { createStarterProject } from "./scaffold.js";
+
+const commandName = "create-invokta-capability-library";
+const helpText = `Usage:
+  ${commandName} <project-directory>
+    [--package-manager npm|pnpm|yarn] [--no-install]
+  ${commandName} --help
+  ${commandName} --version
+`;
+const invalidUsageText = `Invalid arguments. Run "${commandName} --help".\n`;
+const unexpectedFailureText = "The project could not be created.\n";
+
+export interface CreateCapabilityLibraryIo {
+  readonly writeStdout: (text: string) => void | Promise<void>;
+  readonly writeStderr: (text: string) => void | Promise<void>;
+}
+
+const defaultIo: CreateCapabilityLibraryIo = Object.freeze({
+  writeStdout(text: string) {
+    process.stdout.write(text);
+  },
+  writeStderr(text: string) {
+    process.stderr.write(text);
+  },
+});
+
+export interface InstallProjectOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+}
+
+export type InstallProject = (options: InstallProjectOptions) => Promise<void>;
+
+export interface RunCreateCapabilityLibraryCliOptions {
+  readonly argv?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly io?: CreateCapabilityLibraryIo;
+  readonly install?: InstallProject;
+  readonly loadPackageVersion?: () => Promise<string>;
+}
+
+interface CreateArguments {
+  readonly target: string;
+  readonly packageManager?: PackageManager;
+  readonly noInstall: boolean;
+}
+
+function parseCreateArguments(
+  args: readonly string[],
+): CreateArguments | undefined {
+  let target: string | undefined;
+  let packageManager: PackageManager | undefined;
+  let packageManagerSeen = false;
+  let noInstall = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--no-install") {
+      if (noInstall) return undefined;
+      noInstall = true;
+      continue;
+    }
+    if (argument === "--package-manager") {
+      if (packageManagerSeen) return undefined;
+      packageManagerSeen = true;
+      const value = args[index + 1];
+      if (value === undefined || !isPackageManager(value)) return undefined;
+      packageManager = value;
+      index += 1;
+      continue;
+    }
+    if (
+      argument === undefined ||
+      argument.startsWith("-") ||
+      target !== undefined
+    ) {
+      return undefined;
+    }
+    target = argument;
+  }
+
+  if (target === undefined) return undefined;
+  return {
+    target,
+    ...(packageManager === undefined ? {} : { packageManager }),
+    noInstall,
+  };
+}
+
+function asRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  return value as Readonly<Record<string, unknown>>;
+}
+
+async function loadDefaultPackageVersion(): Promise<string> {
+  const manifestUrl = new URL("../package.json", import.meta.url);
+  const namespace = (await import(manifestUrl.href, {
+    with: { type: "json" },
+  })) as unknown;
+  const version = asRecord(asRecord(namespace)?.default)?.version;
+  if (typeof version !== "string" || version === "") {
+    throw new Error("The package version is unreadable.");
+  }
+  return version;
+}
+
+async function writeDiagnostic(
+  io: CreateCapabilityLibraryIo,
+  text: string,
+): Promise<void> {
+  try {
+    await io.writeStderr(text);
+  } catch {
+    // A broken diagnostic stream does not replace the command's numeric result.
+  }
+}
+
+function renderSuccess(
+  projectName: string,
+  packageManager: PackageManager,
+  noInstall: boolean,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  if (noInstall) {
+    return (
+      `Created ${projectName} without installing dependencies.\n\n` +
+      "Next steps:\n" +
+      `  ${commands.installDisplay}\n` +
+      `  ${commands.check}\n`
+    );
+  }
+  return `Created ${projectName}.\n\nNext step:\n  ${commands.check}\n`;
+}
+
+/** Runs the binary command and returns its exit status without exiting. */
+export async function runCreateCapabilityLibraryCli(
+  options: RunCreateCapabilityLibraryCliOptions = {},
+): Promise<0 | 1 | 2> {
+  const argv = options.argv ?? process.argv.slice(2);
+  const io = options.io ?? defaultIo;
+  const [first, ...rest] = argv;
+
+  if (first === "--help" || first === "--version") {
+    if (rest.length > 0) {
+      await writeDiagnostic(io, invalidUsageText);
+      return 2;
+    }
+    try {
+      const output =
+        first === "--help"
+          ? helpText
+          : `${await (options.loadPackageVersion ?? loadDefaultPackageVersion)()}\n`;
+      await io.writeStdout(output);
+      return 0;
+    } catch {
+      await writeDiagnostic(io, unexpectedFailureText);
+      return 1;
+    }
+  }
+
+  const parsed = parseCreateArguments(argv);
+  if (parsed === undefined) {
+    await writeDiagnostic(io, invalidUsageText);
+    return 2;
+  }
+
+  const environment = options.env ?? process.env;
+  const packageManager = selectPackageManager(
+    parsed.packageManager,
+    environment.npm_config_user_agent,
+  );
+  try {
+    const invoktaVersion = await (
+      options.loadPackageVersion ?? loadDefaultPackageVersion
+    )();
+    const project = await createStarterProject({
+      cwd: options.cwd ?? process.cwd(),
+      target: parsed.target,
+      invoktaVersion,
+      packageManager,
+    });
+    if (!parsed.noInstall) {
+      await (options.install ?? installProjectDependencies)({
+        directory: project.directory,
+        packageManager,
+      });
+    }
+    await io.writeStdout(
+      renderSuccess(project.projectName, packageManager, parsed.noInstall),
+    );
+    return 0;
+  } catch (error) {
+    if (error instanceof CreatorError) {
+      await writeDiagnostic(io, renderCreatorDiagnostic(error));
+      return error.exitCode;
+    }
+    await writeDiagnostic(io, unexpectedFailureText);
+    return 1;
+  }
+}

--- a/packages/create-invokta-capability-library/src/errors.ts
+++ b/packages/create-invokta-capability-library/src/errors.ts
@@ -1,0 +1,43 @@
+export const creatorErrorMessages = Object.freeze({
+  TARGET_INVALID: "The project path or name is invalid.",
+  TARGET_UNSAFE: "The project target is unsafe to use.",
+  TARGET_NOT_EMPTY: "The project target is not empty.",
+  SCAFFOLD_CONFLICT: "A scaffold file appeared during creation.",
+  WRITE_FAILED: "The project scaffold could not be written.",
+  INSTALL_FAILED: "The project dependencies could not be installed.",
+} as const);
+
+export type CreatorErrorCode = keyof typeof creatorErrorMessages;
+export type CreatorExitCode = 0 | 1 | 2;
+
+const creatorErrorExitCodes = Object.freeze({
+  TARGET_INVALID: 2,
+  TARGET_UNSAFE: 1,
+  TARGET_NOT_EMPTY: 1,
+  SCAFFOLD_CONFLICT: 1,
+  WRITE_FAILED: 1,
+  INSTALL_FAILED: 1,
+} as const) satisfies Readonly<Record<CreatorErrorCode, CreatorExitCode>>;
+
+/** A sanitized creator failure. It intentionally stores no cause or raw input. */
+export class CreatorError extends Error {
+  readonly code: CreatorErrorCode;
+  readonly exitCode: CreatorExitCode;
+  readonly details: readonly string[];
+
+  constructor(code: CreatorErrorCode, details: readonly string[] = []) {
+    super(creatorErrorMessages[code]);
+    this.name = "CreatorError";
+    this.code = code;
+    this.exitCode = creatorErrorExitCodes[code];
+    this.details = Object.freeze([...details]);
+  }
+}
+
+export function renderCreatorDiagnostic(error: CreatorError): string {
+  const lines = [
+    `${error.code}: ${creatorErrorMessages[error.code]}`,
+    ...error.details.map((detail) => `  ${detail}`),
+  ];
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/create-invokta-capability-library/src/install.ts
+++ b/packages/create-invokta-capability-library/src/install.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+import { CreatorError } from "./errors.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+
+export interface PackageManagerRunOptions {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly shell: false;
+  readonly stdio: "inherit";
+}
+
+export interface PackageManagerRunResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export type PackageManagerRunner = (
+  options: PackageManagerRunOptions,
+) => Promise<PackageManagerRunResult>;
+
+export const defaultPackageManagerRunner: PackageManagerRunner = (options) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(options.command, [...options.args], {
+      cwd: options.cwd,
+      shell: options.shell,
+      stdio: options.stdio,
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+
+export function selectPackageManager(
+  explicit: PackageManager | undefined,
+  userAgent: string | undefined,
+): PackageManager {
+  if (explicit !== undefined) return explicit;
+  const candidate = userAgent?.split(/\s/u, 1)[0]?.split("/", 1)[0];
+  return candidate !== undefined && isPackageManager(candidate)
+    ? candidate
+    : "npm";
+}
+
+export interface InstallProjectDependenciesOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+  readonly runner?: PackageManagerRunner;
+}
+
+/** Runs the one foreground package-manager install authorized by ADR 0014. */
+export async function installProjectDependencies(
+  options: InstallProjectDependenciesOptions,
+): Promise<void> {
+  const commands = packageManagerCommands[options.packageManager];
+  let result: PackageManagerRunResult;
+  try {
+    result = await (options.runner ?? defaultPackageManagerRunner)({
+      command: commands.installExecutable,
+      args: commands.installArguments,
+      cwd: options.directory,
+      shell: false,
+      stdio: "inherit",
+    });
+  } catch {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+  if (result.code !== 0) {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+}

--- a/packages/create-invokta-capability-library/src/package-manager.ts
+++ b/packages/create-invokta-capability-library/src/package-manager.ts
@@ -1,0 +1,39 @@
+export type PackageManager = "npm" | "pnpm" | "yarn";
+
+export interface PackageManagerCommands {
+  readonly installExecutable: PackageManager;
+  readonly installArguments: readonly string[];
+  readonly installDisplay: string;
+  readonly check: string;
+}
+
+export const packageManagerCommands = Object.freeze({
+  npm: Object.freeze({
+    installExecutable: "npm",
+    installArguments: Object.freeze(["install", "--no-audit", "--no-fund"]),
+    installDisplay: "npm install --no-audit --no-fund",
+    check: "npm run check",
+  }),
+  pnpm: Object.freeze({
+    installExecutable: "pnpm",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "pnpm install",
+    check: "pnpm run check",
+  }),
+  yarn: Object.freeze({
+    installExecutable: "yarn",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "yarn install",
+    check: "yarn run check",
+  }),
+} as const) satisfies Readonly<Record<PackageManager, PackageManagerCommands>>;
+
+export const packageManagers = Object.freeze([
+  "npm",
+  "pnpm",
+  "yarn",
+] as const satisfies readonly PackageManager[]);
+
+export function isPackageManager(value: string): value is PackageManager {
+  return packageManagers.some((manager) => manager === value);
+}

--- a/packages/create-invokta-capability-library/src/scaffold.ts
+++ b/packages/create-invokta-capability-library/src/scaffold.ts
@@ -1,0 +1,318 @@
+import type { Stats } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  rmdir,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
+
+import { CreatorError } from "./errors.js";
+import type { PackageManager } from "./package-manager.js";
+import { createStarterFiles, type StarterFile } from "./starter.js";
+
+export const creatorTargetLimits = Object.freeze({
+  maxPathScalars: 1_024,
+  maxPathSegments: 32,
+  maxProjectNameCharacters: 214,
+});
+
+const projectNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export interface ScaffoldFileSystem {
+  readonly lstat: (path: string) => Promise<Stats>;
+  readonly mkdir: (path: string) => Promise<void>;
+  readonly readdir: (path: string) => Promise<string[]>;
+  readonly rmdir: (path: string) => Promise<void>;
+  readonly unlink: (path: string) => Promise<void>;
+  readonly writeFile: (
+    path: string,
+    contents: string,
+    options: Readonly<{ encoding: "utf8"; flag: "wx" }>,
+  ) => Promise<void>;
+}
+
+const nodeScaffoldFileSystem: ScaffoldFileSystem = {
+  lstat,
+  async mkdir(path) {
+    await mkdir(path);
+  },
+  async readdir(path) {
+    return readdir(path);
+  },
+  async rmdir(path) {
+    await rmdir(path);
+  },
+  async unlink(path) {
+    await unlink(path);
+  },
+  async writeFile(path, contents, options) {
+    await writeFile(path, contents, options);
+  },
+};
+
+export const defaultScaffoldFileSystem: ScaffoldFileSystem = Object.freeze(
+  nodeScaffoldFileSystem,
+);
+
+export interface CreateStarterProjectOptions {
+  readonly cwd: string;
+  readonly target: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+  readonly fileSystem?: ScaffoldFileSystem;
+}
+
+export interface StarterProject {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly files: readonly string[];
+}
+
+interface ResolvedTarget {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly segments: readonly string[];
+}
+
+function countScalars(value: string): number {
+  let count = 0;
+  for (const _ of value) count += 1;
+  return count;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function invalidTarget(): never {
+  throw new CreatorError("TARGET_INVALID");
+}
+
+function resolveTarget(cwd: string, target: string): ResolvedTarget {
+  if (
+    target === "" ||
+    target.includes("\u0000") ||
+    countScalars(target) > creatorTargetLimits.maxPathScalars ||
+    isAbsolute(target) ||
+    win32.isAbsolute(target)
+  ) {
+    return invalidTarget();
+  }
+
+  const rawSegments = target.split(/[\\/]/u);
+  if (target !== "." && rawSegments.some((segment) => segment === "")) {
+    return invalidTarget();
+  }
+  const segments = rawSegments.filter((segment) => segment !== ".");
+  if (
+    segments.some((segment) => segment === "..") ||
+    segments.length > creatorTargetLimits.maxPathSegments
+  ) {
+    return invalidTarget();
+  }
+
+  const directory =
+    segments.length === 0 ? resolve(cwd) : resolve(cwd, ...segments);
+  const projectName = basename(directory);
+  if (
+    projectName.length === 0 ||
+    projectName.length > creatorTargetLimits.maxProjectNameCharacters ||
+    !projectNamePattern.test(projectName)
+  ) {
+    return invalidTarget();
+  }
+  return { directory, projectName, segments };
+}
+
+async function readStatus(
+  fileSystem: ScaffoldFileSystem,
+  path: string,
+): Promise<Stats | undefined> {
+  try {
+    return await fileSystem.lstat(path);
+  } catch (error) {
+    const code = readErrorCode(error);
+    if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+}
+
+async function inspectTarget(
+  cwd: string,
+  target: ResolvedTarget,
+  fileSystem: ScaffoldFileSystem,
+): Promise<void> {
+  let current = resolve(cwd);
+  if (target.segments.length === 0) {
+    const status = await readStatus(fileSystem, current);
+    if (
+      status === undefined ||
+      status.isSymbolicLink() ||
+      !status.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  } else {
+    for (const segment of target.segments) {
+      current = join(current, segment);
+      const status = await readStatus(fileSystem, current);
+      if (status === undefined) return;
+      if (status.isSymbolicLink() || !status.isDirectory()) {
+        throw new CreatorError("TARGET_UNSAFE");
+      }
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await fileSystem.readdir(target.directory);
+  } catch {
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+  if (entries.length > 0) throw new CreatorError("TARGET_NOT_EMPTY");
+}
+
+async function ensureDirectory(
+  path: string,
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  const status = await readStatus(fileSystem, path);
+  if (status !== undefined) {
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+    return;
+  }
+  try {
+    await fileSystem.mkdir(path);
+    createdDirectories.push(path);
+  } catch (error) {
+    if (readErrorCode(error) !== "EEXIST") {
+      throw new CreatorError("WRITE_FAILED");
+    }
+    const racedStatus = await readStatus(fileSystem, path);
+    if (
+      racedStatus === undefined ||
+      racedStatus.isSymbolicLink() ||
+      !racedStatus.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  }
+}
+
+async function prepareDirectories(
+  cwd: string,
+  target: ResolvedTarget,
+  files: readonly StarterFile[],
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  let current = resolve(cwd);
+  for (const segment of target.segments) {
+    current = join(current, segment);
+    await ensureDirectory(current, fileSystem, createdDirectories);
+  }
+  for (const directory of new Set(
+    files
+      .map((file) => dirname(file.path))
+      .filter((path) => path !== ".")
+      .sort(),
+  )) {
+    let nested = target.directory;
+    for (const segment of directory.split("/")) {
+      nested = join(nested, segment);
+      await ensureDirectory(nested, fileSystem, createdDirectories);
+    }
+  }
+}
+
+async function rollback(
+  fileSystem: ScaffoldFileSystem,
+  createdFiles: readonly string[],
+  createdDirectories: readonly string[],
+): Promise<boolean> {
+  let failed = false;
+  for (const path of [...createdFiles].reverse()) {
+    try {
+      await fileSystem.unlink(path);
+    } catch (error) {
+      if (readErrorCode(error) !== "ENOENT") failed = true;
+    }
+  }
+  for (const path of [...createdDirectories].reverse()) {
+    try {
+      await fileSystem.rmdir(path);
+    } catch (error) {
+      const code = readErrorCode(error);
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") failed = true;
+    }
+  }
+  return !failed;
+}
+
+/** Creates the fixed starter without installing dependencies or replacing files. */
+export async function createStarterProject(
+  options: CreateStarterProjectOptions,
+): Promise<StarterProject> {
+  const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
+  const target = resolveTarget(options.cwd, options.target);
+  await inspectTarget(options.cwd, target, fileSystem);
+  const files = createStarterFiles({
+    projectName: target.projectName,
+    invoktaVersion: options.invoktaVersion,
+    packageManager: options.packageManager,
+  });
+  const createdFiles: string[] = [];
+  const createdDirectories: string[] = [];
+  let activeFile: StarterFile | undefined;
+
+  try {
+    await prepareDirectories(
+      options.cwd,
+      target,
+      files,
+      fileSystem,
+      createdDirectories,
+    );
+    for (const file of files) {
+      activeFile = file;
+      const path = join(target.directory, ...file.path.split("/"));
+      await fileSystem.writeFile(path, file.contents, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      createdFiles.push(path);
+    }
+  } catch (error) {
+    const rolledBack = await rollback(
+      fileSystem,
+      createdFiles,
+      createdDirectories,
+    );
+    if (!rolledBack) throw new CreatorError("WRITE_FAILED");
+    if (error instanceof CreatorError) throw error;
+    if (readErrorCode(error) === "EEXIST") {
+      throw new CreatorError(
+        "SCAFFOLD_CONFLICT",
+        activeFile === undefined ? [] : [activeFile.path],
+      );
+    }
+    throw new CreatorError(
+      "WRITE_FAILED",
+      activeFile === undefined ? [] : [activeFile.path],
+    );
+  }
+
+  return Object.freeze({
+    directory: target.directory,
+    projectName: target.projectName,
+    files: Object.freeze(files.map((file) => file.path)),
+  });
+}

--- a/packages/create-invokta-capability-library/src/scaffold.ts
+++ b/packages/create-invokta-capability-library/src/scaffold.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   readdir,
   rmdir,
+  symlink,
   unlink,
   writeFile,
 } from "node:fs/promises";
@@ -11,7 +12,7 @@ import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
 
 import { CreatorError } from "./errors.js";
 import type { PackageManager } from "./package-manager.js";
-import { createStarterFiles, type StarterFile } from "./starter.js";
+import { createStarterFiles, type StarterEntry } from "./starter.js";
 
 export const creatorTargetLimits = Object.freeze({
   maxPathScalars: 1_024,
@@ -26,6 +27,7 @@ export interface ScaffoldFileSystem {
   readonly mkdir: (path: string) => Promise<void>;
   readonly readdir: (path: string) => Promise<string[]>;
   readonly rmdir: (path: string) => Promise<void>;
+  readonly symlink: (target: string, path: string) => Promise<void>;
   readonly unlink: (path: string) => Promise<void>;
   readonly writeFile: (
     path: string,
@@ -44,6 +46,9 @@ const nodeScaffoldFileSystem: ScaffoldFileSystem = {
   },
   async rmdir(path) {
     await rmdir(path);
+  },
+  async symlink(target, path) {
+    await symlink(target, path);
   },
   async unlink(path) {
     await unlink(path);
@@ -210,7 +215,7 @@ async function ensureDirectory(
 async function prepareDirectories(
   cwd: string,
   target: ResolvedTarget,
-  files: readonly StarterFile[],
+  entries: readonly StarterEntry[],
   fileSystem: ScaffoldFileSystem,
   createdDirectories: string[],
 ): Promise<void> {
@@ -220,8 +225,8 @@ async function prepareDirectories(
     await ensureDirectory(current, fileSystem, createdDirectories);
   }
   for (const directory of new Set(
-    files
-      .map((file) => dirname(file.path))
+    entries
+      .map((entry) => dirname(entry.path))
       .filter((path) => path !== ".")
       .sort(),
   )) {
@@ -235,11 +240,11 @@ async function prepareDirectories(
 
 async function rollback(
   fileSystem: ScaffoldFileSystem,
-  createdFiles: readonly string[],
+  createdEntries: readonly string[],
   createdDirectories: readonly string[],
 ): Promise<boolean> {
   let failed = false;
-  for (const path of [...createdFiles].reverse()) {
+  for (const path of [...createdEntries].reverse()) {
     try {
       await fileSystem.unlink(path);
     } catch (error) {
@@ -264,36 +269,40 @@ export async function createStarterProject(
   const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
   const target = resolveTarget(options.cwd, options.target);
   await inspectTarget(options.cwd, target, fileSystem);
-  const files = createStarterFiles({
+  const entries = createStarterFiles({
     projectName: target.projectName,
     invoktaVersion: options.invoktaVersion,
     packageManager: options.packageManager,
   });
-  const createdFiles: string[] = [];
+  const createdEntries: string[] = [];
   const createdDirectories: string[] = [];
-  let activeFile: StarterFile | undefined;
+  let activeEntry: StarterEntry | undefined;
 
   try {
     await prepareDirectories(
       options.cwd,
       target,
-      files,
+      entries,
       fileSystem,
       createdDirectories,
     );
-    for (const file of files) {
-      activeFile = file;
-      const path = join(target.directory, ...file.path.split("/"));
-      await fileSystem.writeFile(path, file.contents, {
-        encoding: "utf8",
-        flag: "wx",
-      });
-      createdFiles.push(path);
+    for (const entry of entries) {
+      activeEntry = entry;
+      const path = join(target.directory, ...entry.path.split("/"));
+      if (entry.kind === "file") {
+        await fileSystem.writeFile(path, entry.contents, {
+          encoding: "utf8",
+          flag: "wx",
+        });
+      } else {
+        await fileSystem.symlink(entry.target, path);
+      }
+      createdEntries.push(path);
     }
   } catch (error) {
     const rolledBack = await rollback(
       fileSystem,
-      createdFiles,
+      createdEntries,
       createdDirectories,
     );
     if (!rolledBack) throw new CreatorError("WRITE_FAILED");
@@ -301,18 +310,18 @@ export async function createStarterProject(
     if (readErrorCode(error) === "EEXIST") {
       throw new CreatorError(
         "SCAFFOLD_CONFLICT",
-        activeFile === undefined ? [] : [activeFile.path],
+        activeEntry === undefined ? [] : [activeEntry.path],
       );
     }
     throw new CreatorError(
       "WRITE_FAILED",
-      activeFile === undefined ? [] : [activeFile.path],
+      activeEntry === undefined ? [] : [activeEntry.path],
     );
   }
 
   return Object.freeze({
     directory: target.directory,
     projectName: target.projectName,
-    files: Object.freeze(files.map((file) => file.path)),
+    files: Object.freeze(entries.map((entry) => entry.path)),
   });
 }

--- a/packages/create-invokta-capability-library/src/starter.ts
+++ b/packages/create-invokta-capability-library/src/starter.ts
@@ -3,11 +3,20 @@ import {
   packageManagerCommands,
 } from "./package-manager.js";
 
-export interface StarterFile {
-  /** Project-relative POSIX path. */
-  readonly path: string;
-  readonly contents: string;
-}
+export type StarterEntry =
+  | Readonly<{
+      kind: "file";
+      /** Project-relative POSIX path. */
+      path: string;
+      contents: string;
+    }>
+  | Readonly<{
+      kind: "symlink";
+      /** Project-relative POSIX path. */
+      path: string;
+      /** Project-relative symbolic-link target. */
+      target: string;
+    }>;
 
 export interface CreateStarterFilesOptions {
   readonly projectName: string;
@@ -37,6 +46,30 @@ ${commands.check}
 The starter is private. Before publishing, choose the final package and library
 names, version, default capability IDs, and compatibility policy, then remove
 \`"private": true\` from \`package.json\`.
+`;
+}
+
+function renderAgentInstructions(packageManager: PackageManager): string {
+  const commands = packageManagerCommands[packageManager];
+  return `# Project Instructions
+
+## Language
+
+Write all project content in English, including documentation, source comments,
+public errors, examples, tests, commits, and release notes.
+
+## Capability contracts
+
+- Treat default capability IDs as stable public API.
+- Keep IDs literal and compose explicitly through \`@invokta/core\`.
+- Inject repositories, providers, models, and policy checks through factories or closures.
+- Do not add runtime discovery, registries, adapters, or execution entry points.
+
+## Delivery
+
+- Follow RED, GREEN, REFACTOR for executable behavior.
+- Run \`${commands.check}\` before completing a change.
+- Keep \`CLAUDE.md\` as a symbolic link to this file so agent instructions have one source of truth.
 `;
 }
 
@@ -224,17 +257,29 @@ const tsconfigTest = `{
 }
 `;
 
-/** Returns the complete starter as deterministic, project-relative text files. */
+/** Returns the complete starter as deterministic project-relative entries. */
 export function createStarterFiles(
   options: CreateStarterFilesOptions,
-): readonly StarterFile[] {
+): readonly StarterEntry[] {
   return Object.freeze([
-    { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
     {
+      kind: "file",
+      path: ".gitignore",
+      contents: "node_modules/\ndist/\n*.tsbuildinfo\n",
+    },
+    {
+      kind: "file",
+      path: "AGENTS.md",
+      contents: renderAgentInstructions(options.packageManager),
+    },
+    { kind: "symlink", path: "CLAUDE.md", target: "AGENTS.md" },
+    {
+      kind: "file",
       path: "README.md",
       contents: renderReadme(options.projectName, options.packageManager),
     },
     {
+      kind: "file",
       path: "package.json",
       contents: renderPackageManifest(
         options.projectName,
@@ -242,19 +287,30 @@ export function createStarterFiles(
       ),
     },
     {
+      kind: "file",
       path: "src/capabilities/create-farewell-message.ts",
       contents: farewellCapabilityModule,
     },
     {
+      kind: "file",
       path: "src/capabilities/create-welcome-message.ts",
       contents: welcomeCapabilityModule,
     },
     {
+      kind: "file",
       path: "src/index.ts",
       contents: renderIndexModule(options.projectName),
     },
-    { path: "test/library.test.ts", contents: libraryTestModule },
-    { path: "tsconfig.json", contents: tsconfig },
-    { path: "tsconfig.test.json", contents: tsconfigTest },
+    {
+      kind: "file",
+      path: "test/library.test.ts",
+      contents: libraryTestModule,
+    },
+    { kind: "file", path: "tsconfig.json", contents: tsconfig },
+    {
+      kind: "file",
+      path: "tsconfig.test.json",
+      contents: tsconfigTest,
+    },
   ]);
 }

--- a/packages/create-invokta-capability-library/src/starter.ts
+++ b/packages/create-invokta-capability-library/src/starter.ts
@@ -1,0 +1,260 @@
+import {
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+
+export interface StarterFile {
+  /** Project-relative POSIX path. */
+  readonly path: string;
+  readonly contents: string;
+}
+
+export interface CreateStarterFilesOptions {
+  readonly projectName: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+}
+
+function renderReadme(
+  projectName: string,
+  packageManager: PackageManager,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  return `# ${projectName}
+
+A standalone Invokta capability-library package. It exports one explicit
+\`defineCapabilityLibrary\` value containing two related example capabilities
+that an Action Engine can select and remap at its composition root.
+
+## Validate
+
+\`\`\`sh
+${commands.check}
+\`\`\`
+
+## Publish deliberately
+
+The starter is private. Before publishing, choose the final package and library
+names, version, default capability IDs, and compatibility policy, then remove
+\`"private": true\` from \`package.json\`.
+`;
+}
+
+function renderPackageManifest(
+  projectName: string,
+  invoktaVersion: string,
+): string {
+  const manifest = {
+    name: projectName,
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    sideEffects: false,
+    engines: { node: ">=22.20.0" },
+    exports: {
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+    },
+    scripts: {
+      build: "tsc -p tsconfig.json --pretty false",
+      typecheck:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit",
+      test: "vitest run",
+      check:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit && vitest run && tsc -p tsconfig.json --pretty false",
+    },
+    dependencies: {
+      "@invokta/core": invoktaVersion,
+      zod: "4.4.3",
+    },
+    devDependencies: {
+      "@types/node": "26.1.2",
+      typescript: "7.0.2",
+      vitest: "4.1.10",
+    },
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+const welcomeCapabilityModule = `import { defineCapability } from "@invokta/core";
+import { z } from "zod";
+
+export const createWelcomeMessage = defineCapability({
+  title: "Create a welcome message",
+  description: "Creates a short welcome message for a new team member.",
+  input: z.object({ name: z.string().trim().min(1) }),
+  output: z.object({ message: z.string().min(1) }),
+  access: "public",
+  annotations: {
+    readOnly: true,
+    destructive: false,
+    idempotent: true,
+    openWorld: false,
+  },
+  async run({ input }) {
+    return { message: \`Welcome, \${input.name}!\` };
+  },
+});
+`;
+
+const farewellCapabilityModule = `import { defineCapability } from "@invokta/core";
+import { z } from "zod";
+
+export const createFarewellMessage = defineCapability({
+  title: "Create a farewell message",
+  description: "Creates a short farewell message for a team member.",
+  input: z.object({ name: z.string().trim().min(1) }),
+  output: z.object({ message: z.string().min(1) }),
+  access: "public",
+  annotations: {
+    readOnly: true,
+    destructive: false,
+    idempotent: true,
+    openWorld: false,
+  },
+  async run({ input }) {
+    return { message: \`Farewell, \${input.name}!\` };
+  },
+});
+`;
+
+function renderIndexModule(projectName: string): string {
+  return `import { defineCapabilityLibrary } from "@invokta/core";
+
+import { createFarewellMessage } from "./capabilities/create-farewell-message.js";
+import { createWelcomeMessage } from "./capabilities/create-welcome-message.js";
+
+export const onboardingCapabilityLibrary = defineCapabilityLibrary({
+  name: ${JSON.stringify(projectName)},
+  version: "0.1.0",
+  capabilities: {
+    "onboarding.create-welcome-message": createWelcomeMessage,
+    "onboarding.create-farewell-message": createFarewellMessage,
+  },
+});
+`;
+}
+
+const libraryTestModule = `import {
+  composeCapabilities,
+  createEngine,
+  importCapabilities,
+} from "@invokta/core";
+import { describe, expect, it } from "vitest";
+
+import { onboardingCapabilityLibrary } from "../src/index.js";
+
+const engine = createEngine({
+  name: "capability-library-test-engine",
+  version: "0.0.0-test",
+  capabilities: composeCapabilities({
+    imports: [
+      importCapabilities(onboardingCapabilityLibrary, {
+        include: ["onboarding.create-welcome-message"],
+        remap: {
+          "onboarding.create-welcome-message": "team.welcome-member",
+        },
+      }),
+    ],
+  }),
+});
+
+describe("the onboarding capability library", () => {
+  it("selects, remaps, and invokes through the engine boundary", async () => {
+    expect(engine.list().map((capability) => capability.id)).toEqual([
+      "team.welcome-member",
+    ]);
+    await expect(
+      engine.invoke(
+        "team.welcome-member",
+        { name: "  Ada  " },
+        { principal: null },
+      ),
+    ).resolves.toEqual({ message: "Welcome, Ada!" });
+  });
+
+  it("keeps validation at the engine boundary", async () => {
+    await expect(
+      engine.invoke(
+        "team.welcome-member",
+        { name: "   " },
+        { principal: null },
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+});
+`;
+
+const tsconfig = `{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}
+`;
+
+const tsconfigTest = `{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+`;
+
+/** Returns the complete starter as deterministic, project-relative text files. */
+export function createStarterFiles(
+  options: CreateStarterFilesOptions,
+): readonly StarterFile[] {
+  return Object.freeze([
+    { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
+    {
+      path: "README.md",
+      contents: renderReadme(options.projectName, options.packageManager),
+    },
+    {
+      path: "package.json",
+      contents: renderPackageManifest(
+        options.projectName,
+        options.invoktaVersion,
+      ),
+    },
+    {
+      path: "src/capabilities/create-farewell-message.ts",
+      contents: farewellCapabilityModule,
+    },
+    {
+      path: "src/capabilities/create-welcome-message.ts",
+      contents: welcomeCapabilityModule,
+    },
+    {
+      path: "src/index.ts",
+      contents: renderIndexModule(options.projectName),
+    },
+    { path: "test/library.test.ts", contents: libraryTestModule },
+    { path: "tsconfig.json", contents: tsconfig },
+    { path: "tsconfig.test.json", contents: tsconfigTest },
+  ]);
+}

--- a/packages/create-invokta-capability-library/src/starter.ts
+++ b/packages/create-invokta-capability-library/src/starter.ts
@@ -73,6 +73,46 @@ public errors, examples, tests, commits, and release notes.
 `;
 }
 
+function renderDevelopmentSkill(packageManager: PackageManager): string {
+  const commands = packageManagerCommands[packageManager];
+  return `---
+name: develop-invokta-project
+description: Develop this generated Invokta capability-library package when changing capability contracts, dependencies, default IDs, library metadata, tests, or the package export. Use for implementation, refactoring, debugging, and compatibility review in this project.
+---
+
+# Develop This Capability Library
+
+## Establish the publication contract
+
+1. Read \`AGENTS.md\`, \`README.md\`, \`package.json\`, \`src/index.ts\`, the capability modules, and \`test/library.test.ts\`.
+2. Identify the input, output, access rule, annotations, timeout, default IDs, library name and version, ordering, and root export affected by the change.
+3. Treat schemas, access behavior, literal default IDs, capability order, library identity, and package exports as compatibility surfaces. Request an explicit decision before breaking one.
+
+## Preserve the library boundary
+
+- Keep each domain action as an independent \`defineCapability\` value in \`src/capabilities/\`.
+- Publish through \`defineCapabilityLibrary\` in \`src/index.ts\` with literal, domain-oriented default IDs.
+- Inject repositories, providers, models, tools, and policy checks through a library factory or closure when dependencies are needed.
+- Keep the library independent from CLI, MCP, HTTP, and any consuming engine.
+- Do not add runtime discovery, a registry, a service locator, an adapter, or an engine entry point.
+
+## Deliver the change
+
+1. Add or update a test that imports the public library, selects or remaps with \`importCapabilities\`, composes an engine, invokes through \`engine.invoke\`, and fails for the missing behavior.
+2. Implement the smallest capability or library-publication change that makes the test pass.
+3. Cover invalid input, denied access, output validation, cancellation, dependency failure, selection, and remapping when relevant to the contract.
+4. Keep \`private: true\` until library identity, versioning, default-ID compatibility, and publication are deliberate decisions.
+5. Update project documentation when the public contract or package usage changes.
+6. Run \`${commands.check}\` and resolve every type, test, formatting, and build failure before completion.
+`;
+}
+
+const developmentSkillMetadata = `interface:
+  display_name: "Develop Invokta Capability Library"
+  short_description: "Develop this Invokta capability library"
+  default_prompt: "Use $develop-invokta-project to implement this capability-library change and validate its default IDs and composition contract."
+`;
+
 function renderPackageManifest(
   projectName: string,
   invoktaVersion: string,
@@ -262,6 +302,16 @@ export function createStarterFiles(
   options: CreateStarterFilesOptions,
 ): readonly StarterEntry[] {
   return Object.freeze([
+    {
+      kind: "file",
+      path: ".agents/skills/develop-invokta-project/SKILL.md",
+      contents: renderDevelopmentSkill(options.packageManager),
+    },
+    {
+      kind: "file",
+      path: ".agents/skills/develop-invokta-project/agents/openai.yaml",
+      contents: developmentSkillMetadata,
+    },
     {
       kind: "file",
       path: ".gitignore",

--- a/packages/create-invokta-capability-library/test/creator.test.ts
+++ b/packages/create-invokta-capability-library/test/creator.test.ts
@@ -1,0 +1,373 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runCreateCapabilityLibraryCli } from "../src/cli.js";
+import {
+  installProjectDependencies,
+  type PackageManagerRunner,
+} from "../src/install.js";
+import {
+  createStarterProject,
+  defaultScaffoldFileSystem,
+  type ScaffoldFileSystem,
+} from "../src/scaffold.js";
+import { createStarterFiles } from "../src/starter.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-library-creator-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("the capability library starter", () => {
+  it("renders the fixed project deterministically in lexicographic order", () => {
+    const options = {
+      projectName: "onboarding-capabilities",
+      invoktaVersion: "1.2.3",
+      packageManager: "yarn" as const,
+    };
+    const files = createStarterFiles(options);
+
+    expect(files.map((file) => file.path)).toEqual([
+      ".gitignore",
+      "README.md",
+      "package.json",
+      "src/capabilities/create-farewell-message.ts",
+      "src/capabilities/create-welcome-message.ts",
+      "src/index.ts",
+      "test/library.test.ts",
+      "tsconfig.json",
+      "tsconfig.test.json",
+    ]);
+    expect(files).toEqual(createStarterFiles(options));
+    for (const file of files) {
+      expect(file.contents).not.toContain("\r");
+      expect(file.contents.endsWith("\n")).toBe(true);
+      expect(file.contents.endsWith("\n\n")).toBe(false);
+    }
+  });
+
+  it("pins the core and publishes one explicit library root export", () => {
+    const contents = new Map(
+      createStarterFiles({
+        projectName: "onboarding-capabilities",
+        invoktaVersion: "1.2.3-beta.1",
+        packageManager: "npm",
+      }).map((file) => [file.path, file.contents]),
+    );
+    const manifest = JSON.parse(contents.get("package.json") ?? "") as Record<
+      string,
+      unknown
+    >;
+
+    expect(manifest).toMatchObject({
+      name: "onboarding-capabilities",
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      sideEffects: false,
+      exports: {
+        ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+      },
+      dependencies: { "@invokta/core": "1.2.3-beta.1", zod: "4.4.3" },
+    });
+    expect(contents.get("src/index.ts")).toContain(
+      'name: "onboarding-capabilities"',
+    );
+    expect(contents.get("src/index.ts")).toContain(
+      '"onboarding.create-welcome-message": createWelcomeMessage',
+    );
+    expect(contents.get("src/index.ts")).toContain(
+      '"onboarding.create-farewell-message": createFarewellMessage',
+    );
+    expect(contents.get("test/library.test.ts")).toContain(
+      "importCapabilities(onboardingCapabilityLibrary",
+    );
+    expect(contents.get("test/library.test.ts")).toContain("engine.invoke(");
+  });
+});
+
+describe("createStarterProject", () => {
+  it("creates the complete starter and rejects unsafe paths", async () => {
+    const cwd = createWorkingDirectory();
+    const project = await createStarterProject({
+      cwd,
+      target: "onboarding-capabilities",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+
+    expect(project.files).toHaveLength(9);
+    expect(existsSync(join(project.directory, "src/index.ts"))).toBe(true);
+
+    const outside = createWorkingDirectory();
+    symlinkSync(outside, join(cwd, "linked"), "dir");
+    writeFileSync(join(outside, "sentinel"), "mine\n", "utf8");
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "linked/unsafe-library",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).rejects.toMatchObject({ code: "TARGET_UNSAFE", exitCode: 1 });
+    expect(readFileSync(join(outside, "sentinel"), "utf8")).toBe("mine\n");
+  });
+
+  it("accepts every inclusive target limit", async () => {
+    const cwd = createWorkingDirectory();
+    const projectName = "a".repeat(214);
+    const pathAtLimit = [
+      ...Array.from({ length: 31 }, () => "a".repeat(31)),
+      "b".repeat(32),
+    ].join("/");
+    expect([...pathAtLimit]).toHaveLength(1_024);
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: projectName,
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).resolves.toMatchObject({ projectName });
+    await expect(
+      createStarterProject({
+        cwd,
+        target: pathAtLimit,
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).resolves.toMatchObject({ projectName: "b".repeat(32) });
+  });
+
+  it.each([
+    ["absolute", "/tmp/onboarding-capabilities"],
+    ["parent", "../onboarding-capabilities"],
+    ["empty segment", "packages//onboarding-capabilities"],
+    ["invalid name", "Onboarding Capabilities"],
+    ["long name", "a".repeat(215)],
+    ["many segments", `${"nested/".repeat(32)}onboarding-capabilities`],
+    ["long path", `${"a".repeat(1_025)}-library`],
+  ])(
+    "rejects an exclusive %s target before writing",
+    async (_label, target) => {
+      const cwd = createWorkingDirectory();
+
+      await expect(
+        createStarterProject({
+          cwd,
+          target,
+          invoktaVersion: "1.2.3",
+          packageManager: "npm",
+        }),
+      ).rejects.toMatchObject({ code: "TARGET_INVALID", exitCode: 2 });
+      expect(readdirSync(cwd)).toEqual([]);
+    },
+  );
+
+  it("preserves an entry that wins an exclusive-write race", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "onboarding-capabilities");
+    let raced = false;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        if (!raced) {
+          raced = true;
+          writeFileSync(path, "mine\n", "utf8");
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "onboarding-capabilities",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
+    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".gitignore"]);
+  });
+
+  it("rolls back only paths created by a failed write", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "onboarding-capabilities");
+    mkdirSync(target);
+    let writes = 0;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        writes += 1;
+        if (writes === 3) {
+          const error = new Error("fixture failure") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "onboarding-capabilities",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "WRITE_FAILED", exitCode: 1 });
+    expect(readdirSync(target)).toEqual([]);
+  });
+});
+
+describe("runCreateCapabilityLibraryCli", () => {
+  it("supports offline creation, public help, and sanitized invalid usage", async () => {
+    const cwd = createWorkingDirectory();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const install = vi.fn();
+    const io = {
+      writeStdout(text: string) {
+        stdout.push(text);
+      },
+      writeStderr(text: string) {
+        stderr.push(text);
+      },
+    };
+
+    await expect(
+      runCreateCapabilityLibraryCli({
+        argv: ["onboarding-capabilities", "--no-install"],
+        cwd,
+        env: {},
+        io,
+        install,
+        loadPackageVersion: async () => "1.2.3",
+      }),
+    ).resolves.toBe(0);
+    expect(install).not.toHaveBeenCalled();
+    expect(stdout.join("")).toContain(
+      "Created onboarding-capabilities without installing dependencies.",
+    );
+
+    stdout.length = 0;
+    await expect(
+      runCreateCapabilityLibraryCli({ argv: ["--help"], io }),
+    ).resolves.toBe(0);
+    expect(stdout.join("")).toContain(
+      "create-invokta-capability-library <project-directory>",
+    );
+
+    await expect(
+      runCreateCapabilityLibraryCli({
+        argv: ["../fixture-secret-payload-marker", "--no-install"],
+        cwd,
+        io,
+        loadPackageVersion: async () => "1.2.3",
+      }),
+    ).resolves.toBe(2);
+    expect(stderr.at(-1)).toBe(
+      "TARGET_INVALID: The project path or name is invalid.\n",
+    );
+    expect(stderr.join("")).not.toContain("fixture-secret-payload-marker");
+  });
+
+  it.each([
+    { argv: [] },
+    { argv: ["onboarding-capabilities", "other-library"] },
+    { argv: ["onboarding-capabilities", "--unknown"] },
+    {
+      argv: ["onboarding-capabilities", "--no-install", "--no-install"],
+    },
+    { argv: ["onboarding-capabilities", "--package-manager"] },
+    { argv: ["onboarding-capabilities", "--package-manager", "bun"] },
+    {
+      argv: [
+        "onboarding-capabilities",
+        "--package-manager",
+        "npm",
+        "--package-manager",
+        "pnpm",
+      ],
+    },
+  ])(
+    "rejects invalid arguments without creating a project: $argv",
+    async ({ argv }) => {
+      const cwd = createWorkingDirectory();
+      const stderr: string[] = [];
+
+      await expect(
+        runCreateCapabilityLibraryCli({
+          argv,
+          cwd,
+          io: {
+            writeStdout: vi.fn(),
+            writeStderr(text) {
+              stderr.push(text);
+            },
+          },
+        }),
+      ).resolves.toBe(2);
+      expect(stderr).toEqual([
+        'Invalid arguments. Run "create-invokta-capability-library --help".\n',
+      ]);
+      expect(readdirSync(cwd)).toEqual([]);
+    },
+  );
+});
+
+describe("installProjectDependencies", () => {
+  it("runs one shell-free foreground install and normalizes failure", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => ({
+      code: 0,
+      signal: null,
+    }));
+    await installProjectDependencies({
+      directory: "/work/onboarding-capabilities",
+      packageManager: "yarn",
+      runner,
+    });
+    expect(runner).toHaveBeenCalledWith({
+      command: "yarn",
+      args: ["install"],
+      cwd: "/work/onboarding-capabilities",
+      shell: false,
+      stdio: "inherit",
+    });
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/onboarding-capabilities",
+        packageManager: "pnpm",
+        runner: async () => {
+          throw new Error("fixture child failure");
+        },
+      }),
+    ).rejects.toMatchObject({ code: "INSTALL_FAILED", details: ["pnpm"] });
+  });
+});

--- a/packages/create-invokta-capability-library/test/creator.test.ts
+++ b/packages/create-invokta-capability-library/test/creator.test.ts
@@ -1,8 +1,10 @@
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   readdirSync,
   rmSync,
   symlinkSync,
@@ -50,6 +52,8 @@ describe("the capability library starter", () => {
 
     expect(files.map((file) => file.path)).toEqual([
       ".gitignore",
+      "AGENTS.md",
+      "CLAUDE.md",
       "README.md",
       "package.json",
       "src/capabilities/create-farewell-message.ts",
@@ -61,10 +65,21 @@ describe("the capability library starter", () => {
     ]);
     expect(files).toEqual(createStarterFiles(options));
     for (const file of files) {
+      if (!("contents" in file)) continue;
       expect(file.contents).not.toContain("\r");
       expect(file.contents.endsWith("\n")).toBe(true);
       expect(file.contents.endsWith("\n\n")).toBe(false);
     }
+    const instructions = files.find((file) => file.path === "AGENTS.md");
+    expect(instructions).toMatchObject({ kind: "file", path: "AGENTS.md" });
+    expect(
+      instructions && "contents" in instructions ? instructions.contents : "",
+    ).toContain("Treat default capability IDs as stable public API.");
+    expect(files.find((file) => file.path === "CLAUDE.md")).toEqual({
+      kind: "symlink",
+      path: "CLAUDE.md",
+      target: "AGENTS.md",
+    });
   });
 
   it("pins the core and publishes one explicit library root export", () => {
@@ -73,7 +88,9 @@ describe("the capability library starter", () => {
         projectName: "onboarding-capabilities",
         invoktaVersion: "1.2.3-beta.1",
         packageManager: "npm",
-      }).map((file) => [file.path, file.contents]),
+      }).flatMap((file) =>
+        "contents" in file ? [[file.path, file.contents] as const] : [],
+      ),
     );
     const manifest = JSON.parse(contents.get("package.json") ?? "") as Record<
       string,
@@ -117,8 +134,15 @@ describe("createStarterProject", () => {
       packageManager: "npm",
     });
 
-    expect(project.files).toHaveLength(9);
+    expect(project.files).toHaveLength(11);
     expect(existsSync(join(project.directory, "src/index.ts"))).toBe(true);
+    expect(lstatSync(join(project.directory, "AGENTS.md")).isFile()).toBe(true);
+    expect(
+      lstatSync(join(project.directory, "CLAUDE.md")).isSymbolicLink(),
+    ).toBe(true);
+    expect(readlinkSync(join(project.directory, "CLAUDE.md"))).toBe(
+      "AGENTS.md",
+    );
 
     const outside = createWorkingDirectory();
     symlinkSync(outside, join(cwd, "linked"), "dir");
@@ -214,13 +238,77 @@ describe("createStarterProject", () => {
     expect(readdirSync(target)).toEqual([".gitignore"]);
   });
 
+  it("preserves a symbolic link that wins an exclusive-create race", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "onboarding-capabilities");
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async symlink(linkTarget, path) {
+        symlinkSync("external-agents.md", path);
+        await defaultScaffoldFileSystem.symlink(linkTarget, path);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "onboarding-capabilities",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({
+      code: "SCAFFOLD_CONFLICT",
+      exitCode: 1,
+      details: ["CLAUDE.md"],
+    });
+    expect(readdirSync(target)).toEqual(["CLAUDE.md"]);
+    expect(readlinkSync(join(target, "CLAUDE.md"))).toBe("external-agents.md");
+  });
+
+  it("normalizes a symbolic-link creation failure and rolls back", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "onboarding-capabilities");
+    mkdirSync(target);
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async symlink() {
+        const error = new Error(
+          "fixture link failure",
+        ) as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "onboarding-capabilities",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({
+      code: "WRITE_FAILED",
+      exitCode: 1,
+      details: ["CLAUDE.md"],
+    });
+    expect(readdirSync(target)).toEqual([]);
+  });
+
   it("rolls back only paths created by a failed write", async () => {
     const cwd = createWorkingDirectory();
     const target = join(cwd, "onboarding-capabilities");
     mkdirSync(target);
     let writes = 0;
+    let linkCreated = false;
     const fileSystem: ScaffoldFileSystem = {
       ...defaultScaffoldFileSystem,
+      async symlink(linkTarget, path) {
+        await defaultScaffoldFileSystem.symlink(linkTarget, path);
+        linkCreated = true;
+      },
       async writeFile(path, contents, options) {
         writes += 1;
         if (writes === 3) {
@@ -241,6 +329,7 @@ describe("createStarterProject", () => {
         fileSystem,
       }),
     ).rejects.toMatchObject({ code: "WRITE_FAILED", exitCode: 1 });
+    expect(linkCreated).toBe(true);
     expect(readdirSync(target)).toEqual([]);
   });
 });

--- a/packages/create-invokta-capability-library/test/creator.test.ts
+++ b/packages/create-invokta-capability-library/test/creator.test.ts
@@ -51,6 +51,8 @@ describe("the capability library starter", () => {
     const files = createStarterFiles(options);
 
     expect(files.map((file) => file.path)).toEqual([
+      ".agents/skills/develop-invokta-project/SKILL.md",
+      ".agents/skills/develop-invokta-project/agents/openai.yaml",
       ".gitignore",
       "AGENTS.md",
       "CLAUDE.md",
@@ -80,6 +82,27 @@ describe("the capability library starter", () => {
       path: "CLAUDE.md",
       target: "AGENTS.md",
     });
+    const contents = new Map(
+      files.flatMap((file) =>
+        "contents" in file ? [[file.path, file.contents] as const] : [],
+      ),
+    );
+    const skill =
+      contents.get(".agents/skills/develop-invokta-project/SKILL.md") ?? "";
+    const metadata =
+      contents.get(
+        ".agents/skills/develop-invokta-project/agents/openai.yaml",
+      ) ?? "";
+    expect(skill).toMatch(
+      /^---\nname: develop-invokta-project\ndescription: .+\n---\n/u,
+    );
+    expect(skill).toContain("Publish through `defineCapabilityLibrary`");
+    expect(skill).toContain("Run `yarn run check`");
+    expect(skill).not.toContain("TODO");
+    expect(metadata).toContain(
+      'display_name: "Develop Invokta Capability Library"',
+    );
+    expect(metadata).toContain("$develop-invokta-project");
   });
 
   it("pins the core and publishes one explicit library root export", () => {
@@ -134,7 +157,7 @@ describe("createStarterProject", () => {
       packageManager: "npm",
     });
 
-    expect(project.files).toHaveLength(11);
+    expect(project.files).toHaveLength(13);
     expect(existsSync(join(project.directory, "src/index.ts"))).toBe(true);
     expect(lstatSync(join(project.directory, "AGENTS.md")).isFile()).toBe(true);
     expect(
@@ -143,6 +166,15 @@ describe("createStarterProject", () => {
     expect(readlinkSync(join(project.directory, "CLAUDE.md"))).toBe(
       "AGENTS.md",
     );
+    expect(
+      readFileSync(
+        join(
+          project.directory,
+          ".agents/skills/develop-invokta-project/SKILL.md",
+        ),
+        "utf8",
+      ),
+    ).toContain("# Develop This Capability Library");
 
     const outside = createWorkingDirectory();
     symlinkSync(outside, join(cwd, "linked"), "dir");
@@ -234,8 +266,13 @@ describe("createStarterProject", () => {
         fileSystem,
       }),
     ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
-    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
-    expect(readdirSync(target)).toEqual([".gitignore"]);
+    expect(
+      readFileSync(
+        join(target, ".agents/skills/develop-invokta-project/SKILL.md"),
+        "utf8",
+      ),
+    ).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".agents"]);
   });
 
   it("preserves a symbolic link that wins an exclusive-create race", async () => {
@@ -311,7 +348,7 @@ describe("createStarterProject", () => {
       },
       async writeFile(path, contents, options) {
         writes += 1;
-        if (writes === 3) {
+        if (writes === 5) {
           const error = new Error("fixture failure") as NodeJS.ErrnoException;
           error.code = "EACCES";
           throw error;

--- a/packages/create-invokta-capability-library/tsconfig.json
+++ b/packages/create-invokta-capability-library/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/create-invokta-capability/LICENSE
+++ b/packages/create-invokta-capability/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vini Lana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-invokta-capability/README.md
+++ b/packages/create-invokta-capability/README.md
@@ -29,6 +29,8 @@ to generate files without starting a package manager or performing network I/O.
 ## Generated project
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 README.md
 package.json
@@ -38,6 +40,12 @@ test/capability.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+The generated `develop-invokta-project` skill teaches an agent to preserve the
+atomic publication boundary, evolve capability contracts with
+RED/GREEN/REFACTOR, and prove consumption through `importCapability` and
+`engine.invoke`. Its metadata includes a ready-to-use
+`$develop-invokta-project` prompt.
 
 The private ESM starter pins `@invokta/core` to the creator version and exports
 one deterministic example capability. Its test composes that export into an

--- a/packages/create-invokta-capability/README.md
+++ b/packages/create-invokta-capability/README.md
@@ -1,0 +1,60 @@
+# create-invokta-capability
+
+Create a standalone TypeScript package that publishes one atomic Invokta
+capability through `defineExportedCapability`.
+
+## Commands
+
+```text
+create-invokta-capability <project-directory>
+  [--package-manager npm|pnpm|yarn] [--no-install]
+create-invokta-capability --help
+create-invokta-capability --version
+```
+
+The npm initializer shorthand resolves to this package:
+
+```sh
+npm create invokta-capability@latest my-capability
+```
+
+Creation is non-interactive. The target must be a relative absent or empty real
+directory. Existing files and symbolic-link path components are refused and
+never overwritten.
+
+The invoking package manager is inferred from `npm_config_user_agent`, with npm
+as the fallback. Use `--package-manager` to choose explicitly or `--no-install`
+to generate files without starting a package manager or performing network I/O.
+
+## Generated project
+
+```text
+.gitignore
+README.md
+package.json
+src/capability.ts
+src/index.ts
+test/capability.test.ts
+tsconfig.json
+tsconfig.test.json
+```
+
+The private ESM starter pins `@invokta/core` to the creator version and exports
+one deterministic example capability. Its test composes that export into an
+engine and invokes it through `engine.invoke`. Generated files are project-owned
+and are never updated in place.
+
+The creator does not publish the package, discover dependencies, start an
+adapter, or execute a capability.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Help, version, or project creation succeeded |
+| `1` | Target safety, filesystem creation, or dependency installation failed |
+| `2` | Arguments, project path, or project name were invalid |
+
+Creator diagnostics use `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, or `INSTALL_FAILED`. Rejected arguments,
+environment values, child errors, stacks, and causes are not included.

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "create-invokta-capability",
+  "version": "0.2.0",
+  "description": "Create a standalone Invokta atomic capability package.",
+  "author": "Vini Lana <vini@aicoders.academy>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vinilana/invokta.git",
+    "directory": "packages/create-invokta-capability"
+  },
+  "homepage": "https://docs.invokta.dev/reference/create-invokta-capability/",
+  "bugs": {
+    "url": "https://github.com/vinilana/invokta/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=22.20.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {},
+  "bin": {
+    "create-invokta-capability": "./dist/bin.js"
+  },
+  "scripts": {
+    "build": "tsc -b --pretty false",
+    "prepack": "npm run --silent build"
+  }
+}

--- a/packages/create-invokta-capability/src/bin.ts
+++ b/packages/create-invokta-capability/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { runCreateCapabilityCli } from "./cli.js";
+
+// The composition root owns process status so buffered terminal output can flush.
+process.exitCode = await runCreateCapabilityCli();

--- a/packages/create-invokta-capability/src/cli.ts
+++ b/packages/create-invokta-capability/src/cli.ts
@@ -1,0 +1,210 @@
+import { CreatorError, renderCreatorDiagnostic } from "./errors.js";
+import { installProjectDependencies, selectPackageManager } from "./install.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+import { createStarterProject } from "./scaffold.js";
+
+const commandName = "create-invokta-capability";
+const helpText = `Usage:
+  ${commandName} <project-directory>
+    [--package-manager npm|pnpm|yarn] [--no-install]
+  ${commandName} --help
+  ${commandName} --version
+`;
+const invalidUsageText = `Invalid arguments. Run "${commandName} --help".\n`;
+const unexpectedFailureText = "The project could not be created.\n";
+
+export interface CreateCapabilityIo {
+  readonly writeStdout: (text: string) => void | Promise<void>;
+  readonly writeStderr: (text: string) => void | Promise<void>;
+}
+
+const defaultIo: CreateCapabilityIo = Object.freeze({
+  writeStdout(text: string) {
+    process.stdout.write(text);
+  },
+  writeStderr(text: string) {
+    process.stderr.write(text);
+  },
+});
+
+export interface InstallProjectOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+}
+
+export type InstallProject = (options: InstallProjectOptions) => Promise<void>;
+
+export interface RunCreateCapabilityCliOptions {
+  readonly argv?: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly io?: CreateCapabilityIo;
+  readonly install?: InstallProject;
+  readonly loadPackageVersion?: () => Promise<string>;
+}
+
+interface CreateArguments {
+  readonly target: string;
+  readonly packageManager?: PackageManager;
+  readonly noInstall: boolean;
+}
+
+function parseCreateArguments(
+  args: readonly string[],
+): CreateArguments | undefined {
+  let target: string | undefined;
+  let packageManager: PackageManager | undefined;
+  let packageManagerSeen = false;
+  let noInstall = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--no-install") {
+      if (noInstall) return undefined;
+      noInstall = true;
+      continue;
+    }
+    if (argument === "--package-manager") {
+      if (packageManagerSeen) return undefined;
+      packageManagerSeen = true;
+      const value = args[index + 1];
+      if (value === undefined || !isPackageManager(value)) return undefined;
+      packageManager = value;
+      index += 1;
+      continue;
+    }
+    if (
+      argument === undefined ||
+      argument.startsWith("-") ||
+      target !== undefined
+    ) {
+      return undefined;
+    }
+    target = argument;
+  }
+
+  if (target === undefined) return undefined;
+  return {
+    target,
+    ...(packageManager === undefined ? {} : { packageManager }),
+    noInstall,
+  };
+}
+
+function asRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  return value as Readonly<Record<string, unknown>>;
+}
+
+async function loadDefaultPackageVersion(): Promise<string> {
+  const manifestUrl = new URL("../package.json", import.meta.url);
+  const namespace = (await import(manifestUrl.href, {
+    with: { type: "json" },
+  })) as unknown;
+  const version = asRecord(asRecord(namespace)?.default)?.version;
+  if (typeof version !== "string" || version === "") {
+    throw new Error("The package version is unreadable.");
+  }
+  return version;
+}
+
+async function writeDiagnostic(
+  io: CreateCapabilityIo,
+  text: string,
+): Promise<void> {
+  try {
+    await io.writeStderr(text);
+  } catch {
+    // A broken diagnostic stream does not replace the command's numeric result.
+  }
+}
+
+function renderSuccess(
+  projectName: string,
+  packageManager: PackageManager,
+  noInstall: boolean,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  if (noInstall) {
+    return (
+      `Created ${projectName} without installing dependencies.\n\n` +
+      "Next steps:\n" +
+      `  ${commands.installDisplay}\n` +
+      `  ${commands.check}\n`
+    );
+  }
+  return `Created ${projectName}.\n\nNext step:\n  ${commands.check}\n`;
+}
+
+/** Runs the binary command and returns its exit status without exiting. */
+export async function runCreateCapabilityCli(
+  options: RunCreateCapabilityCliOptions = {},
+): Promise<0 | 1 | 2> {
+  const argv = options.argv ?? process.argv.slice(2);
+  const io = options.io ?? defaultIo;
+  const [first, ...rest] = argv;
+
+  if (first === "--help" || first === "--version") {
+    if (rest.length > 0) {
+      await writeDiagnostic(io, invalidUsageText);
+      return 2;
+    }
+    try {
+      const output =
+        first === "--help"
+          ? helpText
+          : `${await (options.loadPackageVersion ?? loadDefaultPackageVersion)()}\n`;
+      await io.writeStdout(output);
+      return 0;
+    } catch {
+      await writeDiagnostic(io, unexpectedFailureText);
+      return 1;
+    }
+  }
+
+  const parsed = parseCreateArguments(argv);
+  if (parsed === undefined) {
+    await writeDiagnostic(io, invalidUsageText);
+    return 2;
+  }
+
+  const environment = options.env ?? process.env;
+  const packageManager = selectPackageManager(
+    parsed.packageManager,
+    environment.npm_config_user_agent,
+  );
+  try {
+    const invoktaVersion = await (
+      options.loadPackageVersion ?? loadDefaultPackageVersion
+    )();
+    const project = await createStarterProject({
+      cwd: options.cwd ?? process.cwd(),
+      target: parsed.target,
+      invoktaVersion,
+      packageManager,
+    });
+    if (!parsed.noInstall) {
+      await (options.install ?? installProjectDependencies)({
+        directory: project.directory,
+        packageManager,
+      });
+    }
+    await io.writeStdout(
+      renderSuccess(project.projectName, packageManager, parsed.noInstall),
+    );
+    return 0;
+  } catch (error) {
+    if (error instanceof CreatorError) {
+      await writeDiagnostic(io, renderCreatorDiagnostic(error));
+      return error.exitCode;
+    }
+    await writeDiagnostic(io, unexpectedFailureText);
+    return 1;
+  }
+}

--- a/packages/create-invokta-capability/src/errors.ts
+++ b/packages/create-invokta-capability/src/errors.ts
@@ -1,0 +1,43 @@
+export const creatorErrorMessages = Object.freeze({
+  TARGET_INVALID: "The project path or name is invalid.",
+  TARGET_UNSAFE: "The project target is unsafe to use.",
+  TARGET_NOT_EMPTY: "The project target is not empty.",
+  SCAFFOLD_CONFLICT: "A scaffold file appeared during creation.",
+  WRITE_FAILED: "The project scaffold could not be written.",
+  INSTALL_FAILED: "The project dependencies could not be installed.",
+} as const);
+
+export type CreatorErrorCode = keyof typeof creatorErrorMessages;
+export type CreatorExitCode = 0 | 1 | 2;
+
+const creatorErrorExitCodes = Object.freeze({
+  TARGET_INVALID: 2,
+  TARGET_UNSAFE: 1,
+  TARGET_NOT_EMPTY: 1,
+  SCAFFOLD_CONFLICT: 1,
+  WRITE_FAILED: 1,
+  INSTALL_FAILED: 1,
+} as const) satisfies Readonly<Record<CreatorErrorCode, CreatorExitCode>>;
+
+/** A sanitized creator failure. It intentionally stores no cause or raw input. */
+export class CreatorError extends Error {
+  readonly code: CreatorErrorCode;
+  readonly exitCode: CreatorExitCode;
+  readonly details: readonly string[];
+
+  constructor(code: CreatorErrorCode, details: readonly string[] = []) {
+    super(creatorErrorMessages[code]);
+    this.name = "CreatorError";
+    this.code = code;
+    this.exitCode = creatorErrorExitCodes[code];
+    this.details = Object.freeze([...details]);
+  }
+}
+
+export function renderCreatorDiagnostic(error: CreatorError): string {
+  const lines = [
+    `${error.code}: ${creatorErrorMessages[error.code]}`,
+    ...error.details.map((detail) => `  ${detail}`),
+  ];
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/create-invokta-capability/src/install.ts
+++ b/packages/create-invokta-capability/src/install.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+import { CreatorError } from "./errors.js";
+import {
+  isPackageManager,
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+
+export interface PackageManagerRunOptions {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly shell: false;
+  readonly stdio: "inherit";
+}
+
+export interface PackageManagerRunResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+export type PackageManagerRunner = (
+  options: PackageManagerRunOptions,
+) => Promise<PackageManagerRunResult>;
+
+export const defaultPackageManagerRunner: PackageManagerRunner = (options) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(options.command, [...options.args], {
+      cwd: options.cwd,
+      shell: options.shell,
+      stdio: options.stdio,
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+
+export function selectPackageManager(
+  explicit: PackageManager | undefined,
+  userAgent: string | undefined,
+): PackageManager {
+  if (explicit !== undefined) return explicit;
+  const candidate = userAgent?.split(/\s/u, 1)[0]?.split("/", 1)[0];
+  return candidate !== undefined && isPackageManager(candidate)
+    ? candidate
+    : "npm";
+}
+
+export interface InstallProjectDependenciesOptions {
+  readonly directory: string;
+  readonly packageManager: PackageManager;
+  readonly runner?: PackageManagerRunner;
+}
+
+/** Runs the one foreground package-manager install authorized by ADR 0014. */
+export async function installProjectDependencies(
+  options: InstallProjectDependenciesOptions,
+): Promise<void> {
+  const commands = packageManagerCommands[options.packageManager];
+  let result: PackageManagerRunResult;
+  try {
+    result = await (options.runner ?? defaultPackageManagerRunner)({
+      command: commands.installExecutable,
+      args: commands.installArguments,
+      cwd: options.directory,
+      shell: false,
+      stdio: "inherit",
+    });
+  } catch {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+  if (result.code !== 0) {
+    throw new CreatorError("INSTALL_FAILED", [options.packageManager]);
+  }
+}

--- a/packages/create-invokta-capability/src/package-manager.ts
+++ b/packages/create-invokta-capability/src/package-manager.ts
@@ -1,0 +1,39 @@
+export type PackageManager = "npm" | "pnpm" | "yarn";
+
+export interface PackageManagerCommands {
+  readonly installExecutable: PackageManager;
+  readonly installArguments: readonly string[];
+  readonly installDisplay: string;
+  readonly check: string;
+}
+
+export const packageManagerCommands = Object.freeze({
+  npm: Object.freeze({
+    installExecutable: "npm",
+    installArguments: Object.freeze(["install", "--no-audit", "--no-fund"]),
+    installDisplay: "npm install --no-audit --no-fund",
+    check: "npm run check",
+  }),
+  pnpm: Object.freeze({
+    installExecutable: "pnpm",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "pnpm install",
+    check: "pnpm run check",
+  }),
+  yarn: Object.freeze({
+    installExecutable: "yarn",
+    installArguments: Object.freeze(["install"]),
+    installDisplay: "yarn install",
+    check: "yarn run check",
+  }),
+} as const) satisfies Readonly<Record<PackageManager, PackageManagerCommands>>;
+
+export const packageManagers = Object.freeze([
+  "npm",
+  "pnpm",
+  "yarn",
+] as const satisfies readonly PackageManager[]);
+
+export function isPackageManager(value: string): value is PackageManager {
+  return packageManagers.some((manager) => manager === value);
+}

--- a/packages/create-invokta-capability/src/scaffold.ts
+++ b/packages/create-invokta-capability/src/scaffold.ts
@@ -1,0 +1,318 @@
+import type { Stats } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  rmdir,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
+
+import { CreatorError } from "./errors.js";
+import type { PackageManager } from "./package-manager.js";
+import { createStarterFiles, type StarterFile } from "./starter.js";
+
+export const creatorTargetLimits = Object.freeze({
+  maxPathScalars: 1_024,
+  maxPathSegments: 32,
+  maxProjectNameCharacters: 214,
+});
+
+const projectNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+export interface ScaffoldFileSystem {
+  readonly lstat: (path: string) => Promise<Stats>;
+  readonly mkdir: (path: string) => Promise<void>;
+  readonly readdir: (path: string) => Promise<string[]>;
+  readonly rmdir: (path: string) => Promise<void>;
+  readonly unlink: (path: string) => Promise<void>;
+  readonly writeFile: (
+    path: string,
+    contents: string,
+    options: Readonly<{ encoding: "utf8"; flag: "wx" }>,
+  ) => Promise<void>;
+}
+
+const nodeScaffoldFileSystem: ScaffoldFileSystem = {
+  lstat,
+  async mkdir(path) {
+    await mkdir(path);
+  },
+  async readdir(path) {
+    return readdir(path);
+  },
+  async rmdir(path) {
+    await rmdir(path);
+  },
+  async unlink(path) {
+    await unlink(path);
+  },
+  async writeFile(path, contents, options) {
+    await writeFile(path, contents, options);
+  },
+};
+
+export const defaultScaffoldFileSystem: ScaffoldFileSystem = Object.freeze(
+  nodeScaffoldFileSystem,
+);
+
+export interface CreateStarterProjectOptions {
+  readonly cwd: string;
+  readonly target: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+  readonly fileSystem?: ScaffoldFileSystem;
+}
+
+export interface StarterProject {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly files: readonly string[];
+}
+
+interface ResolvedTarget {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly segments: readonly string[];
+}
+
+function countScalars(value: string): number {
+  let count = 0;
+  for (const _ of value) count += 1;
+  return count;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function invalidTarget(): never {
+  throw new CreatorError("TARGET_INVALID");
+}
+
+function resolveTarget(cwd: string, target: string): ResolvedTarget {
+  if (
+    target === "" ||
+    target.includes("\u0000") ||
+    countScalars(target) > creatorTargetLimits.maxPathScalars ||
+    isAbsolute(target) ||
+    win32.isAbsolute(target)
+  ) {
+    return invalidTarget();
+  }
+
+  const rawSegments = target.split(/[\\/]/u);
+  if (target !== "." && rawSegments.some((segment) => segment === "")) {
+    return invalidTarget();
+  }
+  const segments = rawSegments.filter((segment) => segment !== ".");
+  if (
+    segments.some((segment) => segment === "..") ||
+    segments.length > creatorTargetLimits.maxPathSegments
+  ) {
+    return invalidTarget();
+  }
+
+  const directory =
+    segments.length === 0 ? resolve(cwd) : resolve(cwd, ...segments);
+  const projectName = basename(directory);
+  if (
+    projectName.length === 0 ||
+    projectName.length > creatorTargetLimits.maxProjectNameCharacters ||
+    !projectNamePattern.test(projectName)
+  ) {
+    return invalidTarget();
+  }
+  return { directory, projectName, segments };
+}
+
+async function readStatus(
+  fileSystem: ScaffoldFileSystem,
+  path: string,
+): Promise<Stats | undefined> {
+  try {
+    return await fileSystem.lstat(path);
+  } catch (error) {
+    const code = readErrorCode(error);
+    if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+}
+
+async function inspectTarget(
+  cwd: string,
+  target: ResolvedTarget,
+  fileSystem: ScaffoldFileSystem,
+): Promise<void> {
+  let current = resolve(cwd);
+  if (target.segments.length === 0) {
+    const status = await readStatus(fileSystem, current);
+    if (
+      status === undefined ||
+      status.isSymbolicLink() ||
+      !status.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  } else {
+    for (const segment of target.segments) {
+      current = join(current, segment);
+      const status = await readStatus(fileSystem, current);
+      if (status === undefined) return;
+      if (status.isSymbolicLink() || !status.isDirectory()) {
+        throw new CreatorError("TARGET_UNSAFE");
+      }
+    }
+  }
+
+  let entries: string[];
+  try {
+    entries = await fileSystem.readdir(target.directory);
+  } catch {
+    throw new CreatorError("TARGET_UNSAFE");
+  }
+  if (entries.length > 0) throw new CreatorError("TARGET_NOT_EMPTY");
+}
+
+async function ensureDirectory(
+  path: string,
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  const status = await readStatus(fileSystem, path);
+  if (status !== undefined) {
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+    return;
+  }
+  try {
+    await fileSystem.mkdir(path);
+    createdDirectories.push(path);
+  } catch (error) {
+    if (readErrorCode(error) !== "EEXIST") {
+      throw new CreatorError("WRITE_FAILED");
+    }
+    const racedStatus = await readStatus(fileSystem, path);
+    if (
+      racedStatus === undefined ||
+      racedStatus.isSymbolicLink() ||
+      !racedStatus.isDirectory()
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  }
+}
+
+async function prepareDirectories(
+  cwd: string,
+  target: ResolvedTarget,
+  files: readonly StarterFile[],
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  let current = resolve(cwd);
+  for (const segment of target.segments) {
+    current = join(current, segment);
+    await ensureDirectory(current, fileSystem, createdDirectories);
+  }
+  for (const directory of new Set(
+    files
+      .map((file) => dirname(file.path))
+      .filter((path) => path !== ".")
+      .sort(),
+  )) {
+    let nested = target.directory;
+    for (const segment of directory.split("/")) {
+      nested = join(nested, segment);
+      await ensureDirectory(nested, fileSystem, createdDirectories);
+    }
+  }
+}
+
+async function rollback(
+  fileSystem: ScaffoldFileSystem,
+  createdFiles: readonly string[],
+  createdDirectories: readonly string[],
+): Promise<boolean> {
+  let failed = false;
+  for (const path of [...createdFiles].reverse()) {
+    try {
+      await fileSystem.unlink(path);
+    } catch (error) {
+      if (readErrorCode(error) !== "ENOENT") failed = true;
+    }
+  }
+  for (const path of [...createdDirectories].reverse()) {
+    try {
+      await fileSystem.rmdir(path);
+    } catch (error) {
+      const code = readErrorCode(error);
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") failed = true;
+    }
+  }
+  return !failed;
+}
+
+/** Creates the fixed starter without installing dependencies or replacing files. */
+export async function createStarterProject(
+  options: CreateStarterProjectOptions,
+): Promise<StarterProject> {
+  const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
+  const target = resolveTarget(options.cwd, options.target);
+  await inspectTarget(options.cwd, target, fileSystem);
+  const files = createStarterFiles({
+    projectName: target.projectName,
+    invoktaVersion: options.invoktaVersion,
+    packageManager: options.packageManager,
+  });
+  const createdFiles: string[] = [];
+  const createdDirectories: string[] = [];
+  let activeFile: StarterFile | undefined;
+
+  try {
+    await prepareDirectories(
+      options.cwd,
+      target,
+      files,
+      fileSystem,
+      createdDirectories,
+    );
+    for (const file of files) {
+      activeFile = file;
+      const path = join(target.directory, ...file.path.split("/"));
+      await fileSystem.writeFile(path, file.contents, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      createdFiles.push(path);
+    }
+  } catch (error) {
+    const rolledBack = await rollback(
+      fileSystem,
+      createdFiles,
+      createdDirectories,
+    );
+    if (!rolledBack) throw new CreatorError("WRITE_FAILED");
+    if (error instanceof CreatorError) throw error;
+    if (readErrorCode(error) === "EEXIST") {
+      throw new CreatorError(
+        "SCAFFOLD_CONFLICT",
+        activeFile === undefined ? [] : [activeFile.path],
+      );
+    }
+    throw new CreatorError(
+      "WRITE_FAILED",
+      activeFile === undefined ? [] : [activeFile.path],
+    );
+  }
+
+  return Object.freeze({
+    directory: target.directory,
+    projectName: target.projectName,
+    files: Object.freeze(files.map((file) => file.path)),
+  });
+}

--- a/packages/create-invokta-capability/src/starter.ts
+++ b/packages/create-invokta-capability/src/starter.ts
@@ -40,6 +40,46 @@ remove \`"private": true\` from \`package.json\`.
 `;
 }
 
+function renderDevelopmentSkill(packageManager: PackageManager): string {
+  const commands = packageManagerCommands[packageManager];
+  return `---
+name: develop-invokta-project
+description: Develop this generated Invokta atomic capability package when changing its capability contract, dependencies, publication descriptor, tests, or package export. Use for implementation, refactoring, debugging, and compatibility review in this project.
+---
+
+# Develop This Atomic Capability
+
+## Establish the publication contract
+
+1. Read \`README.md\`, \`package.json\`, \`src/capability.ts\`, \`src/index.ts\`, and \`test/capability.test.ts\`.
+2. Identify the input, output, access rule, annotations, timeout, default ID, source metadata, and root export affected by the change.
+3. Treat schemas, access behavior, \`defaultId\`, source identity, and package exports as compatibility surfaces. Request an explicit decision before breaking one.
+
+## Preserve the atomic boundary
+
+- Define the domain action with \`defineCapability\` in \`src/capability.ts\`.
+- Publish through \`defineExportedCapability\` in \`src/index.ts\` with a literal, domain-oriented default ID.
+- Inject repositories, providers, models, tools, and policy checks through a factory or closure when dependencies are needed.
+- Keep the capability independent from CLI, MCP, HTTP, and any consuming engine.
+- Do not add runtime discovery, a registry, a service locator, an adapter, or an engine entry point.
+
+## Deliver the change
+
+1. Add or update a test that imports the public descriptor, composes it with \`importCapability\`, invokes it through \`engine.invoke\`, and fails for the missing behavior.
+2. Implement the smallest capability or publication change that makes the test pass.
+3. Cover invalid input, denied access, output validation, cancellation, or dependency failure when relevant to the contract.
+4. Keep \`private: true\` until package identity, versioning, default-ID compatibility, and publication are deliberate decisions.
+5. Update project documentation when the public contract or package usage changes.
+6. Run \`${commands.check}\` and resolve every type, test, formatting, and build failure before completion.
+`;
+}
+
+const developmentSkillMetadata = `interface:
+  display_name: "Develop Invokta Capability"
+  short_description: "Develop this Invokta capability safely"
+  default_prompt: "Use $develop-invokta-project to implement this atomic capability change and validate its public export contract."
+`;
+
 function renderPackageManifest(
   projectName: string,
   invoktaVersion: string,
@@ -197,6 +237,14 @@ export function createStarterFiles(
   options: CreateStarterFilesOptions,
 ): readonly StarterFile[] {
   return Object.freeze([
+    {
+      path: ".agents/skills/develop-invokta-project/SKILL.md",
+      contents: renderDevelopmentSkill(options.packageManager),
+    },
+    {
+      path: ".agents/skills/develop-invokta-project/agents/openai.yaml",
+      contents: developmentSkillMetadata,
+    },
     { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
     {
       path: "README.md",

--- a/packages/create-invokta-capability/src/starter.ts
+++ b/packages/create-invokta-capability/src/starter.ts
@@ -1,0 +1,221 @@
+import {
+  type PackageManager,
+  packageManagerCommands,
+} from "./package-manager.js";
+
+export interface StarterFile {
+  /** Project-relative POSIX path. */
+  readonly path: string;
+  readonly contents: string;
+}
+
+export interface CreateStarterFilesOptions {
+  readonly projectName: string;
+  readonly invoktaVersion: string;
+  readonly packageManager: PackageManager;
+}
+
+function renderReadme(
+  projectName: string,
+  packageManager: PackageManager,
+): string {
+  const commands = packageManagerCommands[packageManager];
+  return `# ${projectName}
+
+A standalone Invokta atomic capability package. It exports one explicit
+\`defineExportedCapability\` descriptor that an Action Engine can import at its
+composition root.
+
+## Validate
+
+\`\`\`sh
+${commands.check}
+\`\`\`
+
+## Publish deliberately
+
+The starter is private. Before publishing, choose the final package name,
+source metadata, version, default capability ID, and compatibility policy, then
+remove \`"private": true\` from \`package.json\`.
+`;
+}
+
+function renderPackageManifest(
+  projectName: string,
+  invoktaVersion: string,
+): string {
+  const manifest = {
+    name: projectName,
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    sideEffects: false,
+    engines: { node: ">=22.20.0" },
+    exports: {
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+    },
+    scripts: {
+      build: "tsc -p tsconfig.json --pretty false",
+      typecheck:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit",
+      test: "vitest run",
+      check:
+        "tsc -p tsconfig.json --pretty false --noEmit && tsc -p tsconfig.test.json --pretty false --noEmit && vitest run && tsc -p tsconfig.json --pretty false",
+    },
+    dependencies: {
+      "@invokta/core": invoktaVersion,
+      zod: "4.4.3",
+    },
+    devDependencies: {
+      "@types/node": "26.1.2",
+      typescript: "7.0.2",
+      vitest: "4.1.10",
+    },
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+const capabilityModule = `import { defineCapability } from "@invokta/core";
+import { z } from "zod";
+
+export const createWelcomeMessage = defineCapability({
+  title: "Create a welcome message",
+  description: "Creates a short welcome message for a new team member.",
+  input: z.object({ name: z.string().trim().min(1) }),
+  output: z.object({ message: z.string().min(1) }),
+  access: "public",
+  annotations: {
+    readOnly: true,
+    destructive: false,
+    idempotent: true,
+    openWorld: false,
+  },
+  async run({ input }) {
+    return { message: \`Welcome, \${input.name}!\` };
+  },
+});
+`;
+
+function renderIndexModule(projectName: string): string {
+  return `import { defineExportedCapability } from "@invokta/core";
+
+import { createWelcomeMessage } from "./capability.js";
+
+export const createWelcomeMessageExport = defineExportedCapability({
+  source: {
+    name: ${JSON.stringify(projectName)},
+    version: "0.1.0",
+  },
+  defaultId: "onboarding.create-welcome-message",
+  capability: createWelcomeMessage,
+});
+`;
+}
+
+const capabilityTestModule = `import {
+  composeCapabilities,
+  createEngine,
+  importCapability,
+} from "@invokta/core";
+import { describe, expect, it } from "vitest";
+
+import { createWelcomeMessageExport } from "../src/index.js";
+
+const engine = createEngine({
+  name: "atomic-capability-test-engine",
+  version: "0.0.0-test",
+  capabilities: composeCapabilities({
+    imports: [importCapability(createWelcomeMessageExport)],
+  }),
+});
+
+describe("the exported welcome capability", () => {
+  it("composes and invokes through the engine boundary", async () => {
+    await expect(
+      engine.invoke(
+        "onboarding.create-welcome-message",
+        { name: "  Ada  " },
+        { principal: null },
+      ),
+    ).resolves.toEqual({ message: "Welcome, Ada!" });
+  });
+
+  it("keeps validation at the engine boundary", async () => {
+    await expect(
+      engine.invoke(
+        "onboarding.create-welcome-message",
+        { name: "   " },
+        { principal: null },
+      ),
+    ).rejects.toMatchObject({ code: "INPUT_INVALID" });
+  });
+});
+`;
+
+const tsconfig = `{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "moduleDetection": "force",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}
+`;
+
+const tsconfigTest = `{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+`;
+
+/** Returns the complete starter as deterministic, project-relative text files. */
+export function createStarterFiles(
+  options: CreateStarterFilesOptions,
+): readonly StarterFile[] {
+  return Object.freeze([
+    { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
+    {
+      path: "README.md",
+      contents: renderReadme(options.projectName, options.packageManager),
+    },
+    {
+      path: "package.json",
+      contents: renderPackageManifest(
+        options.projectName,
+        options.invoktaVersion,
+      ),
+    },
+    { path: "src/capability.ts", contents: capabilityModule },
+    {
+      path: "src/index.ts",
+      contents: renderIndexModule(options.projectName),
+    },
+    { path: "test/capability.test.ts", contents: capabilityTestModule },
+    { path: "tsconfig.json", contents: tsconfig },
+    { path: "tsconfig.test.json", contents: tsconfigTest },
+  ]);
+}

--- a/packages/create-invokta-capability/test/creator.test.ts
+++ b/packages/create-invokta-capability/test/creator.test.ts
@@ -1,0 +1,405 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runCreateCapabilityCli } from "../src/cli.js";
+import {
+  installProjectDependencies,
+  type PackageManagerRunner,
+} from "../src/install.js";
+import {
+  createStarterProject,
+  defaultScaffoldFileSystem,
+  type ScaffoldFileSystem,
+} from "../src/scaffold.js";
+import { createStarterFiles } from "../src/starter.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-capability-creator-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("the atomic capability starter", () => {
+  it("renders the fixed project deterministically in lexicographic order", () => {
+    const options = {
+      projectName: "welcome-capability",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm" as const,
+    };
+    const files = createStarterFiles(options);
+
+    expect(files.map((file) => file.path)).toEqual([
+      ".gitignore",
+      "README.md",
+      "package.json",
+      "src/capability.ts",
+      "src/index.ts",
+      "test/capability.test.ts",
+      "tsconfig.json",
+      "tsconfig.test.json",
+    ]);
+    expect(files).toEqual(createStarterFiles(options));
+    for (const file of files) {
+      expect(file.contents).not.toContain("\r");
+      expect(file.contents.endsWith("\n")).toBe(true);
+      expect(file.contents.endsWith("\n\n")).toBe(false);
+    }
+  });
+
+  it("pins the core and publishes one explicit atomic root export", () => {
+    const contents = new Map(
+      createStarterFiles({
+        projectName: "welcome-capability",
+        invoktaVersion: "1.2.3-beta.1",
+        packageManager: "npm",
+      }).map((file) => [file.path, file.contents]),
+    );
+    const manifest = JSON.parse(contents.get("package.json") ?? "") as Record<
+      string,
+      unknown
+    >;
+
+    expect(manifest).toMatchObject({
+      name: "welcome-capability",
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      sideEffects: false,
+      exports: {
+        ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+      },
+      dependencies: { "@invokta/core": "1.2.3-beta.1", zod: "4.4.3" },
+    });
+    expect(contents.get("src/index.ts")).toContain(
+      'defaultId: "onboarding.create-welcome-message"',
+    );
+    expect(contents.get("src/index.ts")).toContain(
+      'name: "welcome-capability"',
+    );
+    expect(contents.get("test/capability.test.ts")).toContain(
+      "importCapability(createWelcomeMessageExport)",
+    );
+    expect(contents.get("test/capability.test.ts")).toContain("engine.invoke(");
+  });
+});
+
+describe("createStarterProject", () => {
+  it("creates the complete starter without replacing existing entries", async () => {
+    const cwd = createWorkingDirectory();
+    const project = await createStarterProject({
+      cwd,
+      target: "packages/welcome-capability",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+
+    expect(project.files).toHaveLength(8);
+    expect(project.projectName).toBe("welcome-capability");
+    expect(existsSync(join(project.directory, "src/index.ts"))).toBe(true);
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "packages/welcome-capability",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).rejects.toMatchObject({ code: "TARGET_NOT_EMPTY", exitCode: 1 });
+  });
+
+  it("rejects unsafe and invalid targets without changing them", async () => {
+    const cwd = createWorkingDirectory();
+    const outside = createWorkingDirectory();
+    symlinkSync(outside, join(cwd, "linked"), "dir");
+    writeFileSync(join(outside, "sentinel"), "mine\n", "utf8");
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "linked/welcome-capability",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).rejects.toMatchObject({ code: "TARGET_UNSAFE", exitCode: 1 });
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "../fixture-secret-payload-marker",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).rejects.toMatchObject({ code: "TARGET_INVALID", exitCode: 2 });
+    expect(readFileSync(join(outside, "sentinel"), "utf8")).toBe("mine\n");
+  });
+
+  it("accepts every inclusive target limit", async () => {
+    const cwd = createWorkingDirectory();
+    const projectName = "a".repeat(214);
+    const pathAtLimit = [
+      ...Array.from({ length: 31 }, () => "a".repeat(31)),
+      "b".repeat(32),
+    ].join("/");
+    expect([...pathAtLimit]).toHaveLength(1_024);
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: projectName,
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).resolves.toMatchObject({ projectName });
+    await expect(
+      createStarterProject({
+        cwd,
+        target: pathAtLimit,
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+      }),
+    ).resolves.toMatchObject({ projectName: "b".repeat(32) });
+  });
+
+  it.each([
+    ["absolute", "/tmp/welcome-capability"],
+    ["parent", "../welcome-capability"],
+    ["empty segment", "packages//welcome-capability"],
+    ["invalid name", "Welcome Capability"],
+    ["long name", "a".repeat(215)],
+    ["many segments", `${"nested/".repeat(32)}welcome-capability`],
+    ["long path", `${"a".repeat(1_025)}-capability`],
+  ])(
+    "rejects an exclusive %s target before writing",
+    async (_label, target) => {
+      const cwd = createWorkingDirectory();
+
+      await expect(
+        createStarterProject({
+          cwd,
+          target,
+          invoktaVersion: "1.2.3",
+          packageManager: "npm",
+        }),
+      ).rejects.toMatchObject({ code: "TARGET_INVALID", exitCode: 2 });
+      expect(readdirSync(cwd)).toEqual([]);
+    },
+  );
+
+  it("preserves an entry that wins an exclusive-write race", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "welcome-capability");
+    let raced = false;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        if (!raced) {
+          raced = true;
+          writeFileSync(path, "mine\n", "utf8");
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "welcome-capability",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
+    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".gitignore"]);
+  });
+
+  it("rolls back only paths created by a failed write", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "welcome-capability");
+    mkdirSync(target);
+    let writes = 0;
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async writeFile(path, contents, options) {
+        writes += 1;
+        if (writes === 3) {
+          const error = new Error("fixture failure") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        await defaultScaffoldFileSystem.writeFile(path, contents, options);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "welcome-capability",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({ code: "WRITE_FAILED", exitCode: 1 });
+    expect(readdirSync(target)).toEqual([]);
+  });
+});
+
+describe("runCreateCapabilityCli", () => {
+  it("supports offline creation and sanitized invalid usage", async () => {
+    const cwd = createWorkingDirectory();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const install = vi.fn();
+    const io = {
+      writeStdout(text: string) {
+        stdout.push(text);
+      },
+      writeStderr(text: string) {
+        stderr.push(text);
+      },
+    };
+
+    await expect(
+      runCreateCapabilityCli({
+        argv: ["welcome-capability", "--no-install"],
+        cwd,
+        env: {},
+        io,
+        install,
+        loadPackageVersion: async () => "1.2.3",
+      }),
+    ).resolves.toBe(0);
+    expect(install).not.toHaveBeenCalled();
+    expect(stdout.join("")).toContain(
+      "Created welcome-capability without installing dependencies.",
+    );
+
+    stdout.length = 0;
+    await expect(
+      runCreateCapabilityCli({
+        argv: ["--version", "fixture-secret-payload-marker"],
+        cwd,
+        io,
+      }),
+    ).resolves.toBe(2);
+    expect(stderr.at(-1)).toBe(
+      'Invalid arguments. Run "create-invokta-capability --help".\n',
+    );
+    expect(stderr.join("")).not.toContain("fixture-secret-payload-marker");
+  });
+
+  it("prints its public help and version", async () => {
+    const stdout: string[] = [];
+    const io = {
+      writeStdout(text: string) {
+        stdout.push(text);
+      },
+      writeStderr: vi.fn(),
+    };
+
+    await expect(
+      runCreateCapabilityCli({ argv: ["--help"], io }),
+    ).resolves.toBe(0);
+    expect(stdout.join("")).toContain(
+      "create-invokta-capability <project-directory>",
+    );
+    stdout.length = 0;
+    await expect(
+      runCreateCapabilityCli({
+        argv: ["--version"],
+        io,
+        loadPackageVersion: async () => "1.2.3",
+      }),
+    ).resolves.toBe(0);
+    expect(stdout).toEqual(["1.2.3\n"]);
+  });
+
+  it.each([
+    { argv: [] },
+    { argv: ["welcome-capability", "other-capability"] },
+    { argv: ["welcome-capability", "--unknown"] },
+    { argv: ["welcome-capability", "--no-install", "--no-install"] },
+    { argv: ["welcome-capability", "--package-manager"] },
+    { argv: ["welcome-capability", "--package-manager", "bun"] },
+    {
+      argv: [
+        "welcome-capability",
+        "--package-manager",
+        "npm",
+        "--package-manager",
+        "pnpm",
+      ],
+    },
+  ])(
+    "rejects invalid arguments without creating a project: $argv",
+    async ({ argv }) => {
+      const cwd = createWorkingDirectory();
+      const stderr: string[] = [];
+
+      await expect(
+        runCreateCapabilityCli({
+          argv,
+          cwd,
+          io: {
+            writeStdout: vi.fn(),
+            writeStderr(text) {
+              stderr.push(text);
+            },
+          },
+        }),
+      ).resolves.toBe(2);
+      expect(stderr).toEqual([
+        'Invalid arguments. Run "create-invokta-capability --help".\n',
+      ]);
+      expect(readdirSync(cwd)).toEqual([]);
+    },
+  );
+});
+
+describe("installProjectDependencies", () => {
+  it("runs one shell-free foreground install and normalizes failure", async () => {
+    const runner = vi.fn<PackageManagerRunner>(async () => ({
+      code: 0,
+      signal: null,
+    }));
+    await installProjectDependencies({
+      directory: "/work/welcome-capability",
+      packageManager: "pnpm",
+      runner,
+    });
+    expect(runner).toHaveBeenCalledWith({
+      command: "pnpm",
+      args: ["install"],
+      cwd: "/work/welcome-capability",
+      shell: false,
+      stdio: "inherit",
+    });
+
+    await expect(
+      installProjectDependencies({
+        directory: "/work/welcome-capability",
+        packageManager: "npm",
+        runner: async () => ({ code: 1, signal: null }),
+      }),
+    ).rejects.toMatchObject({ code: "INSTALL_FAILED", details: ["npm"] });
+  });
+});

--- a/packages/create-invokta-capability/test/creator.test.ts
+++ b/packages/create-invokta-capability/test/creator.test.ts
@@ -49,6 +49,8 @@ describe("the atomic capability starter", () => {
     const files = createStarterFiles(options);
 
     expect(files.map((file) => file.path)).toEqual([
+      ".agents/skills/develop-invokta-project/SKILL.md",
+      ".agents/skills/develop-invokta-project/agents/openai.yaml",
       ".gitignore",
       "README.md",
       "package.json",
@@ -64,6 +66,31 @@ describe("the atomic capability starter", () => {
       expect(file.contents.endsWith("\n")).toBe(true);
       expect(file.contents.endsWith("\n\n")).toBe(false);
     }
+  });
+
+  it("scaffolds a focused atomic-capability development skill", () => {
+    const contents = new Map(
+      createStarterFiles({
+        projectName: "welcome-capability",
+        invoktaVersion: "1.2.3",
+        packageManager: "pnpm",
+      }).map((file) => [file.path, file.contents]),
+    );
+    const skill =
+      contents.get(".agents/skills/develop-invokta-project/SKILL.md") ?? "";
+    const metadata =
+      contents.get(
+        ".agents/skills/develop-invokta-project/agents/openai.yaml",
+      ) ?? "";
+
+    expect(skill).toMatch(
+      /^---\nname: develop-invokta-project\ndescription: .+\n---\n/u,
+    );
+    expect(skill).toContain("Publish through `defineExportedCapability`");
+    expect(skill).toContain("Run `pnpm run check`");
+    expect(skill).not.toContain("TODO");
+    expect(metadata).toContain('display_name: "Develop Invokta Capability"');
+    expect(metadata).toContain("$develop-invokta-project");
   });
 
   it("pins the core and publishes one explicit atomic root export", () => {
@@ -113,9 +140,18 @@ describe("createStarterProject", () => {
       packageManager: "npm",
     });
 
-    expect(project.files).toHaveLength(8);
+    expect(project.files).toHaveLength(10);
     expect(project.projectName).toBe("welcome-capability");
     expect(existsSync(join(project.directory, "src/index.ts"))).toBe(true);
+    expect(
+      readFileSync(
+        join(
+          project.directory,
+          ".agents/skills/develop-invokta-project/SKILL.md",
+        ),
+        "utf8",
+      ),
+    ).toContain("# Develop This Atomic Capability");
 
     await expect(
       createStarterProject({
@@ -228,8 +264,13 @@ describe("createStarterProject", () => {
         fileSystem,
       }),
     ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
-    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
-    expect(readdirSync(target)).toEqual([".gitignore"]);
+    expect(
+      readFileSync(
+        join(target, ".agents/skills/develop-invokta-project/SKILL.md"),
+        "utf8",
+      ),
+    ).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".agents"]);
   });
 
   it("rolls back only paths created by a failed write", async () => {

--- a/packages/create-invokta-capability/tsconfig.json
+++ b/packages/create-invokta-capability/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -30,6 +30,8 @@ to generate files without starting a package manager or performing network I/O.
 ## Generated project
 
 ```text
+.agents/skills/develop-invokta-project/SKILL.md
+.agents/skills/develop-invokta-project/agents/openai.yaml
 .gitignore
 AGENTS.md
 CLAUDE.md -> AGENTS.md
@@ -45,6 +47,11 @@ test/engine.test.ts
 tsconfig.json
 tsconfig.test.json
 ```
+
+The generated `develop-invokta-project` skill teaches an agent to evolve the
+Action Engine through explicit capability contracts, engine-owned dependencies,
+RED/GREEN/REFACTOR, and the single `engine.invoke` path. Its metadata includes a
+ready-to-use `$develop-invokta-project` prompt.
 
 `AGENTS.md` documents the starter's architecture and test-first delivery
 constraints. `CLAUDE.md` is a real relative symbolic link to that file, keeping

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -31,6 +31,8 @@ to generate files without starting a package manager or performing network I/O.
 
 ```text
 .gitignore
+AGENTS.md
+CLAUDE.md -> AGENTS.md
 README.md
 invokta.mcp.json
 package.json
@@ -44,8 +46,13 @@ tsconfig.json
 tsconfig.test.json
 ```
 
-Generated Invokta dependencies use the exact creator version. The files become
-project-owned immediately and are never updated in place by the creator.
+`AGENTS.md` documents the starter's architecture and test-first delivery
+constraints. `CLAUDE.md` is a real relative symbolic link to that file, keeping
+agent instructions in one source of truth. If the filesystem cannot create the
+link, creation fails and rolls back instead of copying the instructions.
+
+Generated Invokta dependencies use the exact creator version. The entries
+become project-owned immediately and are never updated in place by the creator.
 
 The starter also includes `@invokta/installer` and a build-first installation
 command:

--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   readdir,
   rmdir,
+  symlink,
   unlink,
   writeFile,
 } from "node:fs/promises";
@@ -11,7 +12,7 @@ import { basename, dirname, isAbsolute, join, resolve, win32 } from "node:path";
 
 import { CreatorError } from "./errors.js";
 import type { PackageManager } from "./package-manager.js";
-import { createStarterFiles, type StarterFile } from "./starter.js";
+import { createStarterFiles, type StarterEntry } from "./starter.js";
 
 export const creatorTargetLimits = Object.freeze({
   maxPathScalars: 1_024,
@@ -26,6 +27,7 @@ export interface ScaffoldFileSystem {
   readonly mkdir: (path: string) => Promise<void>;
   readonly readdir: (path: string) => Promise<string[]>;
   readonly rmdir: (path: string) => Promise<void>;
+  readonly symlink: (target: string, path: string) => Promise<void>;
   readonly unlink: (path: string) => Promise<void>;
   readonly writeFile: (
     path: string,
@@ -44,6 +46,9 @@ const nodeScaffoldFileSystem: ScaffoldFileSystem = {
   },
   async rmdir(path) {
     await rmdir(path);
+  },
+  async symlink(target, path) {
+    await symlink(target, path);
   },
   async unlink(path) {
     await unlink(path);
@@ -211,7 +216,7 @@ async function ensureDirectory(
 async function prepareDirectories(
   cwd: string,
   target: ResolvedTarget,
-  files: readonly StarterFile[],
+  entries: readonly StarterEntry[],
   fileSystem: ScaffoldFileSystem,
   createdDirectories: string[],
 ): Promise<void> {
@@ -221,8 +226,8 @@ async function prepareDirectories(
     await ensureDirectory(current, fileSystem, createdDirectories);
   }
   for (const directory of new Set(
-    files
-      .map((file) => dirname(file.path))
+    entries
+      .map((entry) => dirname(entry.path))
       .filter((path) => path !== ".")
       .sort(),
   )) {
@@ -236,11 +241,11 @@ async function prepareDirectories(
 
 async function rollback(
   fileSystem: ScaffoldFileSystem,
-  createdFiles: readonly string[],
+  createdEntries: readonly string[],
   createdDirectories: readonly string[],
 ): Promise<boolean> {
   let failed = false;
-  for (const path of [...createdFiles].reverse()) {
+  for (const path of [...createdEntries].reverse()) {
     try {
       await fileSystem.unlink(path);
     } catch (error) {
@@ -265,36 +270,40 @@ export async function createStarterProject(
   const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
   const target = resolveTarget(options.cwd, options.target);
   await inspectTarget(options.cwd, target, fileSystem);
-  const files = createStarterFiles({
+  const entries = createStarterFiles({
     projectName: target.projectName,
     invoktaVersion: options.invoktaVersion,
     packageManager: options.packageManager,
   });
-  const createdFiles: string[] = [];
+  const createdEntries: string[] = [];
   const createdDirectories: string[] = [];
-  let activeFile: StarterFile | undefined;
+  let activeEntry: StarterEntry | undefined;
 
   try {
     await prepareDirectories(
       options.cwd,
       target,
-      files,
+      entries,
       fileSystem,
       createdDirectories,
     );
-    for (const file of files) {
-      activeFile = file;
-      const path = join(target.directory, ...file.path.split("/"));
-      await fileSystem.writeFile(path, file.contents, {
-        encoding: "utf8",
-        flag: "wx",
-      });
-      createdFiles.push(path);
+    for (const entry of entries) {
+      activeEntry = entry;
+      const path = join(target.directory, ...entry.path.split("/"));
+      if (entry.kind === "file") {
+        await fileSystem.writeFile(path, entry.contents, {
+          encoding: "utf8",
+          flag: "wx",
+        });
+      } else {
+        await fileSystem.symlink(entry.target, path);
+      }
+      createdEntries.push(path);
     }
   } catch (error) {
     const rolledBack = await rollback(
       fileSystem,
-      createdFiles,
+      createdEntries,
       createdDirectories,
     );
     if (!rolledBack) throw new CreatorError("WRITE_FAILED");
@@ -302,18 +311,18 @@ export async function createStarterProject(
     if (readErrorCode(error) === "EEXIST") {
       throw new CreatorError(
         "SCAFFOLD_CONFLICT",
-        activeFile === undefined ? [] : [activeFile.path],
+        activeEntry === undefined ? [] : [activeEntry.path],
       );
     }
     throw new CreatorError(
       "WRITE_FAILED",
-      activeFile === undefined ? [] : [activeFile.path],
+      activeEntry === undefined ? [] : [activeEntry.path],
     );
   }
 
   return Object.freeze({
     directory: target.directory,
     projectName: target.projectName,
-    files: Object.freeze(files.map((file) => file.path)),
+    files: Object.freeze(entries.map((entry) => entry.path)),
   });
 }

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -3,11 +3,20 @@ import {
   packageManagerCommands,
 } from "./package-manager.js";
 
-export interface StarterFile {
-  /** Project-relative POSIX path. */
-  readonly path: string;
-  readonly contents: string;
-}
+export type StarterEntry =
+  | Readonly<{
+      kind: "file";
+      /** Project-relative POSIX path. */
+      path: string;
+      contents: string;
+    }>
+  | Readonly<{
+      kind: "symlink";
+      /** Project-relative POSIX path. */
+      path: string;
+      /** Project-relative symbolic-link target. */
+      target: string;
+    }>;
 
 export interface CreateStarterFilesOptions {
   readonly projectName: string;
@@ -60,6 +69,30 @@ ${packageManager === "yarn" ? "yarn mcp:install" : `${packageManager} run mcp:in
 Add stateless HTTP only when needed. Install \`@invokta/deploy\`, run
 \`invokta-deploy init\`, and implement its fail-closed authentication hook before
 exposing the endpoint.
+`;
+}
+
+function renderAgentInstructions(packageManager: PackageManager): string {
+  const commands = packageManagerCommands[packageManager];
+  return `# Project Instructions
+
+## Language
+
+Write all project content in English, including documentation, source comments,
+public errors, examples, tests, commits, and release notes.
+
+## Architecture
+
+- Define domain actions as capabilities with explicit input, output, access, and execution contracts.
+- Keep direct, CLI, and MCP entry points on the single \`engine.invoke\` path.
+- Keep models, prompts, providers, data stores, and tools behind replaceable engine-owned dependencies.
+- Do not add framework-wide registries, service locators, or adapter-specific business logic.
+
+## Delivery
+
+- Follow RED, GREEN, REFACTOR for executable behavior.
+- Run \`${commands.check}\` before completing a change.
+- Keep \`CLAUDE.md\` as a symbolic link to this file so agent instructions have one source of truth.
 `;
 }
 
@@ -246,21 +279,34 @@ const tsconfigTest = `{
 }
 `;
 
-/** Returns the complete starter as deterministic, project-relative text files. */
+/** Returns the complete starter as deterministic project-relative entries. */
 export function createStarterFiles(
   options: CreateStarterFilesOptions,
-): readonly StarterFile[] {
+): readonly StarterEntry[] {
   return Object.freeze([
-    { path: ".gitignore", contents: "node_modules/\ndist/\n*.tsbuildinfo\n" },
     {
+      kind: "file",
+      path: ".gitignore",
+      contents: "node_modules/\ndist/\n*.tsbuildinfo\n",
+    },
+    {
+      kind: "file",
+      path: "AGENTS.md",
+      contents: renderAgentInstructions(options.packageManager),
+    },
+    { kind: "symlink", path: "CLAUDE.md", target: "AGENTS.md" },
+    {
+      kind: "file",
       path: "README.md",
       contents: renderReadme(options.projectName, options.packageManager),
     },
     {
+      kind: "file",
       path: "invokta.mcp.json",
       contents: renderMcpInstallManifest(options.projectName),
     },
     {
+      kind: "file",
       path: "package.json",
       contents: renderPackageManifest(
         options.projectName,
@@ -268,18 +314,28 @@ export function createStarterFiles(
       ),
     },
     {
+      kind: "file",
       path: "src/capabilities/create-welcome-message.ts",
       contents: capabilityModule,
     },
-    { path: "src/cli.ts", contents: cliModule },
-    { path: "src/direct.ts", contents: directModule },
+    { kind: "file", path: "src/cli.ts", contents: cliModule },
+    { kind: "file", path: "src/direct.ts", contents: directModule },
     {
+      kind: "file",
       path: "src/engine.ts",
       contents: renderEngineModule(options.projectName),
     },
-    { path: "src/mcp-stdio.ts", contents: mcpStdioModule },
-    { path: "test/engine.test.ts", contents: engineTestModule },
-    { path: "tsconfig.json", contents: tsconfig },
-    { path: "tsconfig.test.json", contents: tsconfigTest },
+    { kind: "file", path: "src/mcp-stdio.ts", contents: mcpStdioModule },
+    {
+      kind: "file",
+      path: "test/engine.test.ts",
+      contents: engineTestModule,
+    },
+    { kind: "file", path: "tsconfig.json", contents: tsconfig },
+    {
+      kind: "file",
+      path: "tsconfig.test.json",
+      contents: tsconfigTest,
+    },
   ]);
 }

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -96,6 +96,47 @@ public errors, examples, tests, commits, and release notes.
 `;
 }
 
+function renderDevelopmentSkill(packageManager: PackageManager): string {
+  const commands = packageManagerCommands[packageManager];
+  return `---
+name: develop-invokta-project
+description: Develop this generated Invokta Action Engine when adding or changing capabilities, dependencies, tests, direct calls, CLI behavior, or MCP behavior. Use for implementation, refactoring, debugging, and contract review in this project.
+---
+
+# Develop This Action Engine
+
+## Establish the contract
+
+1. Read \`AGENTS.md\`, \`README.md\`, and the existing capability and engine tests.
+2. Identify the domain action, public capability ID, input, output, access rule, annotations, timeout, and observable errors affected by the change.
+3. Treat capability IDs, schemas, access behavior, and adapter-visible results as compatibility surfaces. Request an explicit decision before breaking one.
+
+## Keep one architecture
+
+- Define domain actions with \`defineCapability\` and explicit input, output, access, and execution contracts.
+- Inject models, providers, repositories, tools, and policy checks through engine-owned factories or closures.
+- Register capabilities under literal domain-oriented IDs in \`src/engine.ts\`.
+- Keep every execution channel on \`engine.invoke\`; never call a capability's \`run\` directly.
+- Keep business logic out of \`src/direct.ts\`, \`src/cli.ts\`, and \`src/mcp-stdio.ts\`.
+- Do not add a service locator, runtime registry, plugin discovery, workflow engine, or adapter-specific capability implementation.
+
+## Deliver the change
+
+1. Add or update an engine-level test that invokes the capability and fails for the missing behavior.
+2. Implement the smallest capability, dependency, composition-root, or adapter wiring change that makes the test pass.
+3. Cover invalid input, denied access, output validation, cancellation, or dependency failure when relevant to the contract.
+4. Keep direct, CLI, and MCP behavior consistent by testing the shared engine boundary rather than duplicating handlers.
+5. Update project documentation when commands, configuration, capability IDs, or public behavior change.
+6. Run \`${commands.check}\` and resolve every type, test, formatting, and build failure before completion.
+`;
+}
+
+const developmentSkillMetadata = `interface:
+  display_name: "Develop Invokta Action Engine"
+  short_description: "Develop this Invokta Action Engine safely"
+  default_prompt: "Use $develop-invokta-project to implement this Action Engine change through the single engine.invoke path."
+`;
+
 function renderPackageManifest(
   projectName: string,
   invoktaVersion: string,
@@ -284,6 +325,16 @@ export function createStarterFiles(
   options: CreateStarterFilesOptions,
 ): readonly StarterEntry[] {
   return Object.freeze([
+    {
+      kind: "file",
+      path: ".agents/skills/develop-invokta-project/SKILL.md",
+      contents: renderDevelopmentSkill(options.packageManager),
+    },
+    {
+      kind: "file",
+      path: ".agents/skills/develop-invokta-project/agents/openai.yaml",
+      contents: developmentSkillMetadata,
+    },
     {
       kind: "file",
       path: ".gitignore",

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -180,7 +180,7 @@ describe("runCreateEngineCli", () => {
         "  npm\n",
     );
     expect(existsSync(join(cwd, "my-engine/package.json"))).toBe(true);
-    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(10);
+    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(11);
   });
 
   it.each(invalidArgumentCases)(

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -180,7 +180,7 @@ describe("runCreateEngineCli", () => {
         "  npm\n",
     );
     expect(existsSync(join(cwd, "my-engine/package.json"))).toBe(true);
-    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(8);
+    expect(readdirSync(join(cwd, "my-engine"))).toHaveLength(10);
   });
 
   it.each(invalidArgumentCases)(

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -1,9 +1,11 @@
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -51,10 +53,15 @@ describe("createStarterProject", () => {
 
     expect(result.projectName).toBe("my-engine");
     expect(result.directory).toBe(join(cwd, "engines/my-engine"));
-    expect(result.files).toHaveLength(12);
+    expect(result.files).toHaveLength(14);
     expect(
       JSON.parse(readFileSync(join(result.directory, "package.json"), "utf8")),
     ).toMatchObject({ name: "my-engine", private: true });
+    expect(lstatSync(join(result.directory, "AGENTS.md")).isFile()).toBe(true);
+    expect(
+      lstatSync(join(result.directory, "CLAUDE.md")).isSymbolicLink(),
+    ).toBe(true);
+    expect(readlinkSync(join(result.directory, "CLAUDE.md"))).toBe("AGENTS.md");
   });
 
   it("creates the starter in an existing empty directory", async () => {
@@ -65,6 +72,8 @@ describe("createStarterProject", () => {
 
     expect(readdirSync(join(cwd, "my-engine")).sort()).toEqual([
       ".gitignore",
+      "AGENTS.md",
+      "CLAUDE.md",
       "README.md",
       "invokta.mcp.json",
       "package.json",
@@ -208,13 +217,77 @@ describe("createStarterProject", () => {
     expect(readdirSync(target)).toEqual([".gitignore"]);
   });
 
+  it("preserves a symbolic link that wins an exclusive-create race", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async symlink(linkTarget, path) {
+        symlinkSync("external-agents.md", path);
+        await defaultScaffoldFileSystem.symlink(linkTarget, path);
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({
+      code: "SCAFFOLD_CONFLICT",
+      exitCode: 1,
+      details: ["CLAUDE.md"],
+    });
+    expect(readdirSync(target)).toEqual(["CLAUDE.md"]);
+    expect(readlinkSync(join(target, "CLAUDE.md"))).toBe("external-agents.md");
+  });
+
+  it("normalizes a symbolic-link creation failure and rolls back", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    mkdirSync(target);
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async symlink() {
+        const error = new Error(
+          "fixture link failure",
+        ) as NodeJS.ErrnoException;
+        error.code = "EACCES";
+        throw error;
+      },
+    };
+
+    await expect(
+      createStarterProject({
+        cwd,
+        target: "my-engine",
+        invoktaVersion: "1.2.3",
+        packageManager: "npm",
+        fileSystem,
+      }),
+    ).rejects.toMatchObject({
+      code: "WRITE_FAILED",
+      exitCode: 1,
+      details: ["CLAUDE.md"],
+    });
+    expect(readdirSync(target)).toEqual([]);
+  });
+
   it("rolls back only paths created by a failed scaffold write", async () => {
     const cwd = createWorkingDirectory();
     const target = join(cwd, "my-engine");
     mkdirSync(target);
     let writes = 0;
+    let linkCreated = false;
     const fileSystem: ScaffoldFileSystem = {
       ...defaultScaffoldFileSystem,
+      async symlink(linkTarget, path) {
+        await defaultScaffoldFileSystem.symlink(linkTarget, path);
+        linkCreated = true;
+      },
       async writeFile(path, contents, options) {
         writes += 1;
         if (writes === 3) {
@@ -237,6 +310,7 @@ describe("createStarterProject", () => {
         fileSystem,
       }),
     ).rejects.toBeInstanceOf(CreatorError);
+    expect(linkCreated).toBe(true);
     expect(existsSync(target)).toBe(true);
     expect(readdirSync(target)).toEqual([]);
   });

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -53,7 +53,7 @@ describe("createStarterProject", () => {
 
     expect(result.projectName).toBe("my-engine");
     expect(result.directory).toBe(join(cwd, "engines/my-engine"));
-    expect(result.files).toHaveLength(14);
+    expect(result.files).toHaveLength(16);
     expect(
       JSON.parse(readFileSync(join(result.directory, "package.json"), "utf8")),
     ).toMatchObject({ name: "my-engine", private: true });
@@ -62,6 +62,15 @@ describe("createStarterProject", () => {
       lstatSync(join(result.directory, "CLAUDE.md")).isSymbolicLink(),
     ).toBe(true);
     expect(readlinkSync(join(result.directory, "CLAUDE.md"))).toBe("AGENTS.md");
+    expect(
+      readFileSync(
+        join(
+          result.directory,
+          ".agents/skills/develop-invokta-project/SKILL.md",
+        ),
+        "utf8",
+      ),
+    ).toContain("# Develop This Action Engine");
   });
 
   it("creates the starter in an existing empty directory", async () => {
@@ -71,6 +80,7 @@ describe("createStarterProject", () => {
     await createProject(cwd);
 
     expect(readdirSync(join(cwd, "my-engine")).sort()).toEqual([
+      ".agents",
       ".gitignore",
       "AGENTS.md",
       "CLAUDE.md",
@@ -213,8 +223,13 @@ describe("createStarterProject", () => {
         fileSystem,
       }),
     ).rejects.toMatchObject({ code: "SCAFFOLD_CONFLICT", exitCode: 1 });
-    expect(readFileSync(join(target, ".gitignore"), "utf8")).toBe("mine\n");
-    expect(readdirSync(target)).toEqual([".gitignore"]);
+    expect(
+      readFileSync(
+        join(target, ".agents/skills/develop-invokta-project/SKILL.md"),
+        "utf8",
+      ),
+    ).toBe("mine\n");
+    expect(readdirSync(target)).toEqual([".agents"]);
   });
 
   it("preserves a symbolic link that wins an exclusive-create race", async () => {
@@ -290,7 +305,7 @@ describe("createStarterProject", () => {
       },
       async writeFile(path, contents, options) {
         writes += 1;
-        if (writes === 3) {
+        if (writes === 5) {
           const error = new Error(
             "fixture write failure",
           ) as NodeJS.ErrnoException;

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { createStarterFiles } from "../src/starter.js";
 
 const expectedPaths = [
+  ".agents/skills/develop-invokta-project/SKILL.md",
+  ".agents/skills/develop-invokta-project/agents/openai.yaml",
   ".gitignore",
   "AGENTS.md",
   "CLAUDE.md",
@@ -42,6 +44,34 @@ describe("createStarterFiles", () => {
       expect(file.contents.endsWith("\n")).toBe(true);
       expect(file.contents.endsWith("\n\n")).toBe(false);
     }
+  });
+
+  it("scaffolds a focused Action Engine development skill", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+    const contents = new Map(
+      files.flatMap((file) =>
+        "contents" in file ? [[file.path, file.contents] as const] : [],
+      ),
+    );
+    const skill =
+      contents.get(".agents/skills/develop-invokta-project/SKILL.md") ?? "";
+    const metadata =
+      contents.get(
+        ".agents/skills/develop-invokta-project/agents/openai.yaml",
+      ) ?? "";
+
+    expect(skill).toMatch(
+      /^---\nname: develop-invokta-project\ndescription: .+\n---\n/u,
+    );
+    expect(skill).toContain("Keep every execution channel on `engine.invoke`");
+    expect(skill).toContain("Run `npm run check`");
+    expect(skill).not.toContain("TODO");
+    expect(metadata).toContain('display_name: "Develop Invokta Action Engine"');
+    expect(metadata).toContain("$develop-invokta-project");
   });
 
   it("uses one agent-instruction file through a relative Claude alias", () => {

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -4,6 +4,8 @@ import { createStarterFiles } from "../src/starter.js";
 
 const expectedPaths = [
   ".gitignore",
+  "AGENTS.md",
+  "CLAUDE.md",
   "README.md",
   "invokta.mcp.json",
   "package.json",
@@ -34,11 +36,33 @@ describe("createStarterFiles", () => {
       }),
     );
     for (const file of files) {
+      if (!("contents" in file)) continue;
       expect(file.contents).not.toContain("\r");
       expect(file.contents).not.toContain("\u0000");
       expect(file.contents.endsWith("\n")).toBe(true);
       expect(file.contents.endsWith("\n\n")).toBe(false);
     }
+  });
+
+  it("uses one agent-instruction file through a relative Claude alias", () => {
+    const files = createStarterFiles({
+      projectName: "customer-support-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+    });
+    const instructions = files.find((file) => file.path === "AGENTS.md");
+
+    expect(instructions).toMatchObject({ kind: "file", path: "AGENTS.md" });
+    expect(
+      instructions && "contents" in instructions ? instructions.contents : "",
+    ).toContain(
+      "Keep direct, CLI, and MCP entry points on the single `engine.invoke` path.",
+    );
+    expect(files.find((file) => file.path === "CLAUDE.md")).toEqual({
+      kind: "symlink",
+      path: "CLAUDE.md",
+      target: "AGENTS.md",
+    });
   });
 
   it("pins Invokta packages to the creator version in a private ESM project", () => {
@@ -48,10 +72,9 @@ describe("createStarterFiles", () => {
       packageManager: "npm",
     });
     const manifestFile = files.find((file) => file.path === "package.json");
-    const manifest = JSON.parse(manifestFile?.contents ?? "") as Record<
-      string,
-      unknown
-    >;
+    const manifest = JSON.parse(
+      manifestFile && "contents" in manifestFile ? manifestFile.contents : "",
+    ) as Record<string, unknown>;
 
     expect(manifest).toMatchObject({
       name: "customer-support-engine",
@@ -80,7 +103,11 @@ describe("createStarterFiles", () => {
       invoktaVersion: "1.2.3",
       packageManager: "npm",
     });
-    const contents = new Map(files.map((file) => [file.path, file.contents]));
+    const contents = new Map(
+      files.flatMap((file) =>
+        "contents" in file ? [[file.path, file.contents] as const] : [],
+      ),
+    );
     const packageManifest = JSON.parse(contents.get("package.json") ?? "") as {
       readonly scripts: Readonly<Record<string, string>>;
     };
@@ -109,7 +136,11 @@ describe("createStarterFiles", () => {
       invoktaVersion: "1.2.3",
       packageManager: "npm",
     });
-    const contents = new Map(files.map((file) => [file.path, file.contents]));
+    const contents = new Map(
+      files.flatMap((file) =>
+        "contents" in file ? [[file.path, file.contents] as const] : [],
+      ),
+    );
 
     expect(
       contents.get("src/capabilities/create-welcome-message.ts"),
@@ -139,9 +170,10 @@ describe("createStarterFiles", () => {
         packageManager: manager,
       });
 
-      expect(
-        files.find((file) => file.path === "README.md")?.contents,
-      ).toContain(command);
+      const readme = files.find((file) => file.path === "README.md");
+      expect(readme && "contents" in readme ? readme.contents : "").toContain(
+        command,
+      );
     },
   );
 });

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -3,9 +3,11 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -105,6 +107,20 @@ function failReleaseMetadata(message) {
 function requireEqual(actual, expected, label) {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     failReleaseMetadata(`${label} must be ${JSON.stringify(expected)}`);
+  }
+}
+
+function verifyGeneratedAgentInstructions(projectDirectory, creatorName) {
+  const agentsPath = join(projectDirectory, "AGENTS.md");
+  const claudePath = join(projectDirectory, "CLAUDE.md");
+  if (!lstatSync(agentsPath).isFile()) {
+    throw new Error(`${creatorName} did not generate AGENTS.md as a file`);
+  }
+  if (!lstatSync(claudePath).isSymbolicLink()) {
+    throw new Error(`${creatorName} did not generate CLAUDE.md as a symlink`);
+  }
+  if (readlinkSync(claudePath) !== "AGENTS.md") {
+    throw new Error(`${creatorName} generated an invalid CLAUDE.md target`);
   }
 }
 
@@ -476,6 +492,10 @@ try {
   }
 
   const generatedProjectDirectory = join(generatedDirectory, "release-engine");
+  verifyGeneratedAgentInstructions(
+    generatedProjectDirectory,
+    "create-invokta-engine",
+  );
   const generatedManifest = JSON.parse(
     readFileSync(join(generatedProjectDirectory, "package.json"), "utf8"),
   );
@@ -553,11 +573,13 @@ try {
       command: "create-invokta-capability",
       target: "release-capability",
       expectedExports: ["createWelcomeMessageExport"],
+      generatesAgentInstructions: false,
     },
     {
       command: "create-invokta-capability-library",
       target: "release-capability-library",
       expectedExports: ["onboardingCapabilityLibrary"],
+      generatesAgentInstructions: true,
     },
   ];
   for (const creatorCase of capabilityCreatorCases) {
@@ -591,6 +613,9 @@ try {
     }
 
     const projectDirectory = join(generatedDirectory, creatorCase.target);
+    if (creatorCase.generatesAgentInstructions) {
+      verifyGeneratedAgentInstructions(projectDirectory, creatorCase.command);
+    }
     const manifest = JSON.parse(
       readFileSync(join(projectDirectory, "package.json"), "utf8"),
     );

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -56,6 +56,18 @@ const publicPackages = [
     // The creator is binary-only and ships no import API.
     requiredFiles: ["dist/bin.js"],
   },
+  {
+    directory: "create-invokta-capability",
+    name: "create-invokta-capability",
+    // The creator is binary-only and ships no import API.
+    requiredFiles: ["dist/bin.js"],
+  },
+  {
+    directory: "create-invokta-capability-library",
+    name: "create-invokta-capability-library",
+    // The creator is binary-only and ships no import API.
+    requiredFiles: ["dist/bin.js"],
+  },
 ];
 
 function run(command, args, options = {}) {
@@ -535,6 +547,90 @@ try {
   }
   writeGeneratedMcpSmoke(generatedProjectDirectory);
   run("node", ["mcp-smoke.mjs"], { cwd: generatedProjectDirectory });
+
+  const capabilityCreatorCases = [
+    {
+      command: "create-invokta-capability",
+      target: "release-capability",
+      expectedExports: ["createWelcomeMessageExport"],
+    },
+    {
+      command: "create-invokta-capability-library",
+      target: "release-capability-library",
+      expectedExports: ["onboardingCapabilityLibrary"],
+    },
+  ];
+  for (const creatorCase of capabilityCreatorCases) {
+    const command = join(
+      consumerDirectory,
+      "node_modules",
+      ".bin",
+      creatorCase.command,
+    );
+    const version = run(command, ["--version"], {
+      cwd: generatedDirectory,
+      capture: true,
+      env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+    });
+    if (version !== `${releaseVersion}\n`) {
+      throw new Error(`${creatorCase.command} binary version smoke failed`);
+    }
+    const output = run(
+      command,
+      [creatorCase.target, "--package-manager", "npm", "--no-install"],
+      {
+        cwd: generatedDirectory,
+        capture: true,
+        env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+      },
+    );
+    if (
+      !output.startsWith(`Created ${creatorCase.target} without installing`)
+    ) {
+      throw new Error(`${creatorCase.command} scaffold smoke failed`);
+    }
+
+    const projectDirectory = join(generatedDirectory, creatorCase.target);
+    const manifest = JSON.parse(
+      readFileSync(join(projectDirectory, "package.json"), "utf8"),
+    );
+    if (
+      manifest.private !== true ||
+      manifest.dependencies?.["@invokta/core"] !== releaseVersion
+    ) {
+      throw new Error(
+        `${creatorCase.command} generated manifest is not release-aligned`,
+      );
+    }
+    const coreTarball = tarballsByName.get("@invokta/core");
+    if (coreTarball === undefined) {
+      throw new Error("generated capability consumer tarball is incomplete");
+    }
+    run(
+      "npm",
+      ["install", "--ignore-scripts", "--no-audit", "--no-fund", coreTarball],
+      { cwd: projectDirectory },
+    );
+    run("npm", ["run", "--silent", "check"], { cwd: projectDirectory });
+
+    const exportedNames = JSON.parse(
+      run(
+        "node",
+        [
+          "--input-type=module",
+          "--eval",
+          'import("./dist/index.js").then((module) => process.stdout.write(JSON.stringify(Object.keys(module)) + "\\n"))',
+        ],
+        { cwd: projectDirectory, capture: true },
+      ),
+    );
+    if (
+      JSON.stringify(exportedNames) !==
+      JSON.stringify(creatorCase.expectedExports)
+    ) {
+      throw new Error(`${creatorCase.command} root export smoke failed`);
+    }
+  }
 
   const installerVersion = run(installerCommand, ["--version"], {
     cwd: consumerDirectory,

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -124,6 +124,46 @@ function verifyGeneratedAgentInstructions(projectDirectory, creatorName) {
   }
 }
 
+function verifyGeneratedDevelopmentSkill(
+  projectDirectory,
+  creatorName,
+  expectedHeading,
+) {
+  const skillDirectory = join(
+    projectDirectory,
+    ".agents",
+    "skills",
+    "develop-invokta-project",
+  );
+  const skillPath = join(skillDirectory, "SKILL.md");
+  const metadataPath = join(skillDirectory, "agents", "openai.yaml");
+  if (!lstatSync(skillPath).isFile() || !lstatSync(metadataPath).isFile()) {
+    throw new Error(`${creatorName} did not generate regular skill files`);
+  }
+
+  const skill = readFileSync(skillPath, "utf8");
+  if (
+    !/^---\nname: develop-invokta-project\ndescription: [^\n]+\n---\n/u.test(
+      skill,
+    ) ||
+    !skill.includes(expectedHeading) ||
+    skill.includes("TODO")
+  ) {
+    throw new Error(`${creatorName} generated an invalid development skill`);
+  }
+
+  const metadata = readFileSync(metadataPath, "utf8");
+  if (
+    !metadata.startsWith("interface:\n") ||
+    !metadata.includes("display_name:") ||
+    !metadata.includes("short_description:") ||
+    !metadata.includes("default_prompt:") ||
+    !metadata.includes("$develop-invokta-project")
+  ) {
+    throw new Error(`${creatorName} generated invalid skill metadata`);
+  }
+}
+
 function verifyRootReleaseMetadata(packageReport) {
   const releaseVersion = packageReport.version;
   if (
@@ -492,6 +532,11 @@ try {
   }
 
   const generatedProjectDirectory = join(generatedDirectory, "release-engine");
+  verifyGeneratedDevelopmentSkill(
+    generatedProjectDirectory,
+    "create-invokta-engine",
+    "# Develop This Action Engine",
+  );
   verifyGeneratedAgentInstructions(
     generatedProjectDirectory,
     "create-invokta-engine",
@@ -574,12 +619,14 @@ try {
       target: "release-capability",
       expectedExports: ["createWelcomeMessageExport"],
       generatesAgentInstructions: false,
+      expectedSkillHeading: "# Develop This Atomic Capability",
     },
     {
       command: "create-invokta-capability-library",
       target: "release-capability-library",
       expectedExports: ["onboardingCapabilityLibrary"],
       generatesAgentInstructions: true,
+      expectedSkillHeading: "# Develop This Capability Library",
     },
   ];
   for (const creatorCase of capabilityCreatorCases) {
@@ -613,6 +660,11 @@ try {
     }
 
     const projectDirectory = join(generatedDirectory, creatorCase.target);
+    verifyGeneratedDevelopmentSkill(
+      projectDirectory,
+      creatorCase.command,
+      creatorCase.expectedSkillHeading,
+    );
     if (creatorCase.generatesAgentInstructions) {
       verifyGeneratedAgentInstructions(projectDirectory, creatorCase.command);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     { "path": "./packages/cli" },
     { "path": "./packages/mcp" },
     { "path": "./packages/deploy" },
+    { "path": "./packages/create-invokta-capability" },
+    { "path": "./packages/create-invokta-capability-library" },
     { "path": "./packages/create-invokta-engine" },
     { "path": "./packages/installer" },
     { "path": "./packages/tooling" },


### PR DESCRIPTION
## What changed

- add `create-invokta-capability` for standalone atomic capability packages
- add `create-invokta-capability-library` for standalone capability-library packages
- generate deterministic private ESM starters with safe, non-overwriting scaffolding
- add a project-owned `AGENTS.md` and relative `CLAUDE.md -> AGENTS.md` symbolic link to generated engines and capability libraries
- add a valid `develop-invokta-project` skill to generated engines, atomic capabilities, and capability libraries
- tailor each skill to its execution or publication boundary, RED/GREEN/REFACTOR workflow, and package-manager validation command
- preserve racing link entries, normalize unsupported-link failures, and roll back only creator-owned entries
- document the creator contracts in ADRs 0014–0016 and extend CI/release verification to all nine public packages

## Why

Authors can already create a standalone Action Engine, but reusable atomic capabilities and capability libraries still require adapting repository-local examples. These creators provide bounded bootstrap paths without adding discovery, publishing automation, adapters, or another capability execution path.

Generated projects also need durable agent guidance. Engine and library projects expose one instruction source through `AGENTS.md` and a relative `CLAUDE.md` alias. All three project types include the same invocable skill name with content tailored to the project’s actual architectural boundary.

## Developer impact

After the packages are published:

```sh
npm create invokta-capability@latest my-capability
npm create invokta-capability-library@latest my-library
```

Generated projects include `.agents/skills/develop-invokta-project/SKILL.md` and deterministic `agents/openai.yaml` metadata. The skill is static guidance and adds no runtime registry, plugin, adapter, or execution mechanism.

Generated engines and capability libraries also contain a regular `AGENTS.md` and a real relative `CLAUDE.md` symlink. Filesystems that cannot create the symlink fail safely with `WRITE_FAILED`; the creator does not copy or overwrite instructions.

Capability-package starters remain private by default and require deliberate package identity, default-ID, versioning, and publishing decisions.

## Review

- no unresolved GitHub review threads or requested changes
- priority review found no P0 or P1 correctness, security, compatibility, or architecture issues
- generated skills passed canonical validation and isolated forward-tests for all three project types

## Validation

- focused creator suite: 97 tests passed
- `yarn run check`: 1,775 passed, 1 skipped; typecheck, lint, formatting, and build passed
- docs `yarn validate`: 14 tests passed; Astro check and 34-page build passed
- `yarn audit`: 0 vulnerabilities
- `yarn release:verify`: all nine tarballs and generated engine/capability/library consumers passed, including symlink and skill inspection
