### PR TITLE
Implement engine-scoped MCP uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Every generated engine, atomic capability, and capability-library project now
   includes a valid `develop-invokta-project` skill tailored to its architecture
   and test-first workflow.
+- Generated engines now include a build-free `mcp:uninstall` command that
+  removes the same managed engine identity from every configured MCP client
+  through one confirmed, ownership-safe operation.
 
 ## [0.2.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,16 @@ npm create invokta-engine@latest my-engine
 cd my-engine
 npm run check
 npm run mcp:install
+# Later, remove the engine from every managed MCP client:
+npm run mcp:uninstall
 ```
 
 `mcp:install` builds the generated engine, detects eligible MCP clients,
 preselects them, and asks for one confirmation before updating their user
-configuration. See the [installer reference](./apps/docs/src/content/docs/reference/installer.mdx)
-for remote HTTP registration and lifecycle commands.
+configuration. `mcp:uninstall` is build-free and removes the same logical engine
+from every installer-managed client after one confirmation. See the
+[installer reference](./apps/docs/src/content/docs/reference/installer.mdx) for
+remote HTTP registration and lifecycle commands.
 
 Create reusable package boundaries directly when an engine is not the owning
 project:

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -48,10 +48,14 @@ clients with one command:
 cd my-engine
 npm run check
 npm run mcp:install
+# Later, remove the engine from every managed MCP client:
+npm run mcp:uninstall
 ```
 
 The script builds first, preselects every eligible client, and requires one
-confirmation before writing user configuration. See the
+confirmation before writing user configuration. The build-free uninstall script
+uses the manifest ID to remove that engine from every installer-managed client
+after one confirmation, even when its compiled entry point is absent. See the
 [installer reference](/reference/installer/) for supported clients, remote HTTP
 registration, and lifecycle management.
 

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -15,6 +15,8 @@ The shortest path is generated with every starter engine:
 npm create invokta-engine@latest my-engine
 cd my-engine
 npm run mcp:install
+# Later, remove the same logical engine from every managed client:
+npm run mcp:uninstall
 ```
 
 `mcp:install` builds the engine, validates its local installation manifest,
@@ -51,6 +53,7 @@ invokta-installer status
 invokta-installer enable
 invokta-installer disable
 invokta-installer remove
+invokta-installer remove --engine <project-directory>
 invokta-installer --help
 invokta-installer --version
 ```
@@ -72,7 +75,8 @@ recommended interface:
 ```json
 {
   "scripts": {
-    "mcp:install": "tsc -p tsconfig.json --pretty false && invokta-installer install --engine ."
+    "mcp:install": "tsc -p tsconfig.json --pretty false && invokta-installer install --engine .",
+    "mcp:uninstall": "invokta-installer remove --engine ."
   }
 }
 ```
@@ -103,6 +107,12 @@ entry-point path. It does not import, reflect on, or execute project code.
 
 Moving or deleting the project invalidates the recorded launch descriptor.
 Build and install again from the new location to update it explicitly.
+
+The uninstall script is intentionally build-free. It validates the project
+manifest but does not require the compiled entry point, recorded Node
+executable, forwarded environment variables, or an installed client executable.
+The manifest `id` selects the same logical engine across every managed target;
+project location and mutable manifest metadata are not provenance.
 
 ### Install a remote HTTP server
 
@@ -151,6 +161,19 @@ deletes the surrounding client configuration.
 
 An entry changed outside the installer is drift and is never overwritten or
 removed automatically. A different server using the same name is a conflict.
+
+`remove --engine <project-directory>` is the project-scoped overload. It
+preflights every state record matching the manifest ID in stable target order,
+shows removable and blocked clients, and requests one confirmation for the
+complete removable set. Each target remains an independent transaction, so a
+failure stays unchanged without rolling back a different target that already
+committed. Repeating a successful removal is an idempotent no-op.
+
+Every removable record must contain its persisted launch descriptor. Legacy
+records without one remain unavailable, and this command never reconstructs
+ownership metadata from the current manifest or bundled registry. A record
+using the manifest's current server name under another identity fails the whole
+preflight as `ENGINE_IDENTITY_MISMATCH` before confirmation or writes.
 
 ## Supported targets
 

--- a/apps/docs/test/site-contract.node.mjs
+++ b/apps/docs/test/site-contract.node.mjs
@@ -278,9 +278,14 @@ test("an empty installer registry does not hide direct installation", async () =
   );
   assert.match(reference, /bundled capability registry may remain empty/iu);
   assert.match(reference, /install --engine/iu);
+  assert.match(reference, /remove --engine/iu);
+  assert.match(reference, /mcp:uninstall/iu);
+  assert.match(reference, /build-free/iu);
   assert.match(reference, /install --http/iu);
   assert.match(installation, /npm run mcp:install/iu);
+  assert.match(installation, /npm run mcp:uninstall/iu);
   assert.match(rootReadme, /npm run mcp:install/iu);
