### PR TITLE
Add engine-embedded MCP installer commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `@invokta/installer` now exposes the `@invokta/installer/engine` subpath with
+  `runEngineInstallerCli`, so a distributed engine binary can run the existing
+  engine-scoped install and removal sessions against its own package root
+  (ADR 0019). The standalone `invokta-installer` command surface is unchanged.
+- Generated MCP stdio engines now ship a project-named executable whose
+  `install` and `uninstall` commands register or remove the engine in local
+  MCP clients without the project checkout. The starter adds `src/bin.ts`, a
+  package `bin` entry, a packed `files` list, and `@invokta/installer` as a
+  runtime dependency.
+
 ## [0.3.0] - 2026-08-01
 
 ### Added

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -123,8 +123,11 @@ selected channels. Every entry point imports the same engine; direct calls
 MCP stdio profiles also generate `src/bin.ts`, a composition root that
 delegates to
 [`@invokta/installer/engine`](/reference/installer/#embed-install-commands-in-an-engine-binary),
-so the published package ships a project-named executable whose `install` and
-`uninstall` commands register or remove the engine without the checkout.
+so an author-prepared package can ship a project-named executable whose
+`install` and `uninstall` commands register or remove the engine without the
+checkout. Generated projects remain private by default; registry publication
+requires the author to choose package access and license metadata and remove
+`"private": true` explicitly.
 
 MCP HTTP entries are byte-identical to the immutable public planner from
 `@invokta/deploy/scaffold`. The creator merges the complete plan before writing,

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -112,13 +112,19 @@ tsconfig.test.json
 | Feature | Added entries | Added packages and scripts |
 | --- | --- | --- |
 | CLI | `src/cli.ts` | `@invokta/cli`; `cli` |
-| MCP local | `invokta.mcp.json`, `src/mcp-stdio.ts` | `@invokta/mcp`, dev `@invokta/installer`; `mcp:stdio`, `mcp:install`, `mcp:uninstall` |
+| MCP local | `invokta.mcp.json`, `src/bin.ts`, `src/mcp-stdio.ts` | `@invokta/installer`, `@invokta/mcp`; `mcp:stdio`, `mcp:install`, `mcp:uninstall`; a project-named `bin` entry and packed `files` |
 | MCP HTTP | `.env.example`, `invokta.deploy.json`, `src/env.ts`, `src/http-auth.ts`, `src/mcp-http.ts` | `@invokta/mcp`, dev `@invokta/deploy`; `mcp:http`, `deploy:package`, `deploy:probe` |
 
 Dependencies and scripts are exact set unions. Generated Invokta versions match
 the creator version. Documentation and generated agent guidance name only the
 selected channels. Every entry point imports the same engine; direct calls
 `engine.invoke`, while CLI and MCP use official adapters that converge on it.
+
+MCP stdio profiles also generate `src/bin.ts`, a composition root that
+delegates to
+[`@invokta/installer/engine`](/reference/installer/#embed-install-commands-in-an-engine-binary),
+so the published package ships a project-named executable whose `install` and
+`uninstall` commands register or remove the engine without the checkout.
 
 MCP HTTP entries are byte-identical to the immutable public planner from
 `@invokta/deploy/scaffold`. The creator merges the complete plan before writing,

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -118,11 +118,13 @@ project location and mutable manifest metadata are not provenance.
 
 ### Embed install commands in an engine binary
 
-A published engine can ship its own installation command instead of asking the
-consumer to locate the package directory. The `@invokta/installer/engine`
-subpath exports `runEngineInstallerCli`, which accepts exactly `install`,
-`uninstall`, and `--help` and runs the same engine-scoped interactive sessions
-against the embedding package root:
+A packaged engine can ship its own installation command instead of asking the
+consumer to locate the package directory. Generated Invokta starters remain
+private by default, so registry publication requires an explicit author choice
+of package access and license metadata plus removal of `"private": true`. The
+`@invokta/installer/engine` subpath exports `runEngineInstallerCli`, which
+accepts exactly `install`, `uninstall`, and `--help` and runs the same
+engine-scoped interactive sessions against the embedding package root:
 
 ```ts
 #!/usr/bin/env node

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -32,8 +32,10 @@ existing engine when needed:
 npm install --save-dev @invokta/installer
 ```
 
-The package is native ESM, requires Node.js 22.20.0 or later, exposes no
-JavaScript import API, and publishes only the `invokta-installer` binary.
+The package is native ESM, requires Node.js 22.20.0 or later, and publishes
+the `invokta-installer` binary plus one embeddable subpath export,
+[`@invokta/installer/engine`](#embed-install-commands-in-an-engine-binary).
+The package root exports no JavaScript API.
 
 The bundled capability registry may remain empty. Explicit local-engine and
 remote-HTTP commands supply their own reviewed descriptors; new managed state
@@ -113,6 +115,50 @@ manifest but does not require the compiled entry point, recorded Node
 executable, forwarded environment variables, or an installed client executable.
 The manifest `id` selects the same logical engine across every managed target;
 project location and mutable manifest metadata are not provenance.
+
+### Embed install commands in an engine binary
+
+A published engine can ship its own installation command instead of asking the
+consumer to locate the package directory. The `@invokta/installer/engine`
+subpath exports `runEngineInstallerCli`, which accepts exactly `install`,
+`uninstall`, and `--help` and runs the same engine-scoped interactive sessions
+against the embedding package root:
+
+```ts
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+import { runEngineInstallerCli } from "@invokta/installer/engine";
+
+process.exitCode = await runEngineInstallerCli({
+  argv: process.argv.slice(2),
+  binaryName: "support-engine",
+  packageRoot: fileURLToPath(new URL("..", import.meta.url)),
+});
+```
+
+With a package `bin` entry pointing at the compiled module, the consumer runs:
+
+```sh
+npm install --global support-engine
+support-engine install
+# Later:
+support-engine uninstall
+```
+
+Generated MCP stdio projects include this composition root, the `bin` entry,
+and `@invokta/installer` as a runtime dependency. The embedded surface keeps
+the manifest contract, TTY requirement, confirmations, diagnostics, and exit
+statuses of the standalone commands, and it never builds, downloads, imports,
+or executes the engine.
+
+<Aside type="caution" title="Install from a stable location">
+  The recorded launch descriptor points at the absolute entry-point path. Run
+  `install` from a durable installation, such as a global package install. An
+  ephemeral extraction directory (for example a package-runner cache)
+  invalidates the descriptor when it is pruned; `status` then reports the
+  missing entry point.
+</Aside>
 
 ### Install a remote HTTP server
 

--- a/docs/adr/0019-engine-embedded-mcp-install-commands.md
+++ b/docs/adr/0019-engine-embedded-mcp-install-commands.md
@@ -54,8 +54,12 @@ import or execution.
 module URL and delegates to `runEngineInstallerCli`, a package `bin` entry
 named after the project, and a `files` list that packs `dist` and
 `invokta.mcp.json`. `@invokta/installer` becomes a runtime dependency of those
-generated projects. The build-first `mcp:install` and build-free
-`mcp:uninstall` scripts remain the in-checkout author workflow.
+generated projects. The starter remains a private package under ADR 0012;
+registry publication requires the author to choose package access and license
+metadata and remove `"private": true` explicitly. This decision provides the
+distribution entry point but does not publish the generated project. The
+build-first `mcp:install` and build-free `mcp:uninstall` scripts remain the
+in-checkout author workflow.
 
 The persisted launch descriptor still records the absolute Node executable and
 absolute entry point (ADR 0013), so registration is only durable from a stable

--- a/docs/adr/0019-engine-embedded-mcp-install-commands.md
+++ b/docs/adr/0019-engine-embedded-mcp-install-commands.md
@@ -1,0 +1,78 @@
+# ADR 0019: Engine-embedded MCP install and uninstall commands
+
+- Status: Accepted
+- Date: 2026-08-02
+
+## Context
+
+ADR 0013 made `@invokta/installer` a binary-only standalone application, and
+ADR 0017 added engine-scoped removal. Both flows reach a local engine through
+`invokta-installer install --engine <project-directory>` and
+`invokta-installer remove --engine <project-directory>`, and the generated
+`mcp:install` and `mcp:uninstall` package scripts wrap those commands for the
+author working inside the project checkout.
+
+A distributed engine has no equivalent entry point. After an engine package is
+installed from a registry, its consumer does not know the package's on-disk
+directory, so the `--engine <project-directory>` contract is not reachable
+without inspecting the package manager's layout. Engine authors need to ship
+one memorable command with the package itself — for example
+`support-engine install` — without duplicating the installer's reviewed client
+configuration adapters, locking, state, rollback, and ownership rules, and
+without expanding the standalone installer into a package loader.
+
+## Decision
+
+`@invokta/installer` adds one narrow embeddable subpath export,
+`@invokta/installer/engine`, exposing `runEngineInstallerCli`. The root of the
+package remains unexported, the package publishes no `main` or top-level
+`types`, and the `invokta-installer` executable keeps the exact ADR 0013 and
+ADR 0017 command surface. The installer remains the only writer of client
+configuration; the embedded surface reuses the existing engine-scoped
+interactive sessions and adds no new mutation path.
+
+`runEngineInstallerCli` receives the embedding package's absolute root
+directory and executable name and accepts exactly this argument surface:
+
+```text
+<engine-binary> install
+<engine-binary> uninstall
+<engine-binary> --help
+```
+
+`install` runs the ADR 0013 engine installation session and `uninstall` runs
+the ADR 0017 engine-scoped removal session, both with the embedding package
+root as the project directory. The closed `invokta.mcp.json` manifest contract,
+current-user and no-follow path validation, TTY requirement, interactive
+confirmation, diagnostics, and exit statuses `0`, `1`, `2`, and `130` are
+unchanged. Any other argument vector is invalid usage. The embedded surface
+performs no build, no package acquisition, no network access, and no engine
+import or execution.
+
+`create-invokta-engine` generates, for profiles that include MCP stdio, a
+`src/bin.ts` composition root that resolves the package root from its own
+module URL and delegates to `runEngineInstallerCli`, a package `bin` entry
+named after the project, and a `files` list that packs `dist` and
+`invokta.mcp.json`. `@invokta/installer` becomes a runtime dependency of those
+generated projects. The build-first `mcp:install` and build-free
+`mcp:uninstall` scripts remain the in-checkout author workflow.
+
+The persisted launch descriptor still records the absolute Node executable and
+absolute entry point (ADR 0013), so registration is only durable from a stable
+package location, such as a global installation; an ephemeral extraction
+directory invalidates the descriptor when it is pruned, and `status` reports
+the missing entry point. Generated documentation states this constraint.
+
+## Consequences
+
+- A published engine registers and removes itself in local MCP clients with one
+  shipped command, and every mutation continues through the installer's
+  existing transactions, locks, rollback, and ownership fingerprints.
+- `@invokta/installer/engine`, its argument surface, and its exit statuses
+  become compatibility surfaces alongside the standalone command surface; the
+  standalone binary contract is unchanged.
+- The installer package is no longer import-free at its boundary; it remains
+  framework-free, and the subpath export must not grow management, remote, or
+  registry operations without a separate architectural decision.
+- Generated engines carry the installer as a runtime dependency in exchange for
+  a self-contained end-user installation flow.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0016](0016-generated-invokta-development-skills.md) | Generated Invokta development skills | Accepted | 2026-07-30 |
 | [0017](0017-engine-scoped-mcp-uninstall.md) | Engine-scoped MCP uninstall | Accepted | 2026-07-30 |
 | [0018](0018-interactive-engine-creator-profiles.md) | Interactive engine creator profiles | Accepted | 2026-07-30 |
+| [0019](0019-engine-embedded-mcp-install-commands.md) | Engine-embedded MCP install and uninstall commands | Accepted | 2026-08-02 |

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -111,6 +111,18 @@ without rebuilding it:
 \`\`\`sh
 ${runScript("mcp:uninstall")}
 \`\`\`
+
+The package also ships the \`${projectName}\` executable, so a consumer of the
+published package can install or remove the engine without this checkout:
+
+\`\`\`sh
+${projectName} install
+${projectName} uninstall
+\`\`\`
+
+Run \`install\` from a durable location, such as a global package
+installation; the recorded launch descriptor points at this package's absolute
+entry-point path, so an ephemeral package-runner cache invalidates it.
 `
     : "";
   const httpSection = features.mcpHttp
@@ -293,6 +305,7 @@ function renderPackageManifest(
   const dependencies = {
     ...(features.cli ? { "@invokta/cli": invoktaVersion } : {}),
     "@invokta/core": invoktaVersion,
+    ...(features.mcpStdio ? { "@invokta/installer": invoktaVersion } : {}),
     ...(features.mcpStdio || features.mcpHttp
       ? { "@invokta/mcp": invoktaVersion }
       : {}),
@@ -300,7 +313,6 @@ function renderPackageManifest(
   };
   const devDependencies = {
     ...(features.mcpHttp ? { "@invokta/deploy": invoktaVersion } : {}),
-    ...(features.mcpStdio ? { "@invokta/installer": invoktaVersion } : {}),
     "@types/node": "26.1.2",
     typescript: "7.0.2",
     vitest: "4.1.10",
@@ -311,11 +323,31 @@ function renderPackageManifest(
     private: true,
     type: "module",
     engines: { node: ">=22.20.0" },
+    ...(features.mcpStdio
+      ? {
+          bin: { [projectName]: "./dist/bin.js" },
+          files: ["dist", "invokta.mcp.json"],
+        }
+      : {}),
     scripts,
     dependencies,
     devDependencies,
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function renderBinModule(projectName: string): string {
+  return `#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+import { runEngineInstallerCli } from "@invokta/installer/engine";
+
+process.exitCode = await runEngineInstallerCli({
+  argv: process.argv.slice(2),
+  binaryName: ${JSON.stringify(projectName)},
+  packageRoot: fileURLToPath(new URL("..", import.meta.url)),
+});
+`;
 }
 
 function renderMcpInstallManifest(projectName: string): string {
@@ -535,6 +567,7 @@ export function createStarterFiles(
         "invokta.mcp.json",
         renderMcpInstallManifest(options.projectName),
       ),
+      starterFile("src/bin.ts", renderBinModule(options.projectName)),
       starterFile("src/mcp-stdio.ts", mcpStdioModule),
     );
   }

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -112,8 +112,13 @@ without rebuilding it:
 ${runScript("mcp:uninstall")}
 \`\`\`
 
-The package also ships the \`${projectName}\` executable, so a consumer of the
-published package can install or remove the engine without this checkout:
+The package also defines the \`${projectName}\` executable for a durable
+packaged distribution. This starter remains private by default; before registry
+publication, choose the package's license and access metadata deliberately and
+remove \`"private": true\`.
+
+After distribution, a consumer can install or remove the engine without this
+checkout:
 
 \`\`\`sh
 ${projectName} install

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -61,7 +61,7 @@ describe("createStarterProject", () => {
 
     expect(result.projectName).toBe("my-engine");
     expect(result.directory).toBe(join(cwd, "engines/my-engine"));
-    expect(result.files).toHaveLength(21);
+    expect(result.files).toHaveLength(22);
     expect(
       JSON.parse(readFileSync(join(result.directory, "package.json"), "utf8")),
     ).toMatchObject({ name: "my-engine", private: true });
@@ -82,8 +82,8 @@ describe("createStarterProject", () => {
   });
 
   it.each([
-    ["complete", 21],
-    ["mcp-stdio", 15],
+    ["complete", 22],
+    ["mcp-stdio", 16],
     ["mcp-http", 18],
     ["cli", 14],
   ] as const)(

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -34,13 +34,19 @@ const expectedPaths = {
     ".env.example",
     "invokta.deploy.json",
     "invokta.mcp.json",
+    "src/bin.ts",
     "src/cli.ts",
     "src/env.ts",
     "src/http-auth.ts",
     "src/mcp-http.ts",
     "src/mcp-stdio.ts",
   ].sort(),
-  "mcp-stdio": [...commonPaths, "invokta.mcp.json", "src/mcp-stdio.ts"].sort(),
+  "mcp-stdio": [
+    ...commonPaths,
+    "invokta.mcp.json",
+    "src/bin.ts",
+    "src/mcp-stdio.ts",
+  ].sort(),
   "mcp-http": [
     ...commonPaths,
     ".env.example",
@@ -118,14 +124,14 @@ describe("createStarterFiles", () => {
   it.each([
     [
       "complete",
-      ["@invokta/cli", "@invokta/core", "@invokta/mcp", "zod"],
       [
-        "@invokta/deploy",
+        "@invokta/cli",
+        "@invokta/core",
         "@invokta/installer",
-        "@types/node",
-        "typescript",
-        "vitest",
+        "@invokta/mcp",
+        "zod",
       ],
+      ["@invokta/deploy", "@types/node", "typescript", "vitest"],
       [
         "build",
         "check",
@@ -143,8 +149,8 @@ describe("createStarterFiles", () => {
     ],
     [
       "mcp-stdio",
-      ["@invokta/core", "@invokta/mcp", "zod"],
-      ["@invokta/installer", "@types/node", "typescript", "vitest"],
+      ["@invokta/core", "@invokta/installer", "@invokta/mcp", "zod"],
+      ["@types/node", "typescript", "vitest"],
       [
         "build",
         "check",
@@ -231,6 +237,44 @@ describe("createStarterFiles", () => {
       }
     },
   );
+
+  it("ships an embedded installer binary only with MCP stdio profiles", () => {
+    for (const profile of Object.keys(
+      expectedPaths,
+    ) as EngineStarterProfile[]) {
+      const files = createFiles(profile);
+      const contents = new Map(
+        files.flatMap((file) =>
+          "contents" in file ? [[file.path, file.contents] as const] : [],
+        ),
+      );
+      const manifest = JSON.parse(contents.get("package.json") ?? "") as {
+        readonly bin?: Readonly<Record<string, string>>;
+        readonly files?: readonly string[];
+      };
+      const hasStdio = profile === "complete" || profile === "mcp-stdio";
+
+      expect(contents.has("src/bin.ts")).toBe(hasStdio);
+      if (!hasStdio) {
+        expect(manifest.bin).toBeUndefined();
+        expect(manifest.files).toBeUndefined();
+        continue;
+      }
+      expect(manifest.bin).toEqual({
+        "customer-support-engine": "./dist/bin.js",
+      });
+      expect(manifest.files).toEqual(["dist", "invokta.mcp.json"]);
+      const binModule = contents.get("src/bin.ts") ?? "";
+      expect(binModule.startsWith("#!/usr/bin/env node\n")).toBe(true);
+      expect(binModule).toContain(
+        'import { runEngineInstallerCli } from "@invokta/installer/engine";',
+      );
+      expect(binModule).toContain('binaryName: "customer-support-engine"');
+      expect(binModule).toContain(
+        'packageRoot: fileURLToPath(new URL("..", import.meta.url))',
+      );
+    }
+  });
 
   it("uses one shared engine through every entry point included by a profile", () => {
     for (const profile of Object.keys(
@@ -347,11 +391,11 @@ describe("createStarterFiles", () => {
       dependencies: {
         "@invokta/cli": "1.2.3-beta.1",
         "@invokta/core": "1.2.3-beta.1",
+        "@invokta/installer": "1.2.3-beta.1",
         "@invokta/mcp": "1.2.3-beta.1",
         zod: "4.4.3",
       },
       devDependencies: {
-        "@invokta/installer": "1.2.3-beta.1",
         "@types/node": "26.1.2",
         typescript: "7.0.2",
         vitest: "4.1.10",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -25,7 +25,12 @@
     "dist",
     "registry"
   ],
-  "exports": {},
+  "exports": {
+    "./engine": {
+      "types": "./dist/engine-cli.d.ts",
+      "import": "./dist/engine-cli.js"
+    }
+  },
   "bin": {
     "invokta-installer": "./dist/cli.js"
   },

--- a/packages/installer/src/engine-cli-internal.ts
+++ b/packages/installer/src/engine-cli-internal.ts
@@ -1,0 +1,85 @@
+import {
+  executeInteractiveCliCommand,
+  type InstallerCliIo,
+  type InstallerCommand,
+  type InstallerExitCode,
+  resolveInstallerCliIo,
+  writeInitializationFailure,
+} from "./run-installer-cli.js";
+
+import type { RunEngineInstallerCliOptions } from "./engine-cli.js";
+
+interface RunEngineInstallerCliDependencies {
+  readonly io?: Partial<InstallerCliIo>;
+  readonly loadInteractiveSession?: (
+    command: InstallerCommand,
+  ) => Promise<InstallerExitCode>;
+}
+
+function helpText(binaryName: string): string {
+  return `Usage:
+  ${binaryName} install
+  ${binaryName} uninstall
+  ${binaryName} --help
+`;
+}
+
+function parseEngineCommand(
+  argv: readonly string[],
+  packageRoot: string,
+): InstallerCommand | undefined {
+  if (argv.length !== 1) return undefined;
+  if (argv[0] === "install") {
+    return Object.freeze({
+      kind: "install-engine",
+      projectDirectory: packageRoot,
+    });
+  }
+  if (argv[0] === "uninstall") {
+    return Object.freeze({
+      kind: "remove-engine",
+      projectDirectory: packageRoot,
+    });
+  }
+  return undefined;
+}
+
+async function writeUsageFailure(
+  io: InstallerCliIo,
+  binaryName: string,
+): Promise<2> {
+  try {
+    await io.writeStderr(`Invalid arguments. Run "${binaryName} --help".\n`);
+  } catch {
+    // A broken diagnostic destination cannot change the selected exit code.
+  }
+  return 2;
+}
+
+export async function runEngineInstallerCliWithDependencies(
+  options: RunEngineInstallerCliOptions & RunEngineInstallerCliDependencies,
+): Promise<InstallerExitCode> {
+  const io = resolveInstallerCliIo(options.io);
+  const argv = options.argv ?? process.argv.slice(2);
+
+  if (argv.length === 1 && argv[0] === "--help") {
+    try {
+      await io.writeStdout(helpText(options.binaryName));
+      return 0;
+    } catch (error) {
+      return writeInitializationFailure(io, error);
+    }
+  }
+  const command = parseEngineCommand(argv, options.packageRoot);
+  if (command === undefined) {
+    return writeUsageFailure(io, options.binaryName);
+  }
+
+  return executeInteractiveCliCommand({
+    command,
+    io,
+    ...(options.loadInteractiveSession === undefined
+      ? {}
+      : { loadInteractiveSession: options.loadInteractiveSession }),
+  });
+}

--- a/packages/installer/src/engine-cli.ts
+++ b/packages/installer/src/engine-cli.ts
@@ -1,0 +1,90 @@
+import {
+  executeInteractiveCliCommand,
+  type InstallerCliIo,
+  type InstallerCommand,
+  type InstallerExitCode,
+  resolveInstallerCliIo,
+  writeInitializationFailure,
+} from "./run-installer-cli.js";
+
+export type { InstallerCliIo, InstallerExitCode } from "./run-installer-cli.js";
+
+export interface RunEngineInstallerCliOptions {
+  /** Absolute directory holding the embedding engine's `invokta.mcp.json`. */
+  readonly packageRoot: string;
+  /** Executable name rendered in help and usage diagnostics. */
+  readonly binaryName: string;
+  readonly argv?: readonly string[];
+  readonly io?: Partial<InstallerCliIo>;
+  readonly loadInteractiveSession?: (
+    command: InstallerCommand,
+  ) => Promise<InstallerExitCode>;
+}
+
+function helpText(binaryName: string): string {
+  return `Usage:
+  ${binaryName} install
+  ${binaryName} uninstall
+  ${binaryName} --help
+`;
+}
+
+function parseEngineCommand(
+  argv: readonly string[],
+  packageRoot: string,
+): InstallerCommand | undefined {
+  if (argv.length !== 1) return undefined;
+  if (argv[0] === "install") {
+    return Object.freeze({
+      kind: "install-engine",
+      projectDirectory: packageRoot,
+    });
+  }
+  if (argv[0] === "uninstall") {
+    return Object.freeze({
+      kind: "remove-engine",
+      projectDirectory: packageRoot,
+    });
+  }
+  return undefined;
+}
+
+async function writeUsageFailure(
+  io: InstallerCliIo,
+  binaryName: string,
+): Promise<2> {
+  try {
+    await io.writeStderr(`Invalid arguments. Run "${binaryName} --help".\n`);
+  } catch {
+    // A broken diagnostic destination cannot change the selected exit code.
+  }
+  return 2;
+}
+
+export async function runEngineInstallerCli(
+  options: RunEngineInstallerCliOptions,
+): Promise<InstallerExitCode> {
+  const io = resolveInstallerCliIo(options.io);
+  const argv = options.argv ?? process.argv.slice(2);
+
+  if (argv.length === 1 && argv[0] === "--help") {
+    try {
+      await io.writeStdout(helpText(options.binaryName));
+      return 0;
+    } catch (error) {
+      return writeInitializationFailure(io, error);
+    }
+  }
+  const command = parseEngineCommand(argv, options.packageRoot);
+  if (command === undefined) {
+    return writeUsageFailure(io, options.binaryName);
+  }
+
+  return executeInteractiveCliCommand({
+    command,
+    io,
+    ...(options.loadInteractiveSession === undefined
+      ? {}
+      : { loadInteractiveSession: options.loadInteractiveSession }),
+  });
+}

--- a/packages/installer/src/engine-cli.ts
+++ b/packages/installer/src/engine-cli.ts
@@ -1,13 +1,4 @@
-import {
-  executeInteractiveCliCommand,
-  type InstallerCliIo,
-  type InstallerCommand,
-  type InstallerExitCode,
-  resolveInstallerCliIo,
-  writeInitializationFailure,
-} from "./run-installer-cli.js";
-
-export type { InstallerCliIo, InstallerExitCode } from "./run-installer-cli.js";
+import { runEngineInstallerCliWithDependencies } from "./engine-cli-internal.js";
 
 export interface RunEngineInstallerCliOptions {
   /** Absolute directory holding the embedding engine's `invokta.mcp.json`. */
@@ -15,76 +6,14 @@ export interface RunEngineInstallerCliOptions {
   /** Executable name rendered in help and usage diagnostics. */
   readonly binaryName: string;
   readonly argv?: readonly string[];
-  readonly io?: Partial<InstallerCliIo>;
-  readonly loadInteractiveSession?: (
-    command: InstallerCommand,
-  ) => Promise<InstallerExitCode>;
 }
 
-function helpText(binaryName: string): string {
-  return `Usage:
-  ${binaryName} install
-  ${binaryName} uninstall
-  ${binaryName} --help
-`;
-}
-
-function parseEngineCommand(
-  argv: readonly string[],
-  packageRoot: string,
-): InstallerCommand | undefined {
-  if (argv.length !== 1) return undefined;
-  if (argv[0] === "install") {
-    return Object.freeze({
-      kind: "install-engine",
-      projectDirectory: packageRoot,
-    });
-  }
-  if (argv[0] === "uninstall") {
-    return Object.freeze({
-      kind: "remove-engine",
-      projectDirectory: packageRoot,
-    });
-  }
-  return undefined;
-}
-
-async function writeUsageFailure(
-  io: InstallerCliIo,
-  binaryName: string,
-): Promise<2> {
-  try {
-    await io.writeStderr(`Invalid arguments. Run "${binaryName} --help".\n`);
-  } catch {
-    // A broken diagnostic destination cannot change the selected exit code.
-  }
-  return 2;
-}
-
-export async function runEngineInstallerCli(
+export function runEngineInstallerCli(
   options: RunEngineInstallerCliOptions,
-): Promise<InstallerExitCode> {
-  const io = resolveInstallerCliIo(options.io);
-  const argv = options.argv ?? process.argv.slice(2);
-
-  if (argv.length === 1 && argv[0] === "--help") {
-    try {
-      await io.writeStdout(helpText(options.binaryName));
-      return 0;
-    } catch (error) {
-      return writeInitializationFailure(io, error);
-    }
-  }
-  const command = parseEngineCommand(argv, options.packageRoot);
-  if (command === undefined) {
-    return writeUsageFailure(io, options.binaryName);
-  }
-
-  return executeInteractiveCliCommand({
-    command,
-    io,
-    ...(options.loadInteractiveSession === undefined
-      ? {}
-      : { loadInteractiveSession: options.loadInteractiveSession }),
+): Promise<0 | 1 | 2 | 130> {
+  return runEngineInstallerCliWithDependencies({
+    binaryName: options.binaryName,
+    packageRoot: options.packageRoot,
+    ...(options.argv === undefined ? {} : { argv: options.argv }),
   });
 }

--- a/packages/installer/src/run-installer-cli.ts
+++ b/packages/installer/src/run-installer-cli.ts
@@ -60,7 +60,9 @@ const defaultIo: InstallerCliIo = {
   },
 };
 
-function resolveIo(overrides: Partial<InstallerCliIo> | undefined) {
+export function resolveInstallerCliIo(
+  overrides: Partial<InstallerCliIo> | undefined,
+): InstallerCliIo {
   return {
     inputIsTTY: overrides?.inputIsTTY ?? defaultIo.inputIsTTY,
     outputIsTTY: overrides?.outputIsTTY ?? defaultIo.outputIsTTY,
@@ -162,7 +164,7 @@ async function writeStderr(io: InstallerCliIo, text: string): Promise<void> {
   }
 }
 
-async function writeInitializationFailure(
+export async function writeInitializationFailure(
   io: InstallerCliIo,
   error: unknown,
 ): Promise<2> {
@@ -174,37 +176,18 @@ async function writeInitializationFailure(
   return 2;
 }
 
-export async function runInstallerCli(
-  options: RunInstallerCliOptions = {},
+export interface ExecuteInteractiveCliCommandOptions {
+  readonly command: InstallerCommand;
+  readonly io: InstallerCliIo;
+  readonly loadInteractiveSession?: (
+    command: InstallerCommand,
+  ) => Promise<InstallerExitCode>;
+}
+
+export async function executeInteractiveCliCommand(
+  options: ExecuteInteractiveCliCommandOptions,
 ): Promise<InstallerExitCode> {
-  const io = resolveIo(options.io);
-  const argv = options.argv ?? process.argv.slice(2);
-
-  if (argv.length === 1 && argv[0] === "--help") {
-    try {
-      await io.writeStdout(helpText);
-      return 0;
-    } catch (error) {
-      return writeInitializationFailure(io, error);
-    }
-  }
-  if (argv.length === 1 && argv[0] === "--version") {
-    try {
-      const version = await (
-        options.loadPackageVersion ?? loadDefaultPackageVersion
-      )();
-      await io.writeStdout(`${version}\n`);
-      return 0;
-    } catch (error) {
-      return writeInitializationFailure(io, error);
-    }
-  }
-  const command = parseCommand(argv);
-  if (command === undefined) {
-    await writeStderr(io, invalidUsageText);
-    return 2;
-  }
-
+  const { command, io } = options;
   try {
     if (!io.inputIsTTY() || !io.outputIsTTY()) {
       await writeStderr(
@@ -232,4 +215,44 @@ export async function runInstallerCli(
     }
     return writeInitializationFailure(io, error);
   }
+}
+
+export async function runInstallerCli(
+  options: RunInstallerCliOptions = {},
+): Promise<InstallerExitCode> {
+  const io = resolveInstallerCliIo(options.io);
+  const argv = options.argv ?? process.argv.slice(2);
+
+  if (argv.length === 1 && argv[0] === "--help") {
+    try {
+      await io.writeStdout(helpText);
+      return 0;
+    } catch (error) {
+      return writeInitializationFailure(io, error);
+    }
+  }
+  if (argv.length === 1 && argv[0] === "--version") {
+    try {
+      const version = await (
+        options.loadPackageVersion ?? loadDefaultPackageVersion
+      )();
+      await io.writeStdout(`${version}\n`);
+      return 0;
+    } catch (error) {
+      return writeInitializationFailure(io, error);
+    }
+  }
+  const command = parseCommand(argv);
+  if (command === undefined) {
+    await writeStderr(io, invalidUsageText);
+    return 2;
+  }
+
+  return executeInteractiveCliCommand({
+    command,
+    io,
+    ...(options.loadInteractiveSession === undefined
+      ? {}
+      : { loadInteractiveSession: options.loadInteractiveSession }),
+  });
 }

--- a/packages/installer/test/engine-cli.test.ts
+++ b/packages/installer/test/engine-cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { runEngineInstallerCli } from "../src/engine-cli.js";
+import { runEngineInstallerCliWithDependencies } from "../src/engine-cli-internal.js";
 import { InstallerError } from "../src/installer-error.js";
 
 const helpText = `Usage:
@@ -43,7 +43,7 @@ describe("runEngineInstallerCli", () => {
     const output = createIo();
     const loadInteractiveSession = vi.fn(async () => 0 as const);
 
-    const result = await runEngineInstallerCli({
+    const result = await runEngineInstallerCliWithDependencies({
       argv: ["--help"],
       binaryName: "support-engine",
       io: output.io,
@@ -73,7 +73,7 @@ describe("runEngineInstallerCli", () => {
     const output = createIo();
     const loadInteractiveSession = vi.fn(async () => 0 as const);
 
-    const result = await runEngineInstallerCli({
+    const result = await runEngineInstallerCliWithDependencies({
       argv,
       binaryName: "support-engine",
       io: output.io,
@@ -95,7 +95,7 @@ describe("runEngineInstallerCli", () => {
     const output = createIo();
     const loadInteractiveSession = vi.fn(async () => 0 as const);
 
-    const result = await runEngineInstallerCli({
+    const result = await runEngineInstallerCliWithDependencies({
       argv: ["install"],
       binaryName: "support-engine",
       io: output.io,
@@ -116,7 +116,7 @@ describe("runEngineInstallerCli", () => {
     const output = createIo();
     const loadInteractiveSession = vi.fn(async () => 0 as const);
 
-    const result = await runEngineInstallerCli({
+    const result = await runEngineInstallerCliWithDependencies({
       argv: ["uninstall"],
       binaryName: "support-engine",
       io: output.io,
@@ -143,7 +143,7 @@ describe("runEngineInstallerCli", () => {
       const output = createIo(tty);
       const loadInteractiveSession = vi.fn(async () => 0 as const);
 
-      const result = await runEngineInstallerCli({
+      const result = await runEngineInstallerCliWithDependencies({
         argv: ["install"],
         binaryName: "support-engine",
         io: output.io,
@@ -166,7 +166,7 @@ describe("runEngineInstallerCli", () => {
       const output = createIo();
       const loadInteractiveSession = vi.fn(async () => exitCode);
 
-      const result = await runEngineInstallerCli({
+      const result = await runEngineInstallerCliWithDependencies({
         argv: ["install"],
         binaryName: "support-engine",
         io: output.io,
@@ -187,7 +187,7 @@ describe("runEngineInstallerCli", () => {
       throw new InstallerError("CANCELLED");
     });
 
-    const result = await runEngineInstallerCli({
+    const result = await runEngineInstallerCliWithDependencies({
       argv: ["uninstall"],
       binaryName: "support-engine",
       io: output.io,
@@ -205,7 +205,7 @@ describe("runEngineInstallerCli", () => {
       throw new InstallerError("ENGINE_ENTRYPOINT_MISSING");
     });
 
-    const result = await runEngineInstallerCli({
+    const result = await runEngineInstallerCliWithDependencies({
       argv: ["install"],
       binaryName: "support-engine",
       io: output.io,
@@ -230,7 +230,7 @@ describe("runEngineInstallerCli", () => {
         throw error;
       });
 
-      const result = await runEngineInstallerCli({
+      const result = await runEngineInstallerCliWithDependencies({
         argv: ["install"],
         binaryName: "support-engine",
         io: output.io,

--- a/packages/installer/test/engine-cli.test.ts
+++ b/packages/installer/test/engine-cli.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runEngineInstallerCli } from "../src/engine-cli.js";
+import { InstallerError } from "../src/installer-error.js";
+
+const helpText = `Usage:
+  support-engine install
+  support-engine uninstall
+  support-engine --help
+`;
+const packageRoot = "/opt/engines/support-engine";
+
+interface TestIoOptions {
+  readonly inputIsTTY?: boolean;
+  readonly outputIsTTY?: boolean;
+}
+
+function createIo(options: TestIoOptions = {}) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const inputIsTTY = vi.fn(() => options.inputIsTTY ?? true);
+  const outputIsTTY = vi.fn(() => options.outputIsTTY ?? true);
+  return {
+    io: {
+      inputIsTTY,
+      outputIsTTY,
+      writeStdout: vi.fn((text: string) => {
+        stdout.push(text);
+      }),
+      writeStderr: vi.fn((text: string) => {
+        stderr.push(text);
+      }),
+    },
+    inputIsTTY,
+    outputIsTTY,
+    stdout,
+    stderr,
+  };
+}
+
+describe("runEngineInstallerCli", () => {
+  it("writes the exact help text without loading the interactive application", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runEngineInstallerCli({
+      argv: ["--help"],
+      binaryName: "support-engine",
+      io: output.io,
+      loadInteractiveSession,
+      packageRoot,
+    });
+
+    expect(result).toBe(0);
+    expect(output.stdout).toEqual([helpText]);
+    expect(output.stderr).toEqual([]);
+    expect(output.inputIsTTY).not.toHaveBeenCalled();
+    expect(output.outputIsTTY).not.toHaveBeenCalled();
+    expect(loadInteractiveSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [],
+    ["--unknown"],
+    ["install", "extra"],
+    ["uninstall", "extra"],
+    ["--help", "extra"],
+    ["install", "--engine", "."],
+    ["remove"],
+    ["--version"],
+    [""],
+  ])("rejects every undocumented argument vector: %j", async (...argv) => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runEngineInstallerCli({
+      argv,
+      binaryName: "support-engine",
+      io: output.io,
+      loadInteractiveSession,
+      packageRoot,
+    });
+
+    expect(result).toBe(2);
+    expect(output.stdout).toEqual([]);
+    expect(output.stderr).toEqual([
+      'Invalid arguments. Run "support-engine --help".\n',
+    ]);
+    expect(output.inputIsTTY).not.toHaveBeenCalled();
+    expect(output.outputIsTTY).not.toHaveBeenCalled();
+    expect(loadInteractiveSession).not.toHaveBeenCalled();
+  });
+
+  it("maps install onto the engine installation session for the package root", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runEngineInstallerCli({
+      argv: ["install"],
+      binaryName: "support-engine",
+      io: output.io,
+      loadInteractiveSession,
+      packageRoot,
+    });
+
+    expect(result).toBe(0);
+    expect(loadInteractiveSession).toHaveBeenCalledWith({
+      kind: "install-engine",
+      projectDirectory: packageRoot,
+    });
+    expect(output.stdout).toEqual([]);
+    expect(output.stderr).toEqual([]);
+  });
+
+  it("maps uninstall onto the engine-scoped removal session for the package root", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+    const result = await runEngineInstallerCli({
+      argv: ["uninstall"],
+      binaryName: "support-engine",
+      io: output.io,
+      loadInteractiveSession,
+      packageRoot,
+    });
+
+    expect(result).toBe(0);
+    expect(loadInteractiveSession).toHaveBeenCalledWith({
+      kind: "remove-engine",
+      projectDirectory: packageRoot,
+    });
+    expect(output.stdout).toEqual([]);
+    expect(output.stderr).toEqual([]);
+  });
+
+  it.each([
+    { inputIsTTY: false, outputIsTTY: true },
+    { inputIsTTY: true, outputIsTTY: false },
+    { inputIsTTY: false, outputIsTTY: false },
+  ])(
+    "fails closed before interactive loading without both TTYs: %j",
+    async (tty) => {
+      const output = createIo(tty);
+      const loadInteractiveSession = vi.fn(async () => 0 as const);
+
+      const result = await runEngineInstallerCli({
+        argv: ["install"],
+        binaryName: "support-engine",
+        io: output.io,
+        loadInteractiveSession,
+        packageRoot,
+      });
+
+      expect(result).toBe(2);
+      expect(output.stdout).toEqual([]);
+      expect(output.stderr).toEqual([
+        "NO_TTY: The installer requires an interactive terminal.\n",
+      ]);
+      expect(loadInteractiveSession).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([0, 1, 2, 130] as const)(
+    "starts the lazy interactive application and preserves exit code %i",
+    async (exitCode) => {
+      const output = createIo();
+      const loadInteractiveSession = vi.fn(async () => exitCode);
+
+      const result = await runEngineInstallerCli({
+        argv: ["install"],
+        binaryName: "support-engine",
+        io: output.io,
+        loadInteractiveSession,
+        packageRoot,
+      });
+
+      expect(result).toBe(exitCode);
+      expect(loadInteractiveSession).toHaveBeenCalledTimes(1);
+      expect(output.stdout).toEqual([]);
+      expect(output.stderr).toEqual([]);
+    },
+  );
+
+  it("renders cancellation as exit status 130", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => {
+      throw new InstallerError("CANCELLED");
+    });
+
+    const result = await runEngineInstallerCli({
+      argv: ["uninstall"],
+      binaryName: "support-engine",
+      io: output.io,
+      loadInteractiveSession,
+      packageRoot,
+    });
+
+    expect(result).toBe(130);
+    expect(output.stderr).toEqual(["CANCELLED: Installation was cancelled.\n"]);
+  });
+
+  it("renders an operational failure as exit status 1", async () => {
+    const output = createIo();
+    const loadInteractiveSession = vi.fn(async () => {
+      throw new InstallerError("ENGINE_ENTRYPOINT_MISSING");
+    });
+
+    const result = await runEngineInstallerCli({
+      argv: ["install"],
+      binaryName: "support-engine",
+      io: output.io,
+      loadInteractiveSession,
+      packageRoot,
+    });
+
+    expect(result).toBe(1);
+    expect(output.stderr).toEqual([
+      "ENGINE_ENTRYPOINT_MISSING: The Action Engine entry point was not found.\n",
+    ]);
+  });
+
+  it.each([
+    new InstallerError("INSTALLER_INITIALIZATION_FAILED"),
+    new TypeError("unexpected"),
+  ])(
+    "renders an initialization failure as exit status 2: %s",
+    async (error) => {
+      const output = createIo();
+      const loadInteractiveSession = vi.fn(async () => {
+        throw error;
+      });
+
+      const result = await runEngineInstallerCli({
+        argv: ["install"],
+        binaryName: "support-engine",
+        io: output.io,
+        loadInteractiveSession,
+        packageRoot,
+      });
+
+      expect(result).toBe(2);
+      expect(output.stderr).toEqual([
+        "INSTALLER_INITIALIZATION_FAILED: The installer could not be initialized.\n",
+      ]);
+    },
+  );
+});

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -11,7 +11,7 @@ function readJson(path: string): Record<string, unknown> {
 }
 
 describe("@invokta/installer package boundary", () => {
-  it("publishes only the standalone executable on the repository runtime floor", () => {
+  it("publishes the standalone executable and only the engine subpath export", () => {
     const manifest = readJson(`${packageDirectory}/package.json`);
 
     expect(manifest).toMatchObject({
@@ -20,7 +20,12 @@ describe("@invokta/installer package boundary", () => {
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],
-      exports: {},
+      exports: {
+        "./engine": {
+          types: "./dist/engine-cli.d.ts",
+          import: "./dist/engine-cli.js",
+        },
+      },
       bin: { "invokta-installer": "./dist/cli.js" },
       dependencies: {
         "@clack/prompts": "1.7.0",
@@ -29,6 +34,9 @@ describe("@invokta/installer package boundary", () => {
         yaml: "2.9.0",
       },
     });
+    expect(Object.keys(manifest.exports as Record<string, unknown>)).toEqual([
+      "./engine",
+    ]);
     expect(manifest).not.toHaveProperty("main");
     expect(manifest).not.toHaveProperty("types");
   });

--- a/packages/installer/test/public-api.types.ts
+++ b/packages/installer/test/public-api.types.ts
@@ -1,0 +1,32 @@
+import { expectTypeOf } from "vitest";
+
+import {
+  type RunEngineInstallerCliOptions,
+  runEngineInstallerCli,
+} from "../src/engine-cli.js";
+
+const options: RunEngineInstallerCliOptions = {
+  argv: ["install"],
+  binaryName: "support-engine",
+  packageRoot: "/opt/engines/support-engine",
+};
+
+expectTypeOf(runEngineInstallerCli(options)).toEqualTypeOf<
+  Promise<0 | 1 | 2 | 130>
+>();
+
+const io = {
+  inputIsTTY: () => true,
+  outputIsTTY: () => true,
+  writeStderr: (_text: string) => undefined,
+  writeStdout: (_text: string) => undefined,
+};
+
+// @ts-expect-error Installer I/O is internal to the embedded command surface.
+runEngineInstallerCli({ ...options, io });
+
+runEngineInstallerCli({
+  ...options,
+  // @ts-expect-error Interactive session loading is not a public extension point.
+  loadInteractiveSession: async () => 0,
+});

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -831,11 +831,17 @@ try {
         ...commonCreatorEntries,
         ...httpCreatorEntries,
         "invokta.mcp.json",
+        "src/bin.ts",
         "src/cli.ts",
         "src/mcp-stdio.ts",
       ],
-      dependencies: ["@invokta/cli", "@invokta/core", "@invokta/mcp"],
-      devDependencies: ["@invokta/deploy", "@invokta/installer"],
+      dependencies: [
+        "@invokta/cli",
+        "@invokta/core",
+        "@invokta/installer",
+        "@invokta/mcp",
+      ],
+      devDependencies: ["@invokta/deploy"],
       scripts: [
         "build",
         "check",
@@ -863,10 +869,11 @@ try {
       entries: [
         ...commonCreatorEntries,
         "invokta.mcp.json",
+        "src/bin.ts",
         "src/mcp-stdio.ts",
       ],
-      dependencies: ["@invokta/core", "@invokta/mcp"],
-      devDependencies: ["@invokta/installer"],
+      dependencies: ["@invokta/core", "@invokta/installer", "@invokta/mcp"],
+      devDependencies: [],
       scripts: [
         "build",
         "check",

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -746,12 +746,14 @@ try {
     const tooling = await import("@invokta/tooling");
     const deploy = await import("@invokta/deploy");
     const deployScaffold = await import("@invokta/deploy/scaffold");
+    const installerEngine = await import("@invokta/installer/engine");
     if (typeof core.createEngine !== "function") throw new Error("core import failed");
     if (typeof cli.runCli !== "function") throw new Error("cli import failed");
     if (typeof mcp.serveMcpStdio !== "function") throw new Error("mcp import failed");
     if (typeof tooling.checkCapabilities !== "function") throw new Error("tooling import failed");
     if (typeof deploy.runDeployCli !== "function") throw new Error("deploy import failed");
     if (typeof deployScaffold.createMcpHttpScaffoldFiles !== "function") throw new Error("deploy scaffold import failed");
+    if (typeof installerEngine.runEngineInstallerCli !== "function") throw new Error("installer engine import failed");
   `;
   run("node", ["--input-type=module", "--eval", smokeProgram], {
     cwd: consumerDirectory,
@@ -1052,6 +1054,7 @@ try {
       "npm",
       [
         "install",
+        "--no-save",
         "--ignore-scripts",
         "--no-audit",
         "--no-fund",
@@ -1121,6 +1124,52 @@ try {
   const generatedProjectDirectory = generatedProfileDirectories.get("complete");
   if (generatedProjectDirectory === undefined) {
     throw new Error("complete generated profile is missing");
+  }
+
+  const generatedEnginePackReport = JSON.parse(
+    run("npm", ["pack", "--json", "--pack-destination", artifactDirectory], {
+      cwd: generatedProjectDirectory,
+      capture: true,
+    }),
+  )[0];
+  if (
+    !generatedEnginePackReport ||
+    typeof generatedEnginePackReport.filename !== "string"
+  ) {
+    throw new Error("generated engine pack did not report a tarball");
+  }
+  const generatedEngineTarball = join(
+    artifactDirectory,
+    generatedEnginePackReport.filename,
+  );
+  run(
+    "npm",
+    [
+      "install",
+      "--no-save",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      generatedEngineTarball,
+    ],
+    { cwd: consumerDirectory },
+  );
+  const generatedEngineCommand = join(
+    consumerDirectory,
+    "node_modules",
+    ".bin",
+    "release-engine",
+  );
+  const generatedEngineHelp = run(generatedEngineCommand, ["--help"], {
+    cwd: consumerDirectory,
+    capture: true,
+    env: { NODE_OPTIONS: `--no-warnings --import=${networkSentinel}` },
+  });
+  if (
+    generatedEngineHelp !==
+    "Usage:\n  release-engine install\n  release-engine uninstall\n  release-engine --help\n"
+  ) {
+    throw new Error("packed generated engine binary help smoke failed");
   }
 
   const installerFixtureHome = join(temporaryRoot, "installer-home");

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -43,9 +43,11 @@ const publicPackages = [
   {
     directory: "installer",
     name: "@invokta/installer",
-    // The installer is binary-first and intentionally has no import API.
+    // The installer is binary-first; its only import API is the engine subpath.
     requiredFiles: [
       "dist/cli.js",
+      "dist/engine-cli.js",
+      "dist/engine-cli.d.ts",
       "registry/capabilities.json",
       "registry/README.md",
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,9 +770,9 @@ fast-string-width@^3.0.2:
     fast-string-truncated-width "^3.0.2"
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.2"
@@ -865,9 +865,9 @@ hasown@^2.0.2:
     function-bind "^1.1.2"
 
 hono@^4.11.4:
-  version "4.12.32"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.32.tgz#9489eb5507c2b90554ee7817a3f97d9b754ee1ff"
-  integrity sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==
+  version "4.12.34"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.34.tgz#9d6fb4ff01d6a8fa3a0290b4e120da19ea181b9b"
+  integrity sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==
 
 html-escaper@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
## What changed

- expose `runEngineInstallerCli` from the narrow `@invokta/installer/engine` subpath
- reuse the existing interactive engine install and removal sessions for embedded package binaries
- generate a project-named executable for MCP stdio starters, with the installer promoted to a runtime dependency
- document the public contract, stable-install-location requirement, and generated scaffold behavior in ADR 0019 and the reference docs
- extend unit, package-boundary, scaffold, and release-package verification for the new surface

## Why

Consumers of a published engine package should be able to register or remove it without discovering the package manager's on-disk layout. The embedded command keeps all client configuration mutations on the existing installer path while leaving the standalone installer command surface unchanged.

## Impact

Published MCP stdio engines can provide `<engine> install` and `<engine> uninstall`. Installations must run from a durable package location because the stored launch descriptor references the package's absolute entry-point path.

## Validation

- `yarn run check` — 109 test files passed; 1,871 tests passed and 1 skipped; typecheck, lint, formatting, coverage, and build passed
- `yarn run release:verify` — verified release metadata, clean tarballs, isolated ESM imports, generated starter builds/tests, and executable smoke checks