+  assert.match(rootReadme, /npm run mcp:uninstall/iu);
 });
 
 test("the capability package guide covers authoring, publishing, and consuming", async () => {

--- a/docs/adr/0012-standalone-invokta-engine-creator.md
+++ b/docs/adr/0012-standalone-invokta-engine-creator.md
@@ -83,9 +83,11 @@ release; generated files are user-owned and are never upgraded in place.
 
 The generated version-one `invokta.mcp.json` manifest statically identifies the
 compiled MCP stdio entry point and declared starter capability. The package adds
-`@invokta/installer` as a development dependency and an `mcp:install` script
-that builds before starting the interactive project-local installation defined
-by ADR 0013.
+`@invokta/installer` as a development dependency plus `mcp:install` and
+`mcp:uninstall` scripts. Install builds before starting the interactive
+project-local installation defined by ADR 0013. Uninstall invokes the
+engine-scoped removal defined by ADR 0017 without building or requiring the
+compiled entry point.
 
 Unless `--no-install` is present, the creator runs exactly one package-manager
 install as a direct child process without a shell. An explicit package manager

--- a/docs/adr/0017-engine-scoped-mcp-uninstall.md
+++ b/docs/adr/0017-engine-scoped-mcp-uninstall.md
@@ -1,0 +1,72 @@
+# ADR 0017: Engine-scoped MCP uninstall
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+Generated Action Engines build and install their MCP stdio entry point through a
+project-local command, but removing that logical engine still requires selecting
+one managed target at a time through the global installer. Cleanup also stops
+being convenient after the compiled entry point or recorded Node executable is
+unavailable, even though removal authority comes from installer state and the
+current client definition rather than from executing the engine.
+
+The installer state schema already treats `entryId` as the identity shared by
+bundled, local-engine, and direct-remote sources. It persists at most one record
+per identity and target, including the launch descriptor and ownership
+fingerprint needed to inspect and remove the exact managed definition.
+
+## Decision
+
+`@invokta/installer` adds the interactive command:
+
+```text
+invokta-installer remove --engine <project-directory>
+```
+
+The command validates the explicit project's closed `invokta.mcp.json` manifest
+through the existing current-user, no-follow boundary without requiring the
+compiled entry point. Its manifest `id` selects every state record with the same
+`entryId` in the fixed user-scope target catalog. Identity is installer-global:
+project paths, mutable manifest metadata, and source kind are not provenance,
+and reusing an ID denotes the same logical engine.
+
+Before mutation, a state record using the manifest's current server name under a
+different identity fails the complete operation as
+`ENGINE_IDENTITY_MISMATCH`. Records without a persisted launch descriptor remain
+unavailable; the scoped flow does not reconstruct one from the manifest or
+bundled registry.
+
+The command preflights every matching target, reports removable and blocked
+entries, and requires one confirmation for the ordered removable set. Each
+target remains an independent state-lock-then-config-lock transaction with
+locked revalidation, atomic configuration and state commits, exact rollback,
+partial results, and idempotent retry. A blocked or failed target makes the final
+exit status `1` without rolling back an independently committed target.
+
+Removal does not require client executable evidence, the engine runtime,
+launch or credential environment values, process execution, network access,
+engine import, transport startup, or capability invocation. Existing installer
+path-selection environment variables remain available for locating user
+configuration and state. Removal uses only the persisted descriptor, current
+target contract, safe configuration evidence, and exact ownership fingerprint.
+The argument-free `remove` command retains its single-selection behavior.
+
+`create-invokta-engine` adds the build-free package script
+`mcp:uninstall = "invokta-installer remove --engine ."` and documents it beside
+the existing build-first `mcp:install`. Generated projects remain user-owned and
+are not rewritten in place.
+
+## Consequences
+
+- A generated engine has symmetric install and uninstall commands without a new
+  package, state schema, target format, or execution path.
+- The local manifest ID becomes explicit removal authority for all matching
+  installer sources after current-user validation and interactive confirmation.
+- Runtime availability is no longer a removal precondition; drift, conflicts,
+  unsafe paths, unsupported targets, and unavailable ownership metadata still
+  fail closed.
+- Multi-target uninstall is deterministic but not globally atomic. Existing
+  per-target locking, rollback, bounded resources, and secret-free diagnostics
+  remain authoritative.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0014](0014-standalone-capability-project-creators.md) | Standalone capability project creators | Accepted | 2026-07-29 |
 | [0015](0015-generated-agent-instruction-aliases.md) | Generated agent instruction aliases | Accepted | 2026-07-30 |
 | [0016](0016-generated-invokta-development-skills.md) | Generated Invokta development skills | Accepted | 2026-07-30 |
+| [0017](0017-engine-scoped-mcp-uninstall.md) | Engine-scoped MCP uninstall | Accepted | 2026-07-30 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -299,6 +299,8 @@ names but no environment values or credentials.
 **AE-INSTALL-02 — Confirmed user scope.** Installation targets only the finite
 catalog of supported default user configurations. All compatible eligible
 targets are preselected, but no mutation occurs without explicit confirmation.
+Engine-scoped removal preflights every matching managed target and one
+confirmation authorizes its complete ordered removable set.
 Creating a missing configuration requires installed-client evidence. Project,
 profile, remote-workspace, organization-managed, and Windows configuration
 mutation are not provided by this profile.
@@ -306,9 +308,12 @@ mutation are not provided by this profile.
 **AE-INSTALL-03 — Managed lifecycle.** New ownership records persist the
 normalized launch descriptor. `status`, `enable`, `disable`, and `remove`
 re-inspect current configuration and fail closed on conflicts, drift, an unsafe
-path, a missing runtime, or unavailable legacy metadata. Removal deletes only a
-definition whose managed identity still matches and then removes its ownership
-record.
+path, or unavailable legacy metadata. Status and enablement report or fail on a
+missing runtime when execution would require it. Removal does not require the
+engine runtime: it deletes only a definition whose persisted managed identity
+and ownership evidence still match, then removes its ownership record. The
+engine-scoped overload applies that rule independently to every state record
+selected by one validated manifest ID.
 
 **AE-INSTALL-04 — Per-target transaction.** Each client mutation acquires the
 shared state lock before its configuration lock, revalidates after locking,

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -4,7 +4,7 @@
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
-  accepted in ADR 0016
+  accepted in ADR 0016; engine-scoped MCP uninstall accepted in ADR 0017
 
 ## Reuse evidence
 
@@ -39,8 +39,9 @@ consumer can use the protocol surface without coupling to engine code.
 - The creators, installer, and deploy packages remain outside the capability
   call graph and exercise only their documented project creation, local
   configuration, and generation authority.
-- Packed creator smoke tests build a generated engine and exercise its
-  `mcp:install` path. They verify that generated engine and capability-library
+- Packed creator smoke tests build a generated engine and verify its exact
+  build-first `mcp:install` and build-free `mcp:uninstall` paths. They verify
+  that generated engine and capability-library
   projects contain a regular `AGENTS.md`, a symbolic-link `CLAUDE.md`, and the
   exact relative target `AGENTS.md`. All three generated project types contain
   a valid `develop-invokta-project` skill with tailored contract and composition
@@ -48,8 +49,8 @@ consumer can use the protocol surface without coupling to engine code.
   atomic and library packages, compose their public root exports through
   `@invokta/core`, and invoke them through `engine.invoke`. Installer tests
   cover local manifests, remote descriptors, multi-client transactions,
-  lifecycle management, eleven target adapters, and forbidden process,
-  network, and write sentinels.
+  lifecycle management, engine-scoped preflight and removal, eleven target
+  adapters, and forbidden process, network, and write sentinels.
 
 ## Ownership conclusions
 

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -61,17 +61,20 @@ link, creation fails and rolls back instead of copying the instructions.
 Generated Invokta dependencies use the exact creator version. The entries
 become project-owned immediately and are never updated in place by the creator.
 
-The starter also includes `@invokta/installer` and a build-first installation
-command:
+The starter also includes `@invokta/installer`, a build-first installation
+command, and its build-free inverse:
 
 ```sh
 npm run mcp:install
+npm run mcp:uninstall
 ```
 
-That command validates `invokta.mcp.json`, detects eligible MCP clients,
+The install command validates `invokta.mcp.json`, detects eligible MCP clients,
 preselects all of them, and requires one confirmation before changing user
-configuration. The installer never imports or executes the engine while
-discovering its MCP entry point.
+configuration. The uninstall command uses the manifest ID to remove that engine
+from every installer-managed client after one confirmation. It does not build,
+import, or execute the engine and remains usable when its compiled entry point
+is absent.
 
 HTTP scaffolding remains a separate, explicit step owned by `@invokta/deploy`.
 The starter contains no HTTP server, authentication implementation, model

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -29,6 +29,10 @@ function renderReadme(
   packageManager: PackageManager,
 ): string {
   const commands = packageManagerCommands[packageManager];
+  const runScript = (name: string) =>
+    packageManager === "yarn"
+      ? `yarn ${name}`
+      : `${packageManager} run ${name}`;
   return `# ${projectName}
 
 A standalone [Invokta](https://docs.invokta.dev/) Action Engine with one
@@ -63,7 +67,14 @@ MCP stdio reserves standard output for protocol messages. Install this engine in
 all detected MCP clients with:
 
 \`\`\`sh
-${packageManager === "yarn" ? "yarn mcp:install" : `${packageManager} run mcp:install`}
+${runScript("mcp:install")}
+\`\`\`
+
+Remove this engine from every client where Invokta still owns its definition
+without rebuilding it:
+
+\`\`\`sh
+${runScript("mcp:uninstall")}
 \`\`\`
 
 Add stateless HTTP only when needed. Install \`@invokta/deploy\`, run
@@ -159,6 +170,7 @@ function renderPackageManifest(
       "mcp:stdio": "node dist/mcp-stdio.js",
       "mcp:install":
         "tsc -p tsconfig.json --pretty false && invokta-installer install --engine .",
+      "mcp:uninstall": "invokta-installer remove --engine .",
     },
     dependencies: {
       "@invokta/cli": invoktaVersion,

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -145,6 +145,9 @@ describe("createStarterFiles", () => {
     expect(packageManifest.scripts["mcp:install"]).toBe(
       "tsc -p tsconfig.json --pretty false && invokta-installer install --engine .",
     );
+    expect(packageManifest.scripts["mcp:uninstall"]).toBe(
+      "invokta-installer remove --engine .",
+    );
     expect(JSON.parse(contents.get("invokta.mcp.json") ?? "")).toEqual({
       schemaVersion: 1,
       id: "customer-support-engine",
@@ -188,12 +191,17 @@ describe("createStarterFiles", () => {
   });
 
   it.each([
-    ["npm", "npm run check"],
-    ["pnpm", "pnpm run check"],
-    ["yarn", "yarn run check"],
+    ["npm", "npm run check", "npm run mcp:install", "npm run mcp:uninstall"],
+    [
+      "pnpm",
+      "pnpm run check",
+      "pnpm run mcp:install",
+      "pnpm run mcp:uninstall",
+    ],
+    ["yarn", "yarn run check", "yarn mcp:install", "yarn mcp:uninstall"],
   ] as const)(
     "renders %s commands in the generated README",
-    (manager, command) => {
+    (manager, check, install, uninstall) => {
       const files = createStarterFiles({
         projectName: "customer-support-engine",
         invoktaVersion: "1.2.3",
@@ -201,9 +209,10 @@ describe("createStarterFiles", () => {
       });
 
       const readme = files.find((file) => file.path === "README.md");
-      expect(readme && "contents" in readme ? readme.contents : "").toContain(
-        command,
-      );
+      const contents = readme && "contents" in readme ? readme.contents : "";
+      expect(contents).toContain(check);
+      expect(contents).toContain(install);
+      expect(contents).toContain(uninstall);
     },
   );
 });

--- a/packages/installer/src/engine-manifest.ts
+++ b/packages/installer/src/engine-manifest.ts
@@ -57,10 +57,30 @@ export interface LoadEngineInstallManifestOptions {
   readonly projectDirectory: string;
 }
 
+export interface LoadEngineRemovalManifestOptions {
+  readonly currentUserId: number;
+  readonly fileSystem: InstallerTransactionFileSystem;
+  readonly projectDirectory: string;
+}
+
 export interface EngineInstallSource {
   readonly manifestPath: string;
   readonly entrypointPath: string;
   readonly descriptor: CapabilityInstallDescriptor;
+}
+
+export interface EngineRemovalSource {
+  readonly manifestPath: string;
+  readonly id: string;
+  readonly title: string;
+  readonly serverName: string;
+}
+
+interface LoadedEngineManifest {
+  readonly manifest: ValidatedEngineManifest;
+  readonly manifestPath: string;
+  readonly projectDirectory: string;
+  readonly root: InstallerPathRootIdentity;
 }
 
 function manifestInvalid(cause?: unknown): never {
@@ -293,14 +313,12 @@ async function readCapturedManifest(
   }
 }
 
-export async function loadEngineInstallManifest(
-  options: LoadEngineInstallManifestOptions,
-): Promise<EngineInstallSource> {
+async function loadOwnedEngineManifest(
+  options: LoadEngineRemovalManifestOptions,
+): Promise<LoadedEngineManifest> {
   if (
     !Number.isSafeInteger(options.currentUserId) ||
     options.currentUserId < 0 ||
-    !isAbsolute(options.nodeExecutable) ||
-    options.nodeExecutable.includes("\0") ||
     !isAbsolute(resolve(options.projectDirectory)) ||
     options.projectDirectory.includes("\0")
   ) {
@@ -329,6 +347,37 @@ export async function loadEngineInstallManifest(
   const manifest = validateEngineInstallManifestBytes(
     await readCapturedManifest(options.fileSystem, manifestIdentity),
   );
+  return Object.freeze({
+    manifest,
+    manifestPath: manifestIdentity.targetPath,
+    projectDirectory,
+    root,
+  });
+}
+
+export async function loadEngineRemovalManifest(
+  options: LoadEngineRemovalManifestOptions,
+): Promise<EngineRemovalSource> {
+  const loaded = await loadOwnedEngineManifest(options);
+  return Object.freeze({
+    manifestPath: loaded.manifestPath,
+    id: loaded.manifest.id,
+    title: loaded.manifest.title,
+    serverName: loaded.manifest.server.name,
+  });
+}
+
+export async function loadEngineInstallManifest(
+  options: LoadEngineInstallManifestOptions,
+): Promise<EngineInstallSource> {
+  if (
+    !isAbsolute(options.nodeExecutable) ||
+    options.nodeExecutable.includes("\0")
+  ) {
+    throw new InstallerError("ENGINE_PATH_UNSAFE");
+  }
+  const loaded = await loadOwnedEngineManifest(options);
+  const { manifest, projectDirectory, root } = loaded;
   const entrypointPath = join(
     projectDirectory,
     ...manifest.server.entrypoint.split("/"),
@@ -362,7 +411,7 @@ export async function loadEngineInstallManifest(
     server: Object.freeze({ name: manifest.server.name, transport }),
   });
   return Object.freeze({
-    manifestPath: manifestIdentity.targetPath,
+    manifestPath: loaded.manifestPath,
     entrypointPath,
     descriptor,
   });

--- a/packages/installer/src/engine-removal-session.ts
+++ b/packages/installer/src/engine-removal-session.ts
@@ -1,0 +1,146 @@
+import type { EngineRemovalSource } from "./engine-manifest.js";
+import type { HarnessDetectionSnapshot } from "./harness-detection.js";
+import {
+  InstallerError,
+  type InstallerErrorCode,
+  installerErrorMessages,
+} from "./installer-error.js";
+import type { InteractivePrompter } from "./interactive-prompter.js";
+import {
+  inspectEngineManagedInstallations,
+  type ManagedInstallationView,
+} from "./managed-installations.js";
+import {
+  type MutationCoordinatorDependencies,
+  removeEngineDescriptorFromTarget,
+} from "./mutation-coordinator.js";
+import type { InstallerExitCode } from "./run-installer-cli.js";
+
+export interface RunEngineRemovalSessionOptions {
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly prompter: InteractivePrompter;
+  readonly snapshot: HarnessDetectionSnapshot;
+  readonly source: EngineRemovalSource;
+}
+
+interface ClassifiedView {
+  readonly view: ManagedInstallationView;
+  readonly code?: InstallerErrorCode;
+}
+
+function blockedCode(
+  view: ManagedInstallationView,
+): InstallerErrorCode | undefined {
+  if (
+    view.status === "enabled" ||
+    view.status === "disabled" ||
+    view.status === "outdated"
+  ) {
+    return undefined;
+  }
+  if (view.status === "drifted") return "CONFIG_DRIFT";
+  if (view.status === "conflict") return "CONFIG_CONFLICT";
+  return view.unavailableCode ?? "INSTALLATION_UNAVAILABLE";
+}
+
+function logFailure(
+  prompter: InteractivePrompter,
+  view: ManagedInstallationView,
+  code: InstallerErrorCode,
+): void {
+  prompter.log(
+    "error",
+    `${view.displayName}: ${code}: ${installerErrorMessages[code]}`,
+  );
+}
+
+function cancelled(prompter: InteractivePrompter): 130 {
+  prompter.cancel(installerErrorMessages.CANCELLED);
+  return 130;
+}
+
+export async function runEngineRemovalSession(
+  options: RunEngineRemovalSessionOptions,
+): Promise<InstallerExitCode> {
+  const views = await inspectEngineManagedInstallations({
+    dependencies: options.dependencies,
+    engineId: options.source.id,
+    manifestServerName: options.source.serverName,
+    snapshot: options.snapshot,
+  });
+  if (views.length === 0) {
+    options.prompter.outro(`${options.source.title} is already uninstalled.`);
+    return 0;
+  }
+
+  const classified: ClassifiedView[] = views.map((view) => {
+    const code = blockedCode(view);
+    return code === undefined ? { view } : { view, code };
+  });
+  options.prompter.note(
+    classified
+      .map(
+        ({ view, code }) =>
+          `${view.installation.serverName} · ${view.displayName}: ${
+            code === undefined ? "removable" : `blocked (${code})`
+          }`,
+      )
+      .join("\n"),
+    "Engine uninstall preflight",
+  );
+  const removable = classified.filter(
+    (item): item is ClassifiedView & { readonly code?: never } =>
+      item.code === undefined && item.view.descriptor !== undefined,
+  );
+  const blocked = classified.filter(
+    (item): item is ClassifiedView & { readonly code: InstallerErrorCode } =>
+      item.code !== undefined,
+  );
+  if (removable.length === 0) {
+    for (const { view, code } of blocked) {
+      logFailure(options.prompter, view, code);
+    }
+    options.prompter.outro("Engine uninstall could not remove any target.");
+    return 1;
+  }
+
+  const confirmation = await options.prompter.confirm(
+    `Remove ${options.source.title} from ${String(removable.length)} MCP client configuration${removable.length === 1 ? "" : "s"}?`,
+  );
+  if (confirmation.kind === "cancelled") return cancelled(options.prompter);
+  if (!confirmation.value) {
+    options.prompter.outro("No changes were made.");
+    return 0;
+  }
+
+  let failed = blocked.length > 0;
+  for (const { view, code } of blocked) {
+    logFailure(options.prompter, view, code);
+  }
+  for (const { view } of removable) {
+    const descriptor = view.descriptor;
+    if (descriptor === undefined) throw new InstallerError("STATE_INVALID");
+    const result = await removeEngineDescriptorFromTarget({
+      dependencies: options.dependencies,
+      descriptor,
+      manifestServerName: options.source.serverName,
+      snapshot: options.snapshot,
+      targetId: view.installation.targetId,
+    });
+    if (result.outcome === "failed") {
+      failed = true;
+      logFailure(options.prompter, view, result.code);
+      continue;
+    }
+    options.prompter.log(
+      "success",
+      `${view.displayName}: ${result.outcome === "unchanged" ? "already absent" : "removed"}.`,
+    );
+  }
+  options.prompter.outro(
+    failed
+      ? "Engine uninstall completed with errors."
+      : `${options.source.title} was removed from managed MCP clients.`,
+  );
+  return failed ? 1 : 0;
+}

--- a/packages/installer/src/installer-error.ts
+++ b/packages/installer/src/installer-error.ts
@@ -3,6 +3,8 @@ export const installerErrorMessages = Object.freeze({
   ENGINE_MANIFEST_INVALID: "The Action Engine manifest is invalid.",
   ENGINE_PATH_UNSAFE: "The Action Engine path is unsafe.",
   ENGINE_ENTRYPOINT_MISSING: "The Action Engine entry point was not found.",
+  ENGINE_IDENTITY_MISMATCH:
+    "The manifest does not match the managed Action Engine identity.",
   REMOTE_INVALID: "The remote MCP server definition is invalid.",
   INSTALLATION_UNAVAILABLE: "The managed installation is unavailable.",
   INSTALLER_INITIALIZATION_FAILED: "The installer could not be initialized.",

--- a/packages/installer/src/installer-state-transition.ts
+++ b/packages/installer/src/installer-state-transition.ts
@@ -47,6 +47,7 @@ function invalidState(): never {
 function normalizeAndSerializeInstallerState(
   state: InstallerState,
   targetContracts: StateTargetContracts,
+  options: { readonly allowUnavailableTargetContracts?: boolean } = {},
 ): NormalizedStateSerialization {
   let bytes: Uint8Array;
   try {
@@ -54,7 +55,11 @@ function normalizeAndSerializeInstallerState(
   } catch {
     return invalidState();
   }
-  const validation = validateInstallerStateBytes(bytes, targetContracts);
+  const validation = validateInstallerStateBytes(
+    bytes,
+    targetContracts,
+    options,
+  );
   if (!validation.ok) return invalidState();
   return Object.freeze({ state: validation.state, bytes });
 }
@@ -62,8 +67,10 @@ function normalizeAndSerializeInstallerState(
 export function serializeInstallerState(
   state: InstallerState,
   targetContracts: StateTargetContracts,
+  options: { readonly allowUnavailableTargetContracts?: boolean } = {},
 ): Uint8Array {
-  return normalizeAndSerializeInstallerState(state, targetContracts).bytes;
+  return normalizeAndSerializeInstallerState(state, targetContracts, options)
+    .bytes;
 }
 
 function plansMatch(

--- a/packages/installer/src/interactive-session.ts
+++ b/packages/installer/src/interactive-session.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from "node:crypto";
 
 import { createClackInteractivePrompter } from "./clack-interactive-prompter.js";
-import { loadEngineInstallManifest } from "./engine-manifest.js";
+import {
+  loadEngineInstallManifest,
+  loadEngineRemovalManifest,
+} from "./engine-manifest.js";
+import { runEngineRemovalSession } from "./engine-removal-session.js";
 import type {
   InstallerFileSystem,
   InstallerTransactionFileSystem,
@@ -55,17 +59,52 @@ export interface RunInteractiveSessionOptions {
   readonly platform?: NodeJS.Platform;
 }
 
+function mutationDependencies(
+  currentUserId: number,
+  environment: InstallerEnvironment,
+  fileSystem: InstallerTransactionFileSystem,
+): MutationCoordinatorDependencies {
+  return {
+    adapters: configurationTargetAdapters,
+    currentUserId,
+    environment,
+    fileSystem,
+    lock: {
+      clock: {
+        monotonicNow: () => performance.now(),
+        now: () => Date.now(),
+        wait: (milliseconds) =>
+          new Promise((resolveWait) => setTimeout(resolveWait, milliseconds)),
+      },
+      processId: process.pid,
+      randomBytes: (length) => randomBytes(length),
+    },
+    now: () => new Date().toISOString(),
+  };
+}
+
 export async function runInteractiveSession(
   options: RunInteractiveSessionOptions = {},
 ): Promise<InstallerExitCode> {
   const prompter = options.prompter ?? createClackInteractivePrompter();
   prompter.intro("Invokta capability installer");
+  const command = options.command ?? { kind: "inventory" as const };
+  const nodeFileSystem = createNodeFileSystem();
+  const fileSystem = options.fileSystem ?? nodeFileSystem;
+  const transactionFileSystem = options.transactionFileSystem ?? nodeFileSystem;
+  const currentUserId = process.getuid?.() ?? -1;
+  const removalSource =
+    command.kind === "remove-engine"
+      ? await loadEngineRemovalManifest({
+          currentUserId,
+          fileSystem: transactionFileSystem,
+          projectDirectory: command.projectDirectory,
+        })
+      : undefined;
   const progress = prompter.spinner();
   progress.start("Detecting supported AI harnesses");
+  let detectionComplete = false;
   try {
-    const command = options.command ?? { kind: "inventory" as const };
-    const nodeFileSystem = createNodeFileSystem();
-    const fileSystem = options.fileSystem ?? nodeFileSystem;
     const registry =
       command.kind === "inventory" ||
       command.kind === "status" ||
@@ -96,44 +135,40 @@ export async function runInteractiveSession(
         }),
     });
     progress.stop("Harness detection complete");
+    detectionComplete = true;
     if (command.kind === "inventory") {
       return await runReadOnlyInventory(snapshot, prompter);
     }
+    if (command.kind === "remove-engine" && removalSource !== undefined) {
+      return await runEngineRemovalSession({
+        dependencies: mutationDependencies(
+          currentUserId,
+          environment,
+          transactionFileSystem,
+        ),
+        prompter,
+        snapshot,
+        source: removalSource,
+      });
+    }
     if (command.kind === "install-engine" || command.kind === "install-http") {
-      const transactionFileSystem =
-        options.transactionFileSystem ?? nodeFileSystem;
       const descriptor =
         command.kind === "install-engine"
           ? (
               await loadEngineInstallManifest({
-                currentUserId: process.getuid?.() ?? -1,
+                currentUserId,
                 fileSystem: transactionFileSystem,
                 nodeExecutable: process.execPath,
                 projectDirectory: command.projectDirectory,
               })
             ).descriptor
           : createRemoteInstallDescriptor(command);
-      const dependencies: MutationCoordinatorDependencies = {
-        adapters: configurationTargetAdapters,
-        currentUserId: process.getuid?.() ?? -1,
-        environment,
-        fileSystem: transactionFileSystem,
-        lock: {
-          clock: {
-            monotonicNow: () => performance.now(),
-            now: () => Date.now(),
-            wait: (milliseconds) =>
-              new Promise((resolveWait) =>
-                setTimeout(resolveWait, milliseconds),
-              ),
-          },
-          processId: process.pid,
-          randomBytes: (length) => randomBytes(length),
-        },
-        now: () => new Date().toISOString(),
-      };
       return await runInstallSession({
-        dependencies,
+        dependencies: mutationDependencies(
+          currentUserId,
+          environment,
+          transactionFileSystem,
+        ),
         descriptor,
         prompter,
         resolveExecutable,
@@ -147,29 +182,13 @@ export async function runInteractiveSession(
         command.kind === "remove") &&
       registry !== undefined
     ) {
-      const transactionFileSystem =
-        options.transactionFileSystem ?? nodeFileSystem;
       return await runManagementSession({
         action: command.kind,
-        dependencies: {
-          adapters: configurationTargetAdapters,
-          currentUserId: process.getuid?.() ?? -1,
+        dependencies: mutationDependencies(
+          currentUserId,
           environment,
-          fileSystem: transactionFileSystem,
-          lock: {
-            clock: {
-              monotonicNow: () => performance.now(),
-              now: () => Date.now(),
-              wait: (milliseconds) =>
-                new Promise((resolveWait) =>
-                  setTimeout(resolveWait, milliseconds),
-                ),
-            },
-            processId: process.pid,
-            randomBytes: (length) => randomBytes(length),
-          },
-          now: () => new Date().toISOString(),
-        },
+          transactionFileSystem,
+        ),
         prompter,
         registry,
         resolveExecutable,
@@ -178,7 +197,7 @@ export async function runInteractiveSession(
     }
     throw new InstallerError("INSTALLER_INITIALIZATION_FAILED");
   } catch (error) {
-    progress.error("Harness detection failed");
+    if (!detectionComplete) progress.error("Harness detection failed");
     throw error;
   }
 }

--- a/packages/installer/src/managed-installations.ts
+++ b/packages/installer/src/managed-installations.ts
@@ -1,9 +1,10 @@
 import type { InstallerFileStat, InstallerReadHandle } from "./file-system.js";
 import type { HarnessDetectionSnapshot } from "./harness-detection.js";
-import { InstallerError } from "./installer-error.js";
+import { InstallerError, type InstallerErrorCode } from "./installer-error.js";
 import {
   loadInstallerState,
   type ManagedInstallation,
+  type StateTargetContracts,
 } from "./installer-state.js";
 import {
   buildStateTargetContracts,
@@ -28,11 +29,19 @@ export interface ManagedInstallationView {
   readonly displayName: string;
   readonly status: OwnershipPlan["status"] | "unavailable";
   readonly actions: OwnershipPlan["actions"];
+  readonly unavailableCode?: InstallerErrorCode;
 }
 
 export interface InspectManagedInstallationsOptions {
   readonly dependencies: MutationCoordinatorDependencies;
   readonly registry: ValidatedRegistry;
+  readonly snapshot: HarnessDetectionSnapshot;
+}
+
+export interface InspectEngineManagedInstallationsOptions {
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly engineId: string;
+  readonly manifestServerName: string;
   readonly snapshot: HarnessDetectionSnapshot;
 }
 
@@ -51,13 +60,13 @@ function sameStat(
 }
 
 async function readConfig(
-  options: InspectManagedInstallationsOptions,
+  dependencies: MutationCoordinatorDependencies,
   identity: InstallerPathIdentity,
 ): Promise<Uint8Array | undefined> {
   if (identity.missingPaths.length > 0) return undefined;
   let handle: InstallerReadHandle | undefined;
   try {
-    handle = await options.dependencies.fileSystem.openReadNoFollow(
+    handle = await dependencies.fileSystem.openReadNoFollow(
       identity.targetPath,
     );
     if (!sameStat(identity.components.at(-1), await handle.stat())) {
@@ -72,14 +81,10 @@ async function readConfig(
   }
 }
 
-function descriptorFor(
+function persistedDescriptorFor(
   installation: ManagedInstallation,
-  registry: ValidatedRegistry,
 ): CapabilityInstallDescriptor | undefined {
-  const registered = registry.entries.find(
-    ({ descriptor }) => descriptor.id === installation.entryId,
-  )?.descriptor;
-  if (installation.launchDescriptor === undefined) return registered;
+  if (installation.launchDescriptor === undefined) return undefined;
   return Object.freeze({
     id: installation.entryId,
     version: installation.registryVersion,
@@ -90,11 +95,22 @@ function descriptorFor(
   });
 }
 
+function descriptorFor(
+  installation: ManagedInstallation,
+  registry: ValidatedRegistry,
+): CapabilityInstallDescriptor | undefined {
+  const registered = registry.entries.find(
+    ({ descriptor }) => descriptor.id === installation.entryId,
+  )?.descriptor;
+  return persistedDescriptorFor(installation) ?? registered;
+}
+
 function unavailable(
   key: string,
   installation: ManagedInstallation,
   descriptor: CapabilityInstallDescriptor | undefined,
   displayName: string,
+  code?: InstallerErrorCode,
 ): ManagedInstallationView {
   return Object.freeze({
     key,
@@ -103,6 +119,7 @@ function unavailable(
     displayName,
     status: "unavailable",
     actions: Object.freeze([] as []),
+    ...(code === undefined ? {} : { unavailableCode: code }),
   });
 }
 
@@ -161,7 +178,7 @@ export async function inspectManagedInstallations(
       throw new InstallerError("HARNESS_CONFIG_UNSAFE", cause);
     });
     const inspection = adapter.inspect({
-      source: await readConfig(options, identity),
+      source: await readConfig(options.dependencies, identity),
       serverName: installation.serverName,
     });
     const ownership = planOwnership({
@@ -190,6 +207,186 @@ export async function inspectManagedInstallations(
         actions: ownership.actions,
       }),
     );
+  }
+  return Object.freeze(views);
+}
+
+function unavailableCode(
+  cause: unknown,
+  fallback: InstallerErrorCode,
+): InstallerErrorCode {
+  return cause instanceof InstallerError ? cause.code : fallback;
+}
+
+export async function inspectEngineManagedInstallations(
+  options: InspectEngineManagedInstallationsOptions,
+): Promise<readonly ManagedInstallationView[]> {
+  const contracts = buildStateTargetContracts(
+    options.snapshot,
+    options.dependencies.adapters,
+  );
+  const loaded = await loadInstallerState({
+    currentUserId: options.dependencies.currentUserId,
+    environment: options.dependencies.environment,
+    fileSystem: options.dependencies.fileSystem,
+    homeDirectory: options.snapshot.homeDirectory,
+    targetContracts: Object.freeze({}) as StateTargetContracts,
+    allowUnavailableTargetContracts: true,
+  });
+  const allEntries = Object.entries(loaded.state.installations);
+  if (
+    allEntries.some(
+      ([, installation]) =>
+        installation.entryId !== options.engineId &&
+        installation.serverName === options.manifestServerName,
+    )
+  ) {
+    throw new InstallerError("ENGINE_IDENTITY_MISMATCH");
+  }
+  const targetOrder = new Map(
+    options.snapshot.targets.map(({ id }, index) => [id, index] as const),
+  );
+  const entries = allEntries
+    .filter(([, installation]) => installation.entryId === options.engineId)
+    .sort(
+      ([, left], [, right]) =>
+        (targetOrder.get(left.targetId) ?? Number.MAX_SAFE_INTEGER) -
+        (targetOrder.get(right.targetId) ?? Number.MAX_SAFE_INTEGER),
+    );
+  if (entries.length === 0) return Object.freeze([]);
+
+  const homeRoot = await capturePathRoot(options.dependencies.fileSystem, {
+    rootKind: "home",
+    rootPath: options.snapshot.homeDirectory,
+    currentUserId: options.dependencies.currentUserId,
+  }).catch((cause) => {
+    throw new InstallerError("HARNESS_CONFIG_UNSAFE", cause);
+  });
+  const views: ManagedInstallationView[] = [];
+  for (const [key, installation] of entries) {
+    const descriptor = persistedDescriptorFor(installation);
+    const target = options.snapshot.targets.find(
+      ({ id }) => id === installation.targetId,
+    );
+    const displayName = target?.displayName ?? installation.targetId;
+    if (descriptor === undefined) {
+      views.push(
+        unavailable(
+          key,
+          installation,
+          descriptor,
+          displayName,
+          "INSTALLATION_UNAVAILABLE",
+        ),
+      );
+      continue;
+    }
+    if (target === undefined) {
+      views.push(
+        unavailable(
+          key,
+          installation,
+          descriptor,
+          displayName,
+          "TARGET_UNSUPPORTED",
+        ),
+      );
+      continue;
+    }
+    if (target.configuration.kind === "blocked") {
+      views.push(
+        unavailable(
+          key,
+          installation,
+          descriptor,
+          displayName,
+          target.configuration.code,
+        ),
+      );
+      continue;
+    }
+    const contract = contracts[installation.targetId];
+    const adapter = options.dependencies.adapters[installation.targetId];
+    if (
+      contract === undefined ||
+      target.configuration.path !== installation.configPath ||
+      contract.targetContractVersion !== installation.targetContractVersion ||
+      contract.toggleStrategy !== installation.toggleStrategy
+    ) {
+      views.push(
+        unavailable(
+          key,
+          installation,
+          descriptor,
+          displayName,
+          "HARNESS_CONFIG_UNSAFE",
+        ),
+      );
+      continue;
+    }
+    if (!adapter.compatibility(descriptor).supported) {
+      views.push(
+        unavailable(
+          key,
+          installation,
+          descriptor,
+          displayName,
+          "TARGET_UNSUPPORTED",
+        ),
+      );
+      continue;
+    }
+
+    try {
+      const identity = await capturePathIdentity(
+        options.dependencies.fileSystem,
+        {
+          root: homeRoot,
+          targetPath: installation.configPath,
+          targetKind: "regular-file",
+        },
+      );
+      const inspection = adapter.inspect({
+        source: await readConfig(options.dependencies, identity),
+        serverName: installation.serverName,
+      });
+      const ownership = planOwnership({
+        descriptor,
+        targetId: installation.targetId,
+        target: contract,
+        state: loaded.state,
+        registryDefinition: adapter.descriptorToDefinition(descriptor),
+        ...(installation.suspendedDescriptor === undefined
+          ? {}
+          : {
+              normalizedSuspendedDefinition:
+                adapter.suspendedDescriptorToDefinition(
+                  installation.suspendedDescriptor,
+                ),
+            }),
+        currentServer: inspection.currentServer,
+      });
+      views.push(
+        Object.freeze({
+          key,
+          installation,
+          descriptor,
+          displayName,
+          status: ownership.status,
+          actions: ownership.actions,
+        }),
+      );
+    } catch (cause) {
+      views.push(
+        unavailable(
+          key,
+          installation,
+          descriptor,
+          displayName,
+          unavailableCode(cause, "HARNESS_CONFIG_UNSAFE"),
+        ),
+      );
+    }
   }
   return Object.freeze(views);
 }

--- a/packages/installer/src/mutation-coordinator.ts
+++ b/packages/installer/src/mutation-coordinator.ts
@@ -87,6 +87,14 @@ export interface MutateDescriptorAcrossTargetsInput
     | "remove";
 }
 
+export interface RemoveEngineDescriptorFromTargetInput {
+  readonly dependencies: MutationCoordinatorDependencies;
+  readonly descriptor: CapabilityInstallDescriptor;
+  readonly manifestServerName: string;
+  readonly snapshot: HarnessDetectionSnapshot;
+  readonly targetId: ConfigurationTargetId;
+}
+
 const temporaryTokenBytes = 12;
 
 function inside(root: string, candidate: string): boolean {
@@ -330,6 +338,11 @@ async function mutateTarget(
   input: MutateDescriptorAcrossTargetsInput,
   targetId: ConfigurationTargetId,
   contracts: StateTargetContracts,
+  options: {
+    readonly allowAlreadyAbsentRemoval?: boolean;
+    readonly allowUnavailableStateContracts?: boolean;
+    readonly manifestServerName?: string;
+  } = {},
 ): Promise<"disabled" | "enabled" | "installed" | "removed" | "unchanged"> {
   const { dependencies, descriptor, snapshot } = input;
   const target = findTarget(snapshot, targetId);
@@ -337,13 +350,22 @@ async function mutateTarget(
   const adapter = dependencies.adapters[targetId];
   const compatibility = adapter.compatibility(descriptor);
   if (!compatibility.supported) throw new InstallerError("TARGET_UNSUPPORTED");
+  const stateContracts =
+    options.allowUnavailableStateContracts === true
+      ? (Object.freeze({
+          [targetId]: contracts[targetId],
+        }) as StateTargetContracts)
+      : contracts;
 
   const loadedBeforeLock = await loadInstallerState({
     currentUserId: dependencies.currentUserId,
     environment: dependencies.environment,
     fileSystem: dependencies.fileSystem,
     homeDirectory: snapshot.homeDirectory,
-    targetContracts: contracts,
+    targetContracts: stateContracts,
+    ...(options.allowUnavailableStateContracts === true
+      ? { allowUnavailableTargetContracts: true }
+      : {}),
   });
   const homeRoot = await capturePathRoot(dependencies.fileSystem, {
     rootKind: "home",
@@ -386,10 +408,23 @@ async function mutateTarget(
       environment: dependencies.environment,
       fileSystem: dependencies.fileSystem,
       homeDirectory: snapshot.homeDirectory,
-      targetContracts: contracts,
+      targetContracts: stateContracts,
+      ...(options.allowUnavailableStateContracts === true
+        ? { allowUnavailableTargetContracts: true }
+        : {}),
     });
     if (loaded.path !== loadedBeforeLock.path) {
       throw new InstallerError("STATE_CHANGED");
+    }
+    if (
+      options.manifestServerName !== undefined &&
+      Object.values(loaded.state.installations).some(
+        (installation) =>
+          installation.entryId !== descriptor.id &&
+          installation.serverName === options.manifestServerName,
+      )
+    ) {
+      throw new InstallerError("ENGINE_IDENTITY_MISMATCH");
     }
     const configIdentity = await capturePathIdentity(dependencies.fileSystem, {
       root: homeRoot,
@@ -436,6 +471,12 @@ async function mutateTarget(
     let patch: TargetPatch;
     if (input.action === "remove") {
       if (managedInstallation === undefined) {
+        if (
+          options.allowAlreadyAbsentRemoval === true &&
+          inspection.currentServer.kind === "absent"
+        ) {
+          return "unchanged";
+        }
         throw new InstallerError("INSTALLATION_UNAVAILABLE");
       }
       const ownership = planOwnership(planning);
@@ -451,7 +492,10 @@ async function mutateTarget(
       ];
       stateBytes = serializeInstallerState(
         { schemaVersion: 1, installations: nextInstallations },
-        contracts,
+        stateContracts,
+        options.allowUnavailableStateContracts === true
+          ? { allowUnavailableTargetContracts: true }
+          : {},
       );
       patch =
         inspection.currentServer.kind === "absent"
@@ -547,6 +591,44 @@ export async function installDescriptorAcrossTargets(
   input: InstallDescriptorAcrossTargetsInput,
 ): Promise<readonly TargetMutationResult[]> {
   return mutateDescriptorAcrossTargets({ ...input, action: "install" });
+}
+
+export async function removeEngineDescriptorFromTarget(
+  input: RemoveEngineDescriptorFromTargetInput,
+): Promise<TargetMutationResult> {
+  const contracts = buildStateTargetContracts(
+    input.snapshot,
+    input.dependencies.adapters,
+  );
+  try {
+    const outcome = await mutateTarget(
+      {
+        action: "remove",
+        dependencies: input.dependencies,
+        descriptor: input.descriptor,
+        snapshot: input.snapshot,
+        targetIds: [input.targetId],
+      },
+      input.targetId,
+      contracts,
+      {
+        allowAlreadyAbsentRemoval: true,
+        allowUnavailableStateContracts: true,
+        manifestServerName: input.manifestServerName,
+      },
+    );
+    return Object.freeze({ targetId: input.targetId, outcome });
+  } catch (cause) {
+    const error =
+      cause instanceof InstallerError
+        ? cause
+        : new InstallerError("INSTALLER_INITIALIZATION_FAILED", cause);
+    return Object.freeze({
+      targetId: input.targetId,
+      outcome: "failed",
+      code: error.code,
+    });
+  }
 }
 
 export async function mutateDescriptorAcrossTargets(

--- a/packages/installer/src/run-installer-cli.ts
+++ b/packages/installer/src/run-installer-cli.ts
@@ -8,6 +8,7 @@ export type InstallerExitCode = 0 | 1 | 2 | 130;
 export type InstallerCommand =
   | { readonly kind: "inventory" }
   | { readonly kind: "install-engine"; readonly projectDirectory: string }
+  | { readonly kind: "remove-engine"; readonly projectDirectory: string }
   | {
       readonly kind: "install-http";
       readonly serverName: string;
@@ -41,6 +42,7 @@ const helpText = `Usage:
   invokta-installer enable
   invokta-installer disable
   invokta-installer remove
+  invokta-installer remove --engine <project-directory>
   invokta-installer --help
   invokta-installer --version
 `;
@@ -79,6 +81,12 @@ function parseCommand(argv: readonly string[]): InstallerCommand | undefined {
   if (argv.length === 3 && argv[0] === "install" && argv[1] === "--engine") {
     return Object.freeze({
       kind: "install-engine",
+      projectDirectory: argv[2] as string,
+    });
+  }
+  if (argv.length === 3 && argv[0] === "remove" && argv[1] === "--engine") {
+    return Object.freeze({
+      kind: "remove-engine",
       projectDirectory: argv[2] as string,
     });
   }

--- a/packages/installer/test/cli-child-process.test.ts
+++ b/packages/installer/test/cli-child-process.test.ts
@@ -77,6 +77,7 @@ describe("invokta-installer executable", () => {
   invokta-installer enable
   invokta-installer disable
   invokta-installer remove
+  invokta-installer remove --engine <project-directory>
   invokta-installer --help
   invokta-installer --version
 `);

--- a/packages/installer/test/cli-usage.test.ts
+++ b/packages/installer/test/cli-usage.test.ts
@@ -13,6 +13,7 @@ const helpText = `Usage:
   invokta-installer enable
   invokta-installer disable
   invokta-installer remove
+  invokta-installer remove --engine <project-directory>
   invokta-installer --help
   invokta-installer --version
 `;
@@ -202,6 +203,47 @@ describe("runInstallerCli", () => {
     });
     expect(output.stdout).toEqual([]);
     expect(output.stderr).toEqual([]);
+  });
+
+  it("parses project-local engine removal before lazy interactive loading", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runInstallerCli({
+      argv: ["remove", "--engine", "projects/support-engine"],
+      io: output.io,
+      loadInteractiveSession,
+    });
+
+    expect(result).toBe(0);
+    expect(loadInteractiveSession).toHaveBeenCalledWith({
+      kind: "remove-engine",
+      projectDirectory: "projects/support-engine",
+    });
+    expect(output.stdout).toEqual([]);
+    expect(output.stderr).toEqual([]);
+  });
+
+  it.each([
+    ["remove", "--engine"],
+    ["remove", "--engine", ".", "extra"],
+    ["--engine", ".", "remove"],
+    ["remove", "--engine", ".", "--engine", "."],
+  ])("rejects an invalid engine-removal vector: %j", async (...argv) => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runInstallerCli({
+      argv,
+      io: output.io,
+      loadInteractiveSession,
+    });
+
+    expect(result).toBe(2);
+    expect(loadInteractiveSession).not.toHaveBeenCalled();
+    expect(output.stderr).toEqual([
+      'Invalid arguments. Run "invokta-installer --help".\n',
+    ]);
   });
 
   it("parses a remote HTTP installation with environment-only credentials", async () => {

--- a/packages/installer/test/engine-manifest.test.ts
+++ b/packages/installer/test/engine-manifest.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   loadEngineInstallManifest,
+  loadEngineRemovalManifest,
   validateEngineInstallManifestBytes,
 } from "../src/engine-manifest.js";
 import { createNodeFileSystem } from "../src/node-file-system.js";
@@ -150,5 +151,43 @@ describe("loadEngineInstallManifest", () => {
         projectDirectory,
       }),
     ).rejects.toMatchObject({ code: "ENGINE_PATH_UNSAFE" });
+  });
+});
+
+describe("loadEngineRemovalManifest", () => {
+  it("validates owned manifest metadata without requiring the entry point", async () => {
+    const projectDirectory = createProject();
+    rmSync(join(projectDirectory, "dist/mcp-stdio.js"));
+
+    const source = await loadEngineRemovalManifest({
+      currentUserId: process.getuid?.() ?? 0,
+      fileSystem: createNodeFileSystem(),
+      projectDirectory,
+    });
+
+    expect(source).toEqual({
+      manifestPath: join(projectDirectory, "invokta.mcp.json"),
+      id: "support-engine",
+      title: "Support Engine",
+      serverName: "support-engine",
+    });
+    expect(Object.isFrozen(source)).toBe(true);
+  });
+
+  it("retains strict manifest validation when the entry point is absent", async () => {
+    const projectDirectory = createProject();
+    rmSync(join(projectDirectory, "dist/mcp-stdio.js"));
+    writeFileSync(
+      join(projectDirectory, "invokta.mcp.json"),
+      '{"schemaVersion":1,"id":"support-engine","unexpected":true}',
+    );
+
+    await expect(
+      loadEngineRemovalManifest({
+        currentUserId: process.getuid?.() ?? 0,
+        fileSystem: createNodeFileSystem(),
+        projectDirectory,
+      }),
+    ).rejects.toMatchObject({ code: "ENGINE_MANIFEST_INVALID" });
   });
 });

--- a/packages/installer/test/engine-removal-sentinels.test.ts
+++ b/packages/installer/test/engine-removal-sentinels.test.ts
@@ -1,0 +1,50 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+beforeAll(() => {
+  execFileSync(
+    process.execPath,
+    [
+      "node_modules/typescript/bin/tsc",
+      "-b",
+      "packages/installer",
+      "--pretty",
+      "false",
+    ],
+    { cwd: repositoryRoot, stdio: "pipe" },
+  );
+});
+
+describe("engine removal isolation sentinels", () => {
+  it("removes an owned engine without process, network, runtime, or launch-environment access", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        joinFixture("forbid-process-execution.mjs"),
+        "--import",
+        joinFixture("forbid-network-access.mjs"),
+        joinFixture("engine-removal-sentinel-scenario.mjs"),
+      ],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      result: 0,
+      environmentReads: ["XDG_STATE_HOME"],
+      installations: 0,
+    });
+    expect(result.stdout).not.toContain("SUPPORT_API_TOKEN");
+    expect(result.stderr).not.toContain("FORBIDDEN");
+    expect(result.stderr).not.toContain("LAUNCH_ENVIRONMENT_VALUE_READ");
+  });
+});
+
+function joinFixture(name: string): string {
+  return fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url));
+}

--- a/packages/installer/test/engine-removal-session.test.ts
+++ b/packages/installer/test/engine-removal-session.test.ts
@@ -1,0 +1,510 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { EngineRemovalSource } from "../src/engine-manifest.js";
+import { runEngineRemovalSession } from "../src/engine-removal-session.js";
+import type { HarnessDetectionSnapshot } from "../src/harness-detection.js";
+import type { InteractivePrompter } from "../src/interactive-prompter.js";
+import {
+  installDescriptorAcrossTargets,
+  type MutationCoordinatorDependencies,
+  mutateDescriptorAcrossTargets,
+} from "../src/mutation-coordinator.js";
+import { createNodeFileSystem } from "../src/node-file-system.js";
+import type { CapabilityInstallDescriptor } from "../src/registry.js";
+import { configurationTargetAdapters } from "../src/target-adapters.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function snapshot(homeDirectory: string): HarnessDetectionSnapshot {
+  const target = (
+    id: "codex" | "cursor",
+    path: string,
+  ): HarnessDetectionSnapshot["targets"][number] => ({
+    id,
+    displayName: id === "codex" ? "Codex" : "Cursor",
+    surfaceIds: [],
+    evidence: "configuration-only",
+    executables: [],
+    configuration: { kind: "present", path },
+    eligible: true,
+    mayCreateConfiguration: false,
+    reloadHint: `Reload ${id}.`,
+  });
+  return {
+    homeDirectory,
+    surfaces: [],
+    targets: [
+      target("codex", join(homeDirectory, ".codex/config.toml")),
+      target("cursor", join(homeDirectory, ".cursor/mcp.json")),
+    ],
+  };
+}
+
+function descriptor(
+  options: { readonly id?: string; readonly serverName?: string } = {},
+): CapabilityInstallDescriptor {
+  const id = options.id ?? "support-engine";
+  const serverName = options.serverName ?? "support-engine";
+  return {
+    id,
+    version: "1.0.0",
+    title: "Support Engine",
+    description: "Support actions.",
+    capabilityIds: ["tickets.summarize"],
+    server: {
+      name: serverName,
+      transport: {
+        type: "stdio",
+        command: process.execPath,
+        args: ["/workspace/support-engine/dist/mcp-stdio.js"],
+        forwardEnv: [],
+      },
+    },
+  };
+}
+
+function source(
+  options: {
+    readonly id?: string;
+    readonly serverName?: string;
+    readonly title?: string;
+  } = {},
+): EngineRemovalSource {
+  return Object.freeze({
+    manifestPath: "/workspace/support-engine/invokta.mcp.json",
+    id: options.id ?? "support-engine",
+    title: options.title ?? "Support Engine",
+    serverName: options.serverName ?? "support-engine",
+  });
+}
+
+function dependencies(): MutationCoordinatorDependencies {
+  let wallTime = Date.parse("2026-07-30T12:00:00.000Z");
+  let monotonic = 0;
+  let token = 0;
+  return {
+    adapters: configurationTargetAdapters,
+    currentUserId: process.getuid?.() ?? 0,
+    environment: { get: () => undefined },
+    fileSystem: createNodeFileSystem(),
+    lock: {
+      clock: {
+        monotonicNow: () => monotonic,
+        now: () => wallTime,
+        wait: async (milliseconds) => {
+          monotonic += milliseconds;
+          wallTime += milliseconds;
+        },
+      },
+      processId: 321,
+      randomBytes: (length) => {
+        token += 1;
+        return new Uint8Array(length).fill(token);
+      },
+    },
+    now: () => new Date(wallTime).toISOString(),
+  };
+}
+
+function prompter(
+  confirmation: boolean | "cancelled" = true,
+): InteractivePrompter {
+  return {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    cancel: vi.fn(),
+    autocomplete: vi.fn(),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    note: vi.fn(),
+    confirm: vi.fn(async () =>
+      confirmation === "cancelled"
+        ? ({ kind: "cancelled" as const } as const)
+        : ({ kind: "submitted" as const, value: confirmation } as const),
+    ),
+    spinner: vi.fn(() => ({
+      start: vi.fn(),
+      stop: vi.fn(),
+      cancel: vi.fn(),
+      error: vi.fn(),
+      message: vi.fn(),
+      clear: vi.fn(),
+    })),
+    log: vi.fn(),
+  };
+}
+
+function statePath(homeDirectory: string): string {
+  return join(homeDirectory, ".local/state/invokta/installer.json");
+}
+
+describe("runEngineRemovalSession", () => {
+  it("removes every matching owned target after one confirmation", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+    const prompts = prompter();
+
+    const result = await runEngineRemovalSession({
+      dependencies: deps,
+      prompter: prompts,
+      snapshot: detected,
+      source: source(),
+    });
+
+    expect(result).toBe(0);
+    expect(prompts.note).toHaveBeenCalledWith(
+      "support-engine · Codex: removable\nsupport-engine · Cursor: removable",
+      "Engine uninstall preflight",
+    );
+    expect(prompts.confirm).toHaveBeenCalledTimes(1);
+    expect(prompts.confirm).toHaveBeenCalledWith(
+      "Remove Support Engine from 2 MCP client configurations?",
+    );
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).not.toContain("support-engine");
+    expect(
+      readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8"),
+    ).not.toContain("support-engine");
+    const state = JSON.parse(
+      readFileSync(statePath(homeDirectory), "utf8"),
+    ) as {
+      readonly installations: Readonly<Record<string, unknown>>;
+    };
+    expect(state.installations).toEqual({});
+  });
+
+  it("returns an idempotent no-op without confirmation when no identity matches", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const prompts = prompter();
+
+    const result = await runEngineRemovalSession({
+      dependencies: dependencies(),
+      prompter: prompts,
+      snapshot: snapshot(homeDirectory),
+      source: source(),
+    });
+
+    expect(result).toBe(0);
+    expect(prompts.confirm).not.toHaveBeenCalled();
+    expect(prompts.outro).toHaveBeenCalledWith(
+      "Support Engine is already uninstalled.",
+    );
+  });
+
+  it.each([
+    [false, 0],
+    ["cancelled", 130],
+  ] as const)(
+    "keeps every target unchanged when confirmation resolves as %s",
+    async (confirmation, expectedExit) => {
+      const homeDirectory = mkdtempSync(
+        join(tmpdir(), "invokta-remove-engine-"),
+      );
+      temporaryDirectories.push(homeDirectory);
+      const detected = snapshot(homeDirectory);
+      const deps = dependencies();
+      await installDescriptorAcrossTargets({
+        dependencies: deps,
+        descriptor: descriptor(),
+        snapshot: detected,
+        targetIds: ["codex"],
+      });
+      const beforeConfig = readFileSync(
+        join(homeDirectory, ".codex/config.toml"),
+        "utf8",
+      );
+      const beforeState = readFileSync(statePath(homeDirectory), "utf8");
+      const prompts = prompter(confirmation);
+
+      const result = await runEngineRemovalSession({
+        dependencies: deps,
+        prompter: prompts,
+        snapshot: detected,
+        source: source(),
+      });
+
+      expect(result).toBe(expectedExit);
+      expect(
+        readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+      ).toBe(beforeConfig);
+      expect(readFileSync(statePath(homeDirectory), "utf8")).toBe(beforeState);
+      if (confirmation === "cancelled") {
+        expect(prompts.cancel).toHaveBeenCalledWith(
+          "Installation was cancelled.",
+        );
+      }
+    },
+  );
+
+  it("uses persisted identity metadata after manifest metadata changes", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor({ serverName: "persisted-support" }),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+
+    const result = await runEngineRemovalSession({
+      dependencies: deps,
+      prompter: prompter(),
+      snapshot: detected,
+      source: source({
+        serverName: "renamed-support",
+        title: "Renamed Support Engine",
+      }),
+    });
+
+    expect(result).toBe(0);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).not.toContain("persisted-support");
+  });
+
+  it("fails the global preflight for a server-name identity mismatch", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor({ id: "different-engine" }),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    const prompts = prompter();
+
+    await expect(
+      runEngineRemovalSession({
+        dependencies: deps,
+        prompter: prompts,
+        snapshot: detected,
+        source: source(),
+      }),
+    ).rejects.toMatchObject({ code: "ENGINE_IDENTITY_MISMATCH" });
+    expect(prompts.confirm).not.toHaveBeenCalled();
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("support-engine");
+  });
+
+  it("fails a mixed-identity state before removing an exact match", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor({ id: "different-engine" }),
+      snapshot: detected,
+      targetIds: ["cursor"],
+    });
+    const prompts = prompter();
+
+    await expect(
+      runEngineRemovalSession({
+        dependencies: deps,
+        prompter: prompts,
+        snapshot: detected,
+        source: source(),
+      }),
+    ).rejects.toMatchObject({ code: "ENGINE_IDENTITY_MISMATCH" });
+    expect(prompts.confirm).not.toHaveBeenCalled();
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("support-engine");
+  });
+
+  it("does not confirm or mutate an all-blocked legacy set", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    const path = statePath(homeDirectory);
+    const state = JSON.parse(readFileSync(path, "utf8")) as {
+      installations: Record<string, { launchDescriptor?: unknown }>;
+    };
+    for (const installation of Object.values(state.installations)) {
+      delete installation.launchDescriptor;
+    }
+    writeFileSync(path, `${JSON.stringify(state)}\n`);
+    const prompts = prompter();
+
+    const result = await runEngineRemovalSession({
+      dependencies: deps,
+      prompter: prompts,
+      snapshot: detected,
+      source: source(),
+    });
+
+    expect(result).toBe(1);
+    expect(prompts.confirm).not.toHaveBeenCalled();
+    expect(prompts.log).toHaveBeenCalledWith(
+      "error",
+      "Codex: INSTALLATION_UNAVAILABLE: The managed installation is unavailable.",
+    );
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("support-engine");
+  });
+
+  it("commits removable targets while leaving a drifted target unchanged", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex", "cursor"],
+    });
+    const cursorPath = join(homeDirectory, ".cursor/mcp.json");
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf8")) as {
+      mcpServers: Record<string, { args: string[] }>;
+    };
+    cursor.mcpServers["support-engine"]?.args.push("--external-change");
+    writeFileSync(cursorPath, `${JSON.stringify(cursor)}\n`);
+    const prompts = prompter();
+
+    const result = await runEngineRemovalSession({
+      dependencies: deps,
+      prompter: prompts,
+      snapshot: detected,
+      source: source(),
+    });
+
+    expect(result).toBe(1);
+    expect(prompts.confirm).toHaveBeenCalledTimes(1);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).not.toContain("support-engine");
+    expect(readFileSync(cursorPath, "utf8")).toContain("--external-change");
+    expect(prompts.log).toHaveBeenCalledWith(
+      "error",
+      "Cursor: CONFIG_DRIFT: The managed MCP server was changed outside the installer.",
+    );
+  });
+
+  it("commits an independent target when another config path relocated", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const installedSnapshot = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: installedSnapshot,
+      targetIds: ["codex", "cursor"],
+    });
+    const codex = installedSnapshot.targets[0];
+    const cursor = installedSnapshot.targets[1];
+    if (codex === undefined || cursor === undefined) throw new Error("fixture");
+    const relocatedSnapshot = {
+      ...installedSnapshot,
+      targets: [
+        codex,
+        {
+          ...cursor,
+          configuration: {
+            kind: "present" as const,
+            path: join(homeDirectory, ".cursor-relocated/mcp.json"),
+          },
+        },
+      ],
+    };
+    const prompts = prompter();
+
+    const result = await runEngineRemovalSession({
+      dependencies: deps,
+      prompter: prompts,
+      snapshot: relocatedSnapshot,
+      source: source(),
+    });
+
+    expect(result).toBe(1);
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).not.toContain("support-engine");
+    expect(
+      readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8"),
+    ).toContain("support-engine");
+    expect(prompts.log).toHaveBeenCalledWith(
+      "error",
+      "Cursor: HARNESS_CONFIG_UNSAFE: The harness configuration path is unsafe.",
+    );
+  });
+
+  it("removes detached-disabled state without restoring its definition", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-engine-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["cursor"],
+    });
+    await mutateDescriptorAcrossTargets({
+      action: "disable",
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["cursor"],
+    });
+
+    const result = await runEngineRemovalSession({
+      dependencies: deps,
+      prompter: prompter(),
+      snapshot: detected,
+      source: source(),
+    });
+
+    expect(result).toBe(0);
+    expect(
+      JSON.parse(readFileSync(join(homeDirectory, ".cursor/mcp.json"), "utf8")),
+    ).toEqual({ mcpServers: {} });
+    const state = JSON.parse(
+      readFileSync(statePath(homeDirectory), "utf8"),
+    ) as {
+      readonly installations: Readonly<Record<string, unknown>>;
+    };
+    expect(state.installations).toEqual({});
+  });
+});

--- a/packages/installer/test/fixtures/engine-removal-sentinel-scenario.mjs
+++ b/packages/installer/test/fixtures/engine-removal-sentinel-scenario.mjs
@@ -1,0 +1,147 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runEngineRemovalSession } from "../../dist/engine-removal-session.js";
+import { installDescriptorAcrossTargets } from "../../dist/mutation-coordinator.js";
+import { createNodeFileSystem } from "../../dist/node-file-system.js";
+import { configurationTargetAdapters } from "../../dist/target-adapters.js";
+
+const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-remove-sentinel-"));
+let wallTime = Date.parse("2026-07-30T12:00:00.000Z");
+let monotonic = 0;
+let token = 0;
+const environmentReads = new Set();
+const descriptor = {
+  id: "support-engine",
+  version: "1.0.0",
+  title: "Support Engine",
+  description: "Support actions.",
+  capabilityIds: ["tickets.summarize"],
+  server: {
+    name: "support-engine",
+    transport: {
+      type: "stdio",
+      command: "/missing/node",
+      args: ["/missing/project/dist/mcp-stdio.js"],
+      forwardEnv: ["SUPPORT_API_TOKEN"],
+    },
+  },
+};
+const snapshot = {
+  homeDirectory,
+  surfaces: [],
+  targets: [
+    {
+      id: "codex",
+      displayName: "Codex",
+      surfaceIds: [],
+      evidence: "installed",
+      executables: [],
+      configuration: {
+        kind: "absent",
+        path: join(homeDirectory, ".codex/config.toml"),
+      },
+      eligible: true,
+      mayCreateConfiguration: true,
+      reloadHint: "Reload Codex.",
+    },
+  ],
+};
+const dependencies = {
+  adapters: configurationTargetAdapters,
+  currentUserId: process.getuid?.() ?? 0,
+  environment: {
+    get(name) {
+      environmentReads.add(name);
+      if (name === "SUPPORT_API_TOKEN") {
+        throw new Error("LAUNCH_ENVIRONMENT_VALUE_READ");
+      }
+      return undefined;
+    },
+  },
+  fileSystem: createNodeFileSystem(),
+  lock: {
+    clock: {
+      monotonicNow: () => monotonic,
+      now: () => wallTime,
+      wait: async (milliseconds) => {
+        monotonic += milliseconds;
+        wallTime += milliseconds;
+      },
+    },
+    processId: 451,
+    randomBytes: (length) => {
+      token += 1;
+      return new Uint8Array(length).fill(token);
+    },
+  },
+  now: () => new Date(wallTime).toISOString(),
+};
+const prompter = {
+  intro() {},
+  outro() {},
+  cancel() {},
+  async autocomplete() {
+    throw new Error("unexpected prompt");
+  },
+  async select() {
+    throw new Error("unexpected prompt");
+  },
+  async multiselect() {
+    throw new Error("unexpected prompt");
+  },
+  note() {},
+  async confirm() {
+    return { kind: "submitted", value: true };
+  },
+  spinner() {
+    throw new Error("unexpected spinner");
+  },
+  log() {},
+};
+
+try {
+  await installDescriptorAcrossTargets({
+    dependencies,
+    descriptor,
+    snapshot,
+    targetIds: ["codex"],
+  });
+  const result = await runEngineRemovalSession({
+    dependencies,
+    prompter,
+    snapshot: {
+      ...snapshot,
+      targets: [
+        {
+          ...snapshot.targets[0],
+          evidence: "configuration-only",
+          configuration: snapshot.targets[0].configuration,
+          mayCreateConfiguration: false,
+        },
+      ],
+    },
+    source: {
+      manifestPath: "/missing/project/invokta.mcp.json",
+      id: "support-engine",
+      title: "Support Engine",
+      serverName: "support-engine",
+    },
+  });
+  const state = JSON.parse(
+    readFileSync(
+      join(homeDirectory, ".local/state/invokta/installer.json"),
+      "utf8",
+    ),
+  );
+  process.stdout.write(
+    `${JSON.stringify({
+      result,
+      environmentReads: [...environmentReads].sort(),
+      installations: Object.keys(state.installations).length,
+    })}\n`,
+  );
+} finally {
+  rmSync(homeDirectory, { recursive: true, force: true });
+}

--- a/packages/installer/test/installer-error.test.ts
+++ b/packages/installer/test/installer-error.test.ts
@@ -11,6 +11,8 @@ const expectedErrors = {
   ENGINE_MANIFEST_INVALID: "The Action Engine manifest is invalid.",
   ENGINE_PATH_UNSAFE: "The Action Engine path is unsafe.",
   ENGINE_ENTRYPOINT_MISSING: "The Action Engine entry point was not found.",
+  ENGINE_IDENTITY_MISMATCH:
+    "The manifest does not match the managed Action Engine identity.",
   REMOTE_INVALID: "The remote MCP server definition is invalid.",
   INSTALLATION_UNAVAILABLE: "The managed installation is unavailable.",
   INSTALLER_INITIALIZATION_FAILED: "The installer could not be initialized.",
@@ -40,9 +42,9 @@ const expectedErrors = {
 } as const;
 
 describe("InstallerError", () => {
-  it("defines exactly the 28 stable installer codes and messages", () => {
+  it("defines exactly the 29 stable installer codes and messages", () => {
     expect(installerErrorMessages).toEqual(expectedErrors);
-    expect(Object.keys(installerErrorMessages)).toHaveLength(28);
+    expect(Object.keys(installerErrorMessages)).toHaveLength(29);
 
     for (const [code, message] of Object.entries(expectedErrors)) {
       const error = new InstallerError(

--- a/packages/installer/test/interactive-session.test.ts
+++ b/packages/installer/test/interactive-session.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TargetConfigEvidenceProbes } from "../src/harness-detection.js";
 import type { InteractivePrompter } from "../src/interactive-prompter.js";
 import { runInteractiveSession } from "../src/interactive-session.js";
+import { createNodeFileSystem } from "../src/node-file-system.js";
 import type { RegistryCompatibilityAdapters } from "../src/registry.js";
 import { configurationTargetIds } from "../src/registry.js";
 
@@ -43,6 +44,87 @@ function absentConfigProbes(events: string[]): TargetConfigEvidenceProbes {
 }
 
 describe("interactive detection session", () => {
+  it("validates an engine-removal source before target detection", async () => {
+    const projectDirectory = mkdtempSync(
+      join(tmpdir(), "invokta-interactive-remove-project-"),
+    );
+    const homeDirectory = mkdtempSync(
+      join(tmpdir(), "invokta-interactive-remove-home-"),
+    );
+    temporaryDirectories.push(projectDirectory, homeDirectory);
+    writeFileSync(
+      join(projectDirectory, "invokta.mcp.json"),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        id: "support-engine",
+        version: "1.0.0",
+        title: "Support Engine",
+        description: "Support actions.",
+        capabilityIds: ["tickets.summarize"],
+        server: {
+          name: "support-engine",
+          entrypoint: "dist/mcp-stdio.js",
+          forwardEnv: [],
+        },
+      })}\n`,
+    );
+    const events: string[] = [];
+    const fileSystem = createNodeFileSystem();
+    const observedFileSystem = new Proxy(fileSystem, {
+      get(target, property, receiver) {
+        if (property === "openReadNoFollow") {
+          return async (path: string) => {
+            if (path.endsWith("invokta.mcp.json")) events.push("manifest");
+            return target.openReadNoFollow(path);
+          };
+        }
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const prompts: InteractivePrompter = {
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      autocomplete: vi.fn(),
+      select: vi.fn(),
+      multiselect: vi.fn(),
+      note: vi.fn(),
+      confirm: vi.fn(),
+      spinner: vi.fn(() => ({
+        start: vi.fn(),
+        stop: vi.fn(),
+        cancel: vi.fn(),
+        error: vi.fn(),
+        message: vi.fn(),
+        clear: vi.fn(),
+      })),
+      log: vi.fn(),
+    };
+
+    const result = await runInteractiveSession({
+      command: { kind: "remove-engine", projectDirectory },
+      prompter: prompts,
+      fileSystem: observedFileSystem,
+      transactionFileSystem: observedFileSystem,
+      environment: { get: () => undefined },
+      resolveHomeDirectory: () => {
+        events.push("home");
+        return homeDirectory;
+      },
+      resolveExecutable: async () => undefined,
+      configEvidenceProbes: absentConfigProbes(events),
+    });
+
+    expect(result).toBe(0);
+    expect(events.indexOf("manifest")).toBeGreaterThanOrEqual(0);
+    expect(events.indexOf("manifest")).toBeLessThan(events.indexOf("home"));
+    expect(prompts.confirm).not.toHaveBeenCalled();
+    expect(prompts.outro).toHaveBeenCalledWith(
+      "Support Engine is already uninstalled.",
+    );
+  });
+
   it("loads the empty registry, captures one read-only snapshot, and dismisses without mutation", async () => {
     const events: string[] = [];
     const note = vi.fn();

--- a/packages/installer/test/mutation-coordinator.test.ts
+++ b/packages/installer/test/mutation-coordinator.test.ts
@@ -19,6 +19,7 @@ import {
   installDescriptorAcrossTargets,
   type MutationCoordinatorDependencies,
   mutateDescriptorAcrossTargets,
+  removeEngineDescriptorFromTarget,
 } from "../src/mutation-coordinator.js";
 import { createNodeFileSystem } from "../src/node-file-system.js";
 import type { CapabilityInstallDescriptor } from "../src/registry.js";
@@ -452,6 +453,96 @@ describe("installer mutation coordinator", () => {
 
     expect(views).toHaveLength(1);
     expect(views[0]).toMatchObject({ status: "unavailable", actions: [] });
+  });
+
+  it("distinguishes a concurrent complete removal from lost ownership", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    const statePath = join(
+      homeDirectory,
+      ".local/state/invokta/installer.json",
+    );
+    writeFileSync(statePath, '{"schemaVersion":1,"installations":{}}\n');
+    writeFileSync(
+      join(homeDirectory, ".codex/config.toml"),
+      "# removed concurrently\n",
+    );
+
+    await expect(
+      removeEngineDescriptorFromTarget({
+        dependencies: deps,
+        descriptor: descriptor(),
+        manifestServerName: "support-engine",
+        snapshot: detected,
+        targetId: "codex",
+      }),
+    ).resolves.toEqual({ targetId: "codex", outcome: "unchanged" });
+
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    writeFileSync(statePath, '{"schemaVersion":1,"installations":{}}\n');
+
+    await expect(
+      removeEngineDescriptorFromTarget({
+        dependencies: deps,
+        descriptor: descriptor(),
+        manifestServerName: "support-engine",
+        snapshot: detected,
+        targetId: "codex",
+      }),
+    ).resolves.toEqual({
+      targetId: "codex",
+      outcome: "failed",
+      code: "INSTALLATION_UNAVAILABLE",
+    });
+  });
+
+  it("revalidates engine identity under the transaction locks", async () => {
+    const homeDirectory = mkdtempSync(join(tmpdir(), "invokta-mutation-"));
+    temporaryDirectories.push(homeDirectory);
+    const detected = snapshot(homeDirectory);
+    const deps = dependencies();
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: descriptor(),
+      snapshot: detected,
+      targetIds: ["codex"],
+    });
+    await installDescriptorAcrossTargets({
+      dependencies: deps,
+      descriptor: { ...descriptor(), id: "different-engine" },
+      snapshot: detected,
+      targetIds: ["cursor"],
+    });
+
+    await expect(
+      removeEngineDescriptorFromTarget({
+        dependencies: deps,
+        descriptor: descriptor(),
+        manifestServerName: "support-engine",
+        snapshot: detected,
+        targetId: "codex",
+      }),
+    ).resolves.toEqual({
+      targetId: "codex",
+      outcome: "failed",
+      code: "ENGINE_IDENTITY_MISMATCH",
+    });
+    expect(
+      readFileSync(join(homeDirectory, ".codex/config.toml"), "utf8"),
+    ).toContain("support-engine");
   });
 
   it("reports a missing runtime as an explicit status state", async () => {

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
   existsSync,
   lstatSync,
@@ -9,6 +9,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -21,6 +22,9 @@ const checkoutDirectory = join(temporaryRoot, "checkout");
 const artifactDirectory = join(temporaryRoot, "artifacts");
 const consumerDirectory = join(temporaryRoot, "consumer");
 const generatedDirectory = join(temporaryRoot, "generated");
+const scriptExecutable = execFileSync("which", ["script"], {
+  encoding: "utf8",
+}).trim();
 const distEntryFiles = ["dist/index.js", "dist/index.d.ts"];
 const repositoryUrl = "git+https://github.com/vinilana/invokta.git";
 const issuesUrl = "https://github.com/vinilana/invokta/issues";
@@ -98,6 +102,67 @@ function run(command, args, options = {}) {
   }
 
   return result.stdout ?? "";
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function runInteractive(command, args, options) {
+  return new Promise((resolveInteractive, rejectInteractive) => {
+    const child = spawn(
+      scriptExecutable,
+      [
+        "--quiet",
+        "--return",
+        "--command",
+        [command, ...args].map(shellQuote).join(" "),
+        "/dev/null",
+      ],
+      {
+        cwd: options.cwd,
+        env: { ...process.env, ...options.env },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    let submitted = false;
+    const timeout = setTimeout(() => {
+      child.kill();
+      rejectInteractive(
+        new Error(`interactive command timed out\n${stdout}\n${stderr}`),
+      );
+    }, 10_000);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      if (!submitted && stdout.includes(options.waitFor)) {
+        submitted = true;
+        setTimeout(() => child.stdin.write(options.input), 250);
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      rejectInteractive(error);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        rejectInteractive(
+          new Error(
+            `interactive command failed with exit code ${String(code)}\n${stdout}\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolveInteractive(stdout);
+    });
+  });
 }
 
 function failReleaseMetadata(message) {
@@ -361,6 +426,69 @@ function writeGeneratedMcpSmoke(projectDirectory) {
   writeFileSync(join(projectDirectory, "mcp-smoke.mjs"), program);
 }
 
+function writeGeneratedInstallerFixture(projectDirectory) {
+  const program = `
+    import assert from "node:assert/strict";
+    import { join } from "node:path";
+
+    import { loadEngineInstallManifest } from "./node_modules/@invokta/installer/dist/engine-manifest.js";
+    import { installDescriptorAcrossTargets } from "./node_modules/@invokta/installer/dist/mutation-coordinator.js";
+    import { createNodeFileSystem } from "./node_modules/@invokta/installer/dist/node-file-system.js";
+    import { configurationTargetAdapters } from "./node_modules/@invokta/installer/dist/target-adapters.js";
+
+    const homeDirectory = process.env.HOME;
+    assert.ok(homeDirectory);
+    const fileSystem = createNodeFileSystem();
+    const source = await loadEngineInstallManifest({
+      currentUserId: process.getuid?.() ?? 0,
+      fileSystem,
+      nodeExecutable: process.execPath,
+      projectDirectory: process.cwd(),
+    });
+    let now = Date.parse("2026-07-30T12:00:00.000Z");
+    const results = await installDescriptorAcrossTargets({
+      dependencies: {
+        adapters: configurationTargetAdapters,
+        currentUserId: process.getuid?.() ?? 0,
+        environment: { get: (name) => process.env[name] },
+        fileSystem,
+        lock: {
+          clock: {
+            monotonicNow: () => now,
+            now: () => now,
+            wait: async (milliseconds) => { now += milliseconds; },
+          },
+          processId: process.pid,
+          randomBytes: (length) => new Uint8Array(length).fill(7),
+        },
+        now: () => new Date(now).toISOString(),
+      },
+      descriptor: source.descriptor,
+      snapshot: {
+        homeDirectory,
+        surfaces: [],
+        targets: [{
+          id: "codex",
+          displayName: "Codex",
+          surfaceIds: [],
+          evidence: "configuration-only",
+          executables: [],
+          configuration: {
+            kind: "present",
+            path: join(homeDirectory, ".codex", "config.toml"),
+          },
+          eligible: true,
+          mayCreateConfiguration: false,
+          reloadHint: "Reload Codex.",
+        }],
+      },
+      targetIds: ["codex"],
+    });
+    assert.deepEqual(results, [{ targetId: "codex", outcome: "installed" }]);
+  `;
+  writeFileSync(join(projectDirectory, "installer-fixture.mjs"), program);
+}
+
 try {
   mkdirSync(checkoutDirectory);
   mkdirSync(artifactDirectory);
@@ -558,6 +686,14 @@ try {
       "generated @invokta/installer version is not release-aligned",
     );
   }
+  if (
+    generatedManifest.scripts?.["mcp:install"] !==
+      "tsc -p tsconfig.json --pretty false && invokta-installer install --engine ." ||
+    generatedManifest.scripts?.["mcp:uninstall"] !==
+      "invokta-installer remove --engine ."
+  ) {
+    throw new Error("generated MCP lifecycle scripts are invalid");
+  }
   if (existsSync(join(generatedProjectDirectory, "src", "mcp-http.ts"))) {
     throw new Error("creator unexpectedly generated an HTTP entry point");
   }
@@ -612,6 +748,63 @@ try {
   }
   writeGeneratedMcpSmoke(generatedProjectDirectory);
   run("node", ["mcp-smoke.mjs"], { cwd: generatedProjectDirectory });
+
+  const installerFixtureHome = join(temporaryRoot, "installer-home");
+  const installerFixtureBin = join(installerFixtureHome, "bin");
+  const installerFixtureState = join(installerFixtureHome, ".state");
+  const installerFixtureConfig = join(
+    installerFixtureHome,
+    ".codex",
+    "config.toml",
+  );
+  mkdirSync(installerFixtureBin, { recursive: true });
+  mkdirSync(dirname(installerFixtureConfig), { recursive: true });
+  mkdirSync(installerFixtureState, { recursive: true });
+  symlinkSync(process.execPath, join(installerFixtureBin, "node"));
+  symlinkSync("/bin/sh", join(installerFixtureBin, "sh"));
+  const configurationPreimage = "# packed uninstall fixture\n";
+  writeFileSync(installerFixtureConfig, configurationPreimage);
+  const installerFixtureEnvironment = {
+    HOME: installerFixtureHome,
+    PATH: installerFixtureBin,
+    XDG_STATE_HOME: installerFixtureState,
+  };
+  writeGeneratedInstallerFixture(generatedProjectDirectory);
+  run(process.execPath, ["installer-fixture.mjs"], {
+    cwd: generatedProjectDirectory,
+    env: installerFixtureEnvironment,
+  });
+  if (
+    !readFileSync(installerFixtureConfig, "utf8").includes("release-engine")
+  ) {
+    throw new Error("packed installer fixture did not install the engine");
+  }
+  rmSync(join(generatedProjectDirectory, "dist", "mcp-stdio.js"));
+  const npmExecutable = execFileSync("which", ["npm"], {
+    encoding: "utf8",
+  }).trim();
+  await runInteractive(npmExecutable, ["run", "--silent", "mcp:uninstall"], {
+    cwd: generatedProjectDirectory,
+    env: installerFixtureEnvironment,
+    input: "y\n",
+    waitFor: "Engine uninstall preflight",
+  });
+  const uninstalledConfiguration = readFileSync(installerFixtureConfig, "utf8");
+  if (
+    !uninstalledConfiguration.includes(configurationPreimage.trim()) ||
+    uninstalledConfiguration.includes("release-engine")
+  ) {
+    throw new Error("generated uninstall did not preserve unrelated config");
+  }
+  const installerFixtureStateReport = JSON.parse(
+    readFileSync(
+      join(installerFixtureState, "invokta", "installer.json"),
+      "utf8",
+    ),
+  );
+  if (Object.keys(installerFixtureStateReport.installations).length !== 0) {
+    throw new Error("generated uninstall left managed engine state behind");
+  }
 
   const capabilityCreatorCases = [
     {


### PR DESCRIPTION
## What changed

- add `invokta-installer remove --engine <project-directory>`
- scaffold build-free `mcp:uninstall` scripts and package-manager-specific usage
- remove one persisted engine identity from all managed MCP clients with one confirmation
- preserve per-target ownership, locking, rollback, partial completion, and idempotent retry behavior
- document the public workflow and add packed-package, isolation, concurrency, and session coverage

## Why

The previous PR documented the behavior without implementing it. Generated Action Engines therefore still had no project-local inverse for `mcp:install`, and cleanup incorrectly depended on the global one-entry management flow.

## User impact

Engine authors can run `npm run mcp:uninstall` (or the equivalent pnpm/Yarn command) even when the compiled MCP entry point or recorded runtime is unavailable. Only installer-owned definitions matching the manifest ID are eligible for removal.

## Validation

- `yarn run check` — 1,797 passed, 1 skipped
- `yarn audit` — 0 vulnerabilities
- `yarn release:verify` — clean tarballs and executable generated `mcp:uninstall` smoke passed
