### PR TITLE
docs: redesign the documentation UI

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,6 +1,8 @@
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
+import { invoktaCodeDark, invoktaCodeLight } from "./ec-themes.mjs";
+
 const site = (process.env.DOCS_SITE_URL ?? "https://docs.invokta.dev").replace(
   /\/$/,
   "",
@@ -14,9 +16,15 @@ export default defineConfig({
       description:
         "Build repeatable AI-assisted tasks once and invoke them from any agent, CLI, or application.",
       favicon: "/favicon.svg",
-      logo: {
-        src: "./src/assets/invokta-mark.svg",
-        alt: "Invokta",
+      /*
+       * The brand mark is not declared through `logo` because Starlight would
+       * emit it as `<img src>`, and an external image cannot resolve the
+       * `--accent-text` / `--ink-fg` custom properties the mark is drawn
+       * with. `components.SiteTitle` inlines the same SVG instead, so the
+       * mark follows the theme toggle.
+       */
+      components: {
+        SiteTitle: "./src/components/SiteTitle.astro",
       },
       social: [
         {
@@ -29,11 +37,46 @@ export default defineConfig({
         baseUrl: "https://github.com/vinilana/invokta/edit/main/apps/docs/",
       },
       lastUpdated: true,
-      customCss: ["./src/styles/global.css"],
+      // Ordered: font faces, then design tokens, then component surfaces.
+      customCss: [
+        "./src/styles/fonts.css",
+        "./src/styles/tokens.css",
+        "./src/styles/global.css",
+      ],
+      expressiveCode: {
+        themes: [invoktaCodeDark, invoktaCodeLight],
+        /*
+         * The themes above already carry the frame colours, so Starlight's
+         * `--sl-color-*` overlay is switched off — otherwise it rewrites
+         * `theme.bg` for contrast maths and shifts the Night Owl palette.
+         * A contrast floor of 0 keeps every syntax colour exact.
+         */
+        useStarlightUiThemeColors: false,
+        minSyntaxHighlightingColorContrast: 0,
+        styleOverrides: {
+          borderRadius: "0.375rem",
+          borderWidth: "1px",
+          codeFontFamily: "var(--__sl-font-mono)",
+          codeFontSize: "0.8125rem",
+          codeLineHeight: "1.7",
+          codePaddingBlock: "0.875rem",
+          codePaddingInline: "1rem",
+          uiFontFamily: "var(--__sl-font-mono)",
+          uiFontSize: "0.75rem",
+          frames: {
+            frameBoxShadowCssValue: "none",
+            editorTabBorderRadius: "0",
+            editorTabsMarginInlineStart: "0",
+            editorTabsMarginBlockStart: "0",
+            editorActiveTabIndicatorHeight: "1px",
+            terminalTitlebarDotsOpacity: "0.6",
+          },
+        },
+      },
       head: [
         {
           tag: "meta",
-          attrs: { name: "theme-color", content: "#0a0a0a" },
+          attrs: { name: "theme-color", content: "#09090b" },
         },
         {
           tag: "meta",

--- a/apps/docs/ec-themes.mjs
+++ b/apps/docs/ec-themes.mjs
@@ -1,0 +1,197 @@
+/**
+ * Expressive Code themes for the Invokta docs.
+ *
+ * These are plain VS Code theme objects carrying the exact Night Owl and
+ * Night Owl Light palettes from the landing page's `--code-*` tokens, plus
+ * chrome colours taken from the `--ink-*` surfaces so the code frame is built
+ * from the same hairlines as everything else.
+ *
+ * The values are literal hex rather than `var(--code-*)` because Expressive
+ * Code has to parse them at build time. They are kept in lockstep with
+ * `src/styles/tokens.css` — change both together.
+ */
+
+/** Night Owl (dark). */
+const darkSyntax = {
+  plain: "#d6deeb",
+  comment: "#7a8b99",
+  keyword: "#c792ea",
+  string: "#ecc48d",
+  fn: "#82aaff",
+  number: "#f78c6c",
+  prop: "#7fdbca",
+  punct: "#8b96a5",
+};
+
+/** Night Owl Light. */
+const lightSyntax = {
+  plain: "#403f53",
+  comment: "#6b7280",
+  keyword: "#8844ae",
+  string: "#984e4d",
+  fn: "#3b61b0",
+  number: "#aa0982",
+  prop: "#096e72",
+  punct: "#6b7280",
+};
+
+/**
+ * Maps the eight syntax roles onto TextMate scopes.
+ *
+ * The role split is the one the landing page's highlighter uses:
+ * comments are additionally italic, JSON/JS literals (`true`/`false`/`null`)
+ * and shell flags count as keywords, the leading word of a shell line and any
+ * identifier followed by `(` count as functions, and object keys plus `$VAR`
+ * count as properties.
+ */
+function tokenColors(c) {
+  return [
+    {
+      scope: ["comment", "punctuation.definition.comment", "string.comment"],
+      settings: { foreground: c.comment, fontStyle: "italic" },
+    },
+    {
+      scope: [
+        "keyword",
+        "keyword.control",
+        "keyword.other",
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "storage",
+        "storage.type",
+        "storage.modifier",
+        "variable.language",
+        "constant.language",
+        "support.type.primitive",
+        "entity.name.tag",
+        "entity.name.type",
+        "support.class",
+        "support.type",
+        "constant.other.option",
+      ],
+      settings: { foreground: c.keyword },
+    },
+    {
+      scope: [
+        "string",
+        "string.quoted",
+        "string.template",
+        "punctuation.definition.string",
+        "constant.other.symbol",
+      ],
+      settings: { foreground: c.string },
+    },
+    {
+      scope: [
+        "entity.name.function",
+        "support.function",
+        "variable.function",
+        "meta.function-call.generic",
+        "entity.name.command",
+        "support.function.builtin",
+      ],
+      settings: { foreground: c.fn },
+    },
+    {
+      scope: ["constant.numeric", "constant.character", "keyword.other.unit"],
+      settings: { foreground: c.number },
+    },
+    {
+      scope: [
+        "variable.other.property",
+        "support.type.property-name",
+        "meta.object-literal.key",
+        "entity.name.tag.yaml",
+        "entity.other.attribute-name",
+        "support.variable",
+        "variable.other.constant",
+        "variable.other.normal",
+        "punctuation.definition.variable",
+      ],
+      settings: { foreground: c.prop },
+    },
+    {
+      scope: [
+        "punctuation",
+        "punctuation.separator",
+        "punctuation.terminator",
+        "punctuation.accessor",
+        "meta.brace",
+        "keyword.operator",
+      ],
+      settings: { foreground: c.punct },
+    },
+  ];
+}
+
+/**
+ * Frame chrome. `surface` is the recessed code plate, `raised` the active
+ * tab, `line` the hairline and `accent` the 1px tab underline.
+ */
+function frameColors({ surface, raised, line, fg, body, faint, accent, low }) {
+  return {
+    "editor.background": surface,
+    "editor.selectionBackground": low,
+    "editorLineNumber.foreground": faint,
+    "editorLineNumber.activeForeground": body,
+    "editorGroupHeader.tabsBackground": surface,
+    "editorGroupHeader.tabsBorder": line,
+    "tab.activeBackground": raised,
+    "tab.activeForeground": fg,
+    "tab.inactiveBackground": surface,
+    "tab.inactiveForeground": body,
+    "tab.border": line,
+    /* Fully transparent hex: theme colours are parsed, so keywords like
+       `transparent` are rejected here. */
+    "tab.activeBorder": "#00000000",
+    "tab.activeBorderTop": accent,
+    "titleBar.activeBackground": surface,
+    "titleBar.activeForeground": body,
+    "titleBar.border": line,
+    "panel.border": line,
+    "terminal.background": surface,
+    "scrollbarSlider.background": line,
+    "scrollbarSlider.hoverBackground": faint,
+    focusBorder: accent,
+  };
+}
+
+export const invoktaCodeDark = {
+  name: "invokta-dark",
+  type: "dark",
+  colors: {
+    ...frameColors({
+      surface: "#0e0e11",
+      raised: "#18181b",
+      line: "#27272a",
+      fg: "#fafafa",
+      body: "#a1a1aa",
+      faint: "#71717a",
+      accent: "#3369ff",
+      low: "#16224a",
+    }),
+    "editor.foreground": darkSyntax.plain,
+    "terminal.foreground": darkSyntax.plain,
+  },
+  tokenColors: tokenColors(darkSyntax),
+};
+
+export const invoktaCodeLight = {
+  name: "invokta-light",
+  type: "light",
+  colors: {
+    ...frameColors({
+      surface: "#fafafa",
+      raised: "#ffffff",
+      line: "#e4e4e7",
+      fg: "#18181b",
+      body: "#71717a",
+      faint: "#a1a1aa",
+      accent: "#3d50f5",
+      low: "#eaecfe",
+    }),
+    "editor.foreground": lightSyntax.plain,
+    "terminal.foreground": lightSyntax.plain,
+  },
+  tokenColors: tokenColors(lightSyntax),
+};

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "0.41.5",
-    "@fontsource-variable/geist": "5.3.0",
-    "@fontsource-variable/geist-mono": "5.3.0",
+    "@fontsource/inter-tight": "5.3.0",
+    "@fontsource/jetbrains-mono": "5.3.0",
     "astro": "7.1.6"
   },
   "devDependencies": {

--- a/apps/docs/public/favicon.svg
+++ b/apps/docs/public/favicon.svg
@@ -1,5 +1,10 @@
-<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" role="img" aria-label="Invokta">
   <title>Invokta</title>
-  <rect width="32" height="32" rx="8" fill="#111"/>
-  <path d="M9 9h5v14H9V9Zm8 0h6v5h-6V9Zm0 8h6v6h-6v-6Z" fill="#fff"/>
+  <!-- A favicon cannot read page tokens, so the brand values are literal. -->
+  <g transform="translate(16,16) scale(0.47) translate(-32,-32)">
+    <g fill="none" stroke-width="11" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M11 15 L29 32 L11 49" stroke="#3D50F5"/>
+      <path d="M36 49 H53" stroke="#18181B"/>
+    </g>
+  </g>
 </svg>

--- a/apps/docs/public/images/how-an-action-engine-works.svg
+++ b/apps/docs/public/images/how-an-action-engine-works.svg
@@ -3,19 +3,19 @@
   <desc id="desc">Claude Code, Codex, Hermes, and CLI invoke one Action Engine. The engine owns providers, scripts, data, templates, permissions, contracts, and rules, and returns a validated result.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#111827"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#18181b"/>
     </marker>
     <style>
-      .title{font:700 72px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#111827}
-      .subtitle{font:400 34px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#111827}
-      .heading{font:700 50px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#111827}
-      .label{font:500 30px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#111827}
-      .small{font:500 25px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#111827}
-      .tiny{font:500 23px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#111827}
-      .stroke{stroke:#111827;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;fill:none}
-      .blue{stroke:#2563eb;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;fill:#fff}
+      .title{font:700 72px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#18181b}
+      .subtitle{font:400 34px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#18181b}
+      .heading{font:700 50px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#18181b}
+      .label{font:500 30px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#18181b}
+      .small{font:500 25px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#18181b}
+      .tiny{font:500 23px 'Comic Sans MS','Trebuchet MS',sans-serif;fill:#18181b}
+      .stroke{stroke:#18181b;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;fill:none}
+      .blue{stroke:#3d50f5;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;fill:#fff}
       .green{stroke:#3f8f3f;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;fill:#fff}
-      .soft{fill:#f8fbff}
+      .soft{fill:#fafafa}
     </style>
   </defs>
 
@@ -23,29 +23,29 @@
 
   <text class="title" x="724" y="95" text-anchor="middle">How an Action Engine works</text>
   <text class="subtitle" x="724" y="155" text-anchor="middle">Define the action once. Invoke it anywhere.</text>
-  <path d="M405 183 C620 166 828 166 1043 183" stroke="#60a5fa" stroke-width="4" fill="none" stroke-linecap="round"/>
+  <path d="M405 183 C620 166 828 166 1043 183" stroke="#6e7cf7" stroke-width="4" fill="none" stroke-linecap="round"/>
 
   <g>
     <rect x="70" y="205" rx="20" ry="20" width="300" height="105" class="stroke soft"/>
-    <rect x="98" y="230" width="62" height="50" rx="6" fill="#eef6ff" stroke="#111827" stroke-width="3"/>
-    <circle cx="108" cy="240" r="4" fill="#2563eb"/><circle cx="120" cy="240" r="4" fill="#2563eb"/><circle cx="132" cy="240" r="4" fill="#2563eb"/>
+    <rect x="98" y="230" width="62" height="50" rx="6" fill="#f4f4f5" stroke="#18181b" stroke-width="3"/>
+    <circle cx="108" cy="240" r="4" fill="#3d50f5"/><circle cx="120" cy="240" r="4" fill="#3d50f5"/><circle cx="132" cy="240" r="4" fill="#3d50f5"/>
     <path d="M108 263 l12 0 l-8 8 m8-8 l-8-8 M132 272 h16" class="stroke" stroke-width="3"/>
     <text class="label" x="185" y="270">Claude Code</text>
 
     <rect x="70" y="330" rx="20" ry="20" width="300" height="105" class="stroke soft"/>
-    <rect x="101" y="354" width="54" height="54" rx="7" fill="#eef6ff" stroke="#111827" stroke-width="3"/>
-    <rect x="111" y="364" width="12" height="12" fill="#93c5fd" stroke="#111827" stroke-width="2"/>
-    <rect x="133" y="364" width="12" height="12" fill="#93c5fd" stroke="#111827" stroke-width="2"/>
-    <rect x="111" y="386" width="12" height="12" fill="#93c5fd" stroke="#111827" stroke-width="2"/>
-    <rect x="133" y="386" width="12" height="12" fill="#93c5fd" stroke="#111827" stroke-width="2"/>
+    <rect x="101" y="354" width="54" height="54" rx="7" fill="#f4f4f5" stroke="#18181b" stroke-width="3"/>
+    <rect x="111" y="364" width="12" height="12" fill="#eaecfe" stroke="#18181b" stroke-width="2"/>
+    <rect x="133" y="364" width="12" height="12" fill="#eaecfe" stroke="#18181b" stroke-width="2"/>
+    <rect x="111" y="386" width="12" height="12" fill="#eaecfe" stroke="#18181b" stroke-width="2"/>
+    <rect x="133" y="386" width="12" height="12" fill="#eaecfe" stroke="#18181b" stroke-width="2"/>
     <text class="label" x="190" y="395">Codex</text>
 
     <rect x="70" y="455" rx="20" ry="20" width="300" height="105" class="stroke soft"/>
-    <path d="M103 510 L156 474 L142 532 L128 514 L112 530 Z" fill="#93c5fd" stroke="#111827" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M103 510 L156 474 L142 532 L128 514 L112 530 Z" fill="#eaecfe" stroke="#18181b" stroke-width="3" stroke-linejoin="round"/>
     <text class="label" x="190" y="520">Hermes</text>
 
     <rect x="70" y="580" rx="20" ry="20" width="300" height="105" class="stroke soft"/>
-    <rect x="100" y="607" width="58" height="50" rx="7" fill="#eef6ff" stroke="#111827" stroke-width="3"/>
+    <rect x="100" y="607" width="58" height="50" rx="7" fill="#f4f4f5" stroke="#18181b" stroke-width="3"/>
     <path d="M111 630 l12 0 l-8 8 m8-8 l-8-8 M132 639 h14" class="stroke" stroke-width="3"/>
     <text class="label" x="200" y="645">CLI</text>
 
@@ -57,12 +57,12 @@
 
   <g>
     <rect x="470" y="265" rx="38" ry="38" width="480" height="430" class="blue"/>
-    <path d="M470 300 l-18 -18 M489 274 l-5 -23 M932 300 l18 -18 M918 274 l5 -23" stroke="#2563eb" stroke-width="4" stroke-linecap="round"/>
-    <circle cx="710" cy="365" r="64" fill="#eff6ff" stroke="#2563eb" stroke-width="5"/>
-    <path d="M710 300 v-20 M710 450 v-20 M645 365 h-20 M795 365 h-20 M665 320 l-15-15 M770 425 l-15-15 M665 410 l-15 15 M770 305 l-15 15" stroke="#2563eb" stroke-width="5" stroke-linecap="round"/>
-    <path d="M694 337 l28 0 l-18 30 l20 0 l-32 42 l10-34 l-20 0 z" fill="#60a5fa" stroke="#2563eb" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M470 300 l-18 -18 M489 274 l-5 -23 M932 300 l18 -18 M918 274 l5 -23" stroke="#3d50f5" stroke-width="4" stroke-linecap="round"/>
+    <circle cx="710" cy="365" r="64" fill="#eaecfe" stroke="#3d50f5" stroke-width="5"/>
+    <path d="M710 300 v-20 M710 450 v-20 M645 365 h-20 M795 365 h-20 M665 320 l-15-15 M770 425 l-15-15 M665 410 l-15 15 M770 305 l-15 15" stroke="#3d50f5" stroke-width="5" stroke-linecap="round"/>
+    <path d="M694 337 l28 0 l-18 30 l20 0 l-32 42 l10-34 l-20 0 z" fill="#6e7cf7" stroke="#3d50f5" stroke-width="3" stroke-linejoin="round"/>
     <text class="heading" x="710" y="505" text-anchor="middle">Action Engine</text>
-    <path d="M555 525 C650 534 770 534 865 525" stroke="#2563eb" stroke-width="4" fill="none" stroke-linecap="round"/>
+    <path d="M555 525 C650 534 770 534 865 525" stroke="#3d50f5" stroke-width="4" fill="none" stroke-linecap="round"/>
     <text class="small" x="710" y="575" text-anchor="middle">capabilities + contracts + rules</text>
   </g>
 
@@ -86,34 +86,34 @@
 
   <g>
     <rect x="135" y="785" rx="20" ry="20" width="230" height="150" class="stroke soft"/>
-    <path d="M195 846 c-22-25 8-55 36-43 c14-28 55-19 55 12 c31-3 43 39 10 49 h-91 c-18 0-28-10-10-18z" fill="#eef6ff" stroke="#111827" stroke-width="3"/>
+    <path d="M195 846 c-22-25 8-55 36-43 c14-28 55-19 55 12 c31-3 43 39 10 49 h-91 c-18 0-28-10-10-18z" fill="#f4f4f5" stroke="#18181b" stroke-width="3"/>
     <text class="label" x="250" y="910" text-anchor="middle">Providers</text>
 
     <rect x="385" y="785" rx="20" ry="20" width="210" height="150" class="stroke soft"/>
-    <rect x="445" y="818" width="90" height="54" rx="7" fill="#eef6ff" stroke="#111827" stroke-width="3"/>
+    <rect x="445" y="818" width="90" height="54" rx="7" fill="#f4f4f5" stroke="#18181b" stroke-width="3"/>
     <path d="M460 845 l12 0 l-8 8 m8-8 l-8-8 M486 854 h20" class="stroke" stroke-width="3"/>
     <text class="label" x="490" y="910" text-anchor="middle">Scripts</text>
 
     <rect x="610" y="785" rx="20" ry="20" width="200" height="150" class="stroke soft"/>
-    <ellipse cx="710" cy="828" rx="40" ry="16" fill="#ede9fe" stroke="#111827" stroke-width="3"/>
-    <path d="M670 828 v42 c0 9 18 16 40 16 s40-7 40-16 v-42 M670 849 c0 9 18 16 40 16 s40-7 40-16" fill="#ede9fe" stroke="#111827" stroke-width="3"/>
+    <ellipse cx="710" cy="828" rx="40" ry="16" fill="#ede9fe" stroke="#18181b" stroke-width="3"/>
+    <path d="M670 828 v42 c0 9 18 16 40 16 s40-7 40-16 v-42 M670 849 c0 9 18 16 40 16 s40-7 40-16" fill="#ede9fe" stroke="#18181b" stroke-width="3"/>
     <text class="label" x="710" y="910" text-anchor="middle">Data</text>
 
     <rect x="825" y="785" rx="20" ry="20" width="210" height="150" class="stroke soft"/>
-    <path d="M895 812 h55 l22 22 v48 h-77z" fill="#fff7d6" stroke="#111827" stroke-width="3"/>
-    <path d="M950 812 v22 h22" fill="none" stroke="#111827" stroke-width="3"/>
-    <path d="M910 850 h45 M910 866 h38" stroke="#111827" stroke-width="3" stroke-linecap="round"/>
+    <path d="M895 812 h55 l22 22 v48 h-77z" fill="#fff7d6" stroke="#18181b" stroke-width="3"/>
+    <path d="M950 812 v22 h22" fill="none" stroke="#18181b" stroke-width="3"/>
+    <path d="M910 850 h45 M910 866 h38" stroke="#18181b" stroke-width="3" stroke-linecap="round"/>
     <text class="label" x="930" y="910" text-anchor="middle">Templates</text>
 
     <rect x="1055" y="785" rx="20" ry="20" width="250" height="150" class="stroke soft"/>
-    <path d="M1179 813 l45 18 v35 c0 28-18 47-45 58 c-27-11-45-30-45-58 v-35z" fill="#ecfdf3" stroke="#111827" stroke-width="3"/>
-    <rect x="1166" y="850" width="26" height="24" rx="4" fill="#bbf7d0" stroke="#111827" stroke-width="3"/>
-    <path d="M1172 850 v-8 c0-11 14-11 14 0 v8" fill="none" stroke="#111827" stroke-width="3"/>
+    <path d="M1179 813 l45 18 v35 c0 28-18 47-45 58 c-27-11-45-30-45-58 v-35z" fill="#ecfdf3" stroke="#18181b" stroke-width="3"/>
+    <rect x="1166" y="850" width="26" height="24" rx="4" fill="#bbf7d0" stroke="#18181b" stroke-width="3"/>
+    <path d="M1172 850 v-8 c0-11 14-11 14 0 v8" fill="none" stroke="#18181b" stroke-width="3"/>
     <text class="label" x="1180" y="910" text-anchor="middle">Permissions</text>
   </g>
 
-  <path d="M215 965 q0-28 28-28 h960 q28 0 28 28 v55 q0 28-28 28 h-890 l-52 30 15-30 h-33 q-28 0-28-28z" fill="#fff" stroke="#2563eb" stroke-width="5" stroke-linejoin="round"/>
-  <circle cx="285" cy="995" r="28" fill="#fde047" stroke="#111827" stroke-width="3"/>
-  <path d="M276 996 c0-18 18-24 25-11 c5 10-6 17-8 26 h-10 c-1-6-7-9-7-15z M281 1016 h14 M283 1024 h10" fill="none" stroke="#111827" stroke-width="3" stroke-linecap="round"/>
-  <text class="label" x="335" y="1007"><tspan fill="#2563eb">MCP</tspan><tspan> connects tools. The </tspan><tspan fill="#2563eb">Action Engine</tspan><tspan> standardizes the action.</tspan></text>
+  <path d="M215 965 q0-28 28-28 h960 q28 0 28 28 v55 q0 28-28 28 h-890 l-52 30 15-30 h-33 q-28 0-28-28z" fill="#fff" stroke="#3d50f5" stroke-width="5" stroke-linejoin="round"/>
+  <circle cx="285" cy="995" r="28" fill="#fde047" stroke="#18181b" stroke-width="3"/>
+  <path d="M276 996 c0-18 18-24 25-11 c5 10-6 17-8 26 h-10 c-1-6-7-9-7-15z M281 1016 h14 M283 1024 h10" fill="none" stroke="#18181b" stroke-width="3" stroke-linecap="round"/>
+  <text class="label" x="335" y="1007"><tspan fill="#3d50f5">MCP</tspan><tspan> connects tools. The </tspan><tspan fill="#3d50f5">Action Engine</tspan><tspan> standardizes the action.</tspan></text>
 </svg>

--- a/apps/docs/public/og.svg
+++ b/apps/docs/public/og.svg
@@ -1,23 +1,31 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
   <title>Invokta documentation</title>
-  <rect width="1200" height="630" fill="#0a0a0a"/>
-  <path d="M0 1h1200M0 629h1200M1 0v630M1199 0v630" stroke="#2a2a2a"/>
+  <!--
+    Social preview card. A link unfurl cannot read page tokens, so every
+    colour is the literal dark-theme resolution of the design tokens:
+    #09090b --ink-bg, #27272a --ink-line, #fafafa --ink-fg, #a1a1aa --ink-body,
+    #6f93ff --accent-text.
+  -->
+  <rect width="1200" height="630" fill="#09090b"/>
+  <path d="M0 1h1200M0 629h1200M1 0v630M1199 0v630" stroke="#27272a"/>
   <g transform="translate(96 94)">
-    <rect width="72" height="72" rx="18" fill="#fff"/>
-    <path d="M20 20h12v32H20V20Zm20 0h12v12H40V20Zm0 20h12v12H40V40Z" fill="#0a0a0a"/>
+    <g transform="scale(1.4)" fill="none" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M11 15 L29 32 L11 49" stroke="#6f93ff" transform="translate(-6.5,-10.5)"/>
+      <path d="M36 49 H53" stroke="#fafafa" transform="translate(-6.5,-10.5)"/>
+    </g>
   </g>
-  <text x="96" y="265" fill="#fff" font-family="Arial, sans-serif" font-size="88" font-weight="650">Invokta</text>
-  <text x="96" y="353" fill="#a1a1a1" font-family="Arial, sans-serif" font-size="36">Typed domain capabilities, one execution path.</text>
-  <g transform="translate(96 454)" fill="none" stroke="#3f3f46">
-    <rect width="210" height="70" rx="12"/>
-    <rect x="234" width="210" height="70" rx="12"/>
-    <rect x="468" width="210" height="70" rx="12"/>
-    <rect x="702" width="210" height="70" rx="12"/>
+  <text x="96" y="265" fill="#fafafa" font-family="Inter Tight, Arial, sans-serif" font-size="88" font-weight="600" letter-spacing="-3">Invokta</text>
+  <text x="96" y="353" fill="#a1a1aa" font-family="Inter Tight, Arial, sans-serif" font-size="36" letter-spacing="-0.36">Typed domain capabilities, one execution path.</text>
+  <g transform="translate(96 454)" fill="none" stroke="#27272a">
+    <rect width="210" height="70" rx="6"/>
+    <rect x="234" width="210" height="70" rx="6"/>
+    <rect x="468" width="210" height="70" rx="6"/>
+    <rect x="702" width="210" height="70" rx="6"/>
   </g>
-  <g fill="#d4d4d8" font-family="monospace" font-size="24" text-anchor="middle">
-    <text x="201" y="498">direct</text>
+  <g fill="#a1a1aa" font-family="JetBrains Mono, monospace" font-size="24" letter-spacing="3.4" text-anchor="middle">
+    <text x="201" y="498">DIRECT</text>
     <text x="435" y="498">CLI</text>
-    <text x="669" y="498">MCP stdio</text>
+    <text x="669" y="498">MCP STDIO</text>
     <text x="903" y="498">MCP HTTP</text>
   </g>
 </svg>

--- a/apps/docs/src/assets/invokta-mark.svg
+++ b/apps/docs/src/assets/invokta-mark.svg
@@ -1,4 +1,17 @@
-<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Invokta mark">
-  <rect width="32" height="32" rx="8" fill="#fafafa"/>
-  <path d="M9 9h5v14H9V9Zm8 0h6v5h-6V9Zm0 8h6v6h-6v-6Z" fill="#09090b"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 51 43" fill="none" aria-hidden="true" focusable="false">
+  <!--
+    Invokta mark — terminal prompt: accent chevron plus an ink underscore.
+    Ported from the landing page (lp-invokta InvoktaMark). Aspect is 51:43;
+    control the height and let the width follow.
+
+    The stroke colours read the page tokens so the mark tracks the theme
+    toggle. That only works because `src/components/SiteTitle.astro` inlines
+    this file into the document; the literal fallbacks are the light-theme
+    values, so the mark still draws if it is ever referenced as an external
+    image instead.
+  -->
+  <g transform="translate(-6.5,-10.5)" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M11 15 L29 32 L11 49" stroke="var(--accent-text, #3d50f5)"/>
+    <path d="M36 49 H53" stroke="var(--ink-fg, #18181b)"/>
+  </g>
 </svg>

--- a/apps/docs/src/components/InvocationFlow.astro
+++ b/apps/docs/src/components/InvocationFlow.astro
@@ -23,15 +23,18 @@
 </div>
 
 <style>
+  /*
+   * Blueprint diagram: hairline plate, mono annotation chips, and a single
+   * accent-bordered node at the convergence point. Every colour, radius and
+   * size comes from the design tokens in `src/styles/tokens.css`.
+   */
   .invocation-flow {
     margin-block: 1.75rem;
     padding: clamp(1rem, 3vw, 1.5rem);
     overflow: hidden;
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 0.75rem;
-    background:
-      linear-gradient(var(--sl-color-bg), var(--sl-color-bg)) padding-box,
-      radial-gradient(circle at 50% 0%, var(--sl-color-accent-low), transparent 55%);
+    border: 1px solid var(--ink-line);
+    border-radius: var(--ivk-radius-md);
+    background: var(--ink-surface);
   }
 
   .channels,
@@ -48,13 +51,14 @@
     min-height: 2.55rem;
     place-items: center;
     padding: 0.45rem;
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 0.5rem;
-    color: var(--sl-color-gray-2);
-    background: var(--sl-color-bg-nav);
+    border: 1px solid var(--ink-line);
+    border-radius: var(--ivk-radius-sm);
+    color: var(--ink-muted);
+    background: var(--ink-bg);
     font-family: var(--sl-font-mono);
-    font-size: 0.72rem;
-    line-height: 1.2;
+    font-size: 0.6875rem;
+    letter-spacing: 0.02em;
+    line-height: 1.3;
     text-align: center;
   }
 
@@ -67,7 +71,7 @@
   .connector::after {
     position: absolute;
     content: "";
-    background: var(--sl-color-gray-5);
+    background: var(--ink-line);
   }
 
   .connector::before {
@@ -90,10 +94,11 @@
     left: 50%;
     width: 1px;
     height: 1.3rem;
-    background: var(--sl-color-gray-5);
+    background: var(--ink-line);
     content: "";
   }
 
+  /* The one lifted element in the diagram. */
   .invoke {
     display: flex;
     width: fit-content;
@@ -101,30 +106,32 @@
     gap: 0.75rem;
     margin: 0 auto 1.4rem;
     padding: 0.8rem 1.1rem;
-    border: 1px solid var(--sl-color-white);
-    border-radius: 0.55rem;
-    color: var(--sl-color-black);
-    background: var(--sl-color-white);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--sl-color-accent) 12%, transparent);
+    border: 1px solid var(--accent);
+    border-radius: var(--ivk-radius-sm);
+    color: var(--ink-fg);
+    background: var(--ink-surface-raised);
+    box-shadow: var(--shadow-raised);
   }
 
   .invoke code {
     padding: 0;
+    border: 0;
     color: inherit;
     background: transparent;
-    font-size: 0.86rem;
+    font-family: var(--sl-font-mono);
+    font-size: 0.8125rem;
   }
 
   .prompt {
-    color: var(--sl-color-accent-high);
+    color: var(--accent-text);
     font-family: var(--sl-font-mono);
-    font-weight: 700;
+    font-weight: 500;
   }
 
   .stages span:not(:last-child)::after {
     position: absolute;
     right: -0.52rem;
-    color: var(--sl-color-gray-3);
+    color: var(--ink-faint);
     content: "›";
   }
 

--- a/apps/docs/src/components/SiteTitle.astro
+++ b/apps/docs/src/components/SiteTitle.astro
@@ -8,8 +8,10 @@
  * Everything else matches the upstream component: same anchor, same
  * `.site-title` class, same wordmark span.
  */
+// biome-ignore lint/correctness/noUnusedImports: Biome does not track references from Astro frontmatter into the template.
 import mark from "../assets/invokta-mark.svg?raw";
 
+// biome-ignore lint/correctness/noUnusedVariables: These values are rendered by the Astro template below.
 const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
 ---
 

--- a/apps/docs/src/components/SiteTitle.astro
+++ b/apps/docs/src/components/SiteTitle.astro
@@ -1,0 +1,33 @@
+---
+/*
+ * Starlight's own `SiteTitle` renders the configured logo as `<img src>`, and
+ * an external image cannot read the page's custom properties. The brand mark
+ * is drawn from `--accent-text` and `--ink-fg` so it follows the theme
+ * toggle, so this override inlines the SVG instead of linking it.
+ *
+ * Everything else matches the upstream component: same anchor, same
+ * `.site-title` class, same wordmark span.
+ */
+import mark from "../assets/invokta-mark.svg?raw";
+
+const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
+---
+
+<a href={siteTitleHref} class="site-title sl-flex">
+  <Fragment set:html={mark} />
+  <span translate="no">{siteTitle}</span>
+</a>
+
+<style>
+  .site-title {
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .site-title span {
+    overflow: hidden;
+  }
+</style>

--- a/apps/docs/src/styles/fonts.css
+++ b/apps/docs/src/styles/fonts.css
@@ -1,0 +1,15 @@
+/*
+ * Typefaces — Inter Tight for display/UI, JetBrains Mono for code and labels.
+ *
+ * Only the weights the design system actually uses are loaded:
+ *   400 body copy, mono, annotations
+ *   500 buttons, badges, active tabs, arrow links
+ *   700 the wordmark
+ * Weight 600 (headings) resolves to the nearest real face because
+ * `font-synthesis-weight: none` is set on `body` — never fake a weight.
+ */
+@import "@fontsource/inter-tight/400.css";
+@import "@fontsource/inter-tight/500.css";
+@import "@fontsource/inter-tight/700.css";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -408,9 +408,8 @@ site-search button[data-close-modal] {
   color: var(--ink-fg);
 }
 
-#starlight__search .pagefind-ui__result-title:not(
-    :where(.pagefind-ui__result-nested *)
-  ),
+#starlight__search
+  .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
 #starlight__search .pagefind-ui__result-nested,
 #starlight__search .pagefind-ui__result-tags {
   background-color: var(--ink-surface);
@@ -504,7 +503,7 @@ site-search button[data-close-modal] {
   margin-bottom: 0.75rem;
 }
 
-starlight-toc nav a {
+:root starlight-toc nav a {
   border-radius: var(--ivk-radius-sm);
   padding-block: 0.3rem;
   color: var(--ink-muted);
@@ -512,11 +511,11 @@ starlight-toc nav a {
   transition: color var(--ivk-dur-fast) var(--ivk-ease);
 }
 
-starlight-toc nav a:hover {
+:root starlight-toc nav a:hover {
   color: var(--ink-fg);
 }
 
-starlight-toc nav a[aria-current="true"] {
+:root starlight-toc nav a[aria-current="true"] {
   color: var(--accent-text);
   font-weight: 500;
 }
@@ -529,7 +528,7 @@ mobile-starlight-toc nav {
   -webkit-backdrop-filter: blur(24px);
 }
 
-mobile-starlight-toc summary {
+:root mobile-starlight-toc summary {
   border-bottom: 1px solid var(--ink-line);
 }
 
@@ -951,8 +950,11 @@ starlight-tabs [role="tablist"] {
   *,
   *::before,
   *::after {
+    /* biome-ignore lint/complexity/noImportantStyles: The accessibility override must win over component animation rules. */
     animation-duration: 0.01ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: The accessibility override must win over component animation rules. */
     animation-iteration-count: 1 !important;
+    /* biome-ignore lint/complexity/noImportantStyles: The accessibility override must win over component transition rules. */
     transition-duration: 0.01ms !important;
   }
 

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -1,176 +1,937 @@
-@import "@fontsource-variable/geist";
-@import "@fontsource-variable/geist/wght-italic.css";
-@import "@fontsource-variable/geist-mono";
+/*
+ * Invokta docs — component surfaces.
+ *
+ * Everything here is deliberately unlayered: Starlight ships its own styles
+ * inside `@layer starlight.*`, and unlayered author CSS outranks every
+ * cascade layer regardless of specificity. That lets these rules stay short
+ * and readable instead of fighting selector arithmetic.
+ *
+ * The house rules, taken from the landing page:
+ *   - Every border is a 1px hairline in `--ink-line`. The only 2px edge is
+ *     the aside's accent border.
+ *   - Shadow is reserved for the one recipe, `--shadow-raised`.
+ *   - Text is never coloured with `--accent`; use `--accent-text`.
+ *   - Labels the site itself authors (sidebar groups, TOC heading, pagination
+ *     "previous"/"next") use the "annotation" treatment: mono, 11px,
+ *     uppercase, 0.14em tracking. Authored content is never uppercased.
+ *   - `--bp-label` is a decoration tint, not a text colour: it fails AA in
+ *     both themes, so anything a screen reader reaches uses `--ink-muted`.
+ *   - Motion is 120ms/200ms on cubic-bezier(0.2, 0, 0, 1), and collapses
+ *     completely under `prefers-reduced-motion`.
+ */
 
-:root {
-  --sl-font: "Geist Variable", ui-sans-serif, system-ui, sans-serif;
-  --sl-font-mono: "Geist Mono Variable", "SFMono-Regular", Consolas, monospace;
-  --sl-color-accent-low: #172554;
-  --sl-color-accent: #60a5fa;
-  --sl-color-accent-high: #bfdbfe;
-  --sl-color-white: #fafafa;
-  --sl-color-gray-1: #e4e4e7;
-  --sl-color-gray-2: #a1a1aa;
-  --sl-color-gray-3: #71717a;
-  --sl-color-gray-4: #3f3f46;
-  --sl-color-gray-5: #27272a;
-  --sl-color-gray-6: #18181b;
-  --sl-color-black: #09090b;
-  --sl-color-bg-nav: color-mix(in srgb, var(--sl-color-black) 92%, transparent);
-  --sl-color-bg-sidebar: var(--sl-color-black);
-  --sl-content-width: 48rem;
-  --sl-text-5xl: clamp(3rem, 7vw, 4.75rem);
-}
-
-:root[data-theme="light"] {
-  --sl-color-accent-low: #dbeafe;
-  --sl-color-accent: #2563eb;
-  --sl-color-accent-high: #1e3a8a;
-  --sl-color-white: #18181b;
-  --sl-color-gray-1: #27272a;
-  --sl-color-gray-2: #52525b;
-  --sl-color-gray-3: #71717a;
-  --sl-color-gray-4: #a1a1aa;
-  --sl-color-gray-5: #e4e4e7;
-  --sl-color-gray-6: #f4f4f5;
-  --sl-color-gray-7: #fafafa;
-  --sl-color-black: #ffffff;
-  --sl-color-bg-nav: color-mix(in srgb, white 90%, transparent);
-  --sl-color-bg-sidebar: #ffffff;
-}
+/* ================================================================== *
+ * 1. Base
+ * ================================================================== */
 
 html {
-  letter-spacing: -0.012em;
+  letter-spacing: var(--ivk-track-body);
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
-  background-image:
-    linear-gradient(
-      to right,
-      color-mix(in srgb, var(--sl-color-gray-5) 30%, transparent) 1px,
-      transparent 1px
-    ),
-    linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--sl-color-gray-5) 22%, transparent) 1px,
-      transparent 1px
-    );
-  background-position: center top;
-  background-size: 64px 64px;
+  font-synthesis-weight: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
-header.header {
-  border-bottom-color: var(--sl-color-gray-5);
-  backdrop-filter: blur(16px) saturate(140%);
+/*
+ * The blueprint rail layer: five 1px verticals on the signature column grid,
+ * pinned to the viewport. This replaces the old 64px gradient lattice — it is
+ * more distinctive and does not fight with content. Hidden on narrow screens,
+ * where there is no margin for it to live in.
+ */
+@media (min-width: 40rem) {
+  body {
+    background-image:
+      linear-gradient(var(--bp-rail), var(--bp-rail)),
+      linear-gradient(var(--bp-rail), var(--bp-rail)),
+      linear-gradient(var(--bp-rail), var(--bp-rail)),
+      linear-gradient(var(--bp-rail), var(--bp-rail)),
+      linear-gradient(var(--bp-rail), var(--bp-rail));
+    background-repeat: no-repeat;
+    background-size: 1px 100%;
+    background-attachment: fixed;
+    background-position:
+      var(--ivk-col-1) 0,
+      var(--ivk-col-2) 0,
+      var(--ivk-col-3) 0,
+      var(--ivk-col-4) 0,
+      var(--ivk-col-5) 0;
+  }
 }
 
-.site-title {
-  gap: 0.65rem;
-  font-weight: 600;
-  letter-spacing: -0.035em;
+::selection {
+  background-color: var(--accent-low);
+  color: var(--ink-fg);
 }
 
-.site-title img {
-  width: 1.75rem;
-  height: 1.75rem;
+/*
+ * The focus ring uses `--accent-text`, not `--accent`, for the same contrast
+ * reason accent text does. Unlike the landing page it does not force a
+ * `border-radius`, which would square off pill-shaped controls while focused.
+ */
+:focus-visible {
+  outline: 2px solid var(--accent-text);
+  outline-offset: 2px;
 }
 
-.sidebar-pane {
-  border-inline-end: 1px solid var(--sl-color-gray-5);
+/* ================================================================== *
+ * 2. The annotation label
+ * ================================================================== */
+
+/*
+ * `text-transform: uppercase` is what makes this pattern read as a blueprint
+ * callout, so it is only applied to labels the site itself authors — never to
+ * authored content, where an identifier such as `engine.invoke` has to stay
+ * literal. Table headers and figure captions therefore get their own rules
+ * further down instead of joining this list.
+ *
+ * The colour is `--ink-muted`, not `--bp-label`. Every surface below is real,
+ * screen-reader-exposed text; `--bp-label` is a decoration tint that only
+ * clears ~2:1 against either ground and is reserved for the `aria-hidden`
+ * blueprint layer.
+ */
+.annotation,
+.sidebar-content .group-label > .large,
+.right-sidebar-panel h2 {
+  color: var(--ink-muted);
+  font-family: var(--sl-font-mono);
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: var(--ivk-track-label);
+  text-transform: uppercase;
+  line-height: 1;
 }
 
-.sidebar-content a[aria-current="page"] {
-  border-radius: 0.38rem;
-  font-weight: 550;
+/* ================================================================== *
+ * 3. Typography
+ * ================================================================== */
+
+.sl-markdown-content :is(h1, h2, h3, h4),
+.content-panel h1#_top,
+.hero h1 {
+  color: var(--ink-fg);
+  letter-spacing: var(--ivk-track-display);
+  text-wrap: balance;
 }
 
-.content-panel + .content-panel {
-  border-top-color: var(--sl-color-gray-5);
-}
-
-.sl-markdown-content h1,
-.sl-markdown-content h2,
-.sl-markdown-content h3 {
-  letter-spacing: -0.035em;
-}
-
+.content-panel h1#_top,
 .sl-markdown-content h1 {
-  font-weight: 630;
+  line-height: var(--ivk-leading-tight);
+  font-weight: 600;
 }
 
+/* Section rules: an h2 opens with a hairline across the content column,
+   echoing the landing page's section boundaries. */
 .sl-markdown-content h2 {
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--sl-color-gray-5);
-  font-weight: 610;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--ink-line);
+  line-height: 1.08;
+  font-weight: 600;
+}
+
+.sl-markdown-content :is(h3, h4, h5, h6) {
+  font-weight: 600;
 }
 
 .sl-markdown-content a:not([class]) {
+  color: var(--accent-text);
   text-decoration-color: color-mix(
     in srgb,
-    var(--sl-color-accent) 45%,
+    var(--accent-text) 45%,
     transparent
   );
   text-underline-offset: 0.2em;
+  transition: color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+.sl-markdown-content a:not([class]):hover {
+  color: var(--accent-text);
+  text-decoration-color: currentColor;
+}
+
+.sl-markdown-content strong {
+  color: var(--ink-fg);
+  font-weight: 600;
 }
 
 .sl-markdown-content code:not(:where(.not-content *)) {
-  border: 1px solid var(--sl-color-gray-5);
-  border-radius: 0.32rem;
+  border: 1px solid var(--ink-line);
+  border-radius: 4px;
+  background-color: var(--ink-surface-2);
+  padding: 0.1rem 0.32rem;
 }
 
-.expressive-code {
-  --ec-brdRad: 0.65rem;
-  --ec-brdWd: 1px;
-  --ec-brdCol: var(--sl-color-gray-5);
+.sl-markdown-content blockquote:not(:where(.not-content *)) {
+  border-inline-start: 2px solid var(--ink-line);
+  color: var(--ink-muted);
 }
+
+.sl-markdown-content hr:not(:where(.not-content *)) {
+  border: 0;
+  border-top: 1px solid var(--ink-line);
+}
+
+/* --- Tables ------------------------------------------------------- */
+
+.sl-markdown-content table:not(:where(.not-content *)) {
+  font-size: 0.875rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ink-line) transparent;
+}
+
+.sl-markdown-content table:not(:where(.not-content *))::-webkit-scrollbar {
+  height: 6px;
+}
+
+.sl-markdown-content
+  table:not(:where(.not-content *))::-webkit-scrollbar-thumb {
+  border-radius: 3px;
+  background-color: var(--ink-line);
+}
+
+.sl-markdown-content :is(th, td):not(:where(.not-content *)) {
+  border-bottom: 1px solid var(--ink-line);
+  padding: 0.6rem 1rem;
+}
+
+/*
+ * Header cells keep the annotation *feel* — mono, small, tracked — but not
+ * `text-transform: uppercase`. Two shipped headers carry inline identifiers
+ * (`Reaches <code>engine.invoke</code>`, `Calls <code>run</code>`) and
+ * `text-transform` inherits into `<code>`, which would render them as
+ * ENGINE.INVOKE and RUN. Same reason the figure rules below are guarded for
+ * Expressive Code frame titles: API names have to stay literal.
+ */
+.sl-markdown-content th:not(:where(.not-content *)) {
+  border-bottom-color: var(--ink-line);
+  padding-bottom: 0.5rem;
+  color: var(--ink-muted);
+  font-family: var(--sl-font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: var(--ivk-track-label);
+  line-height: 1.4;
+}
+
+/* The label tracking and the 11px step are wrong for an identifier chip, so
+   the inline code inside a header cell opts back out of both. */
+.sl-markdown-content th:not(:where(.not-content *)) code {
+  font-size: 0.75rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* --- Figures ------------------------------------------------------ *
+ *
+ * Every rule below is guarded with `:not(:where(.not-content, .not-content *))`.
+ * Expressive Code renders each code block as `<figure class="frame
+ * not-content"><figcaption class="header">`, and those live *inside*
+ * `.sl-markdown-content`. Starlight's usual `:not(:where(.not-content *))`
+ * guard is not enough here because the EC figure carries `.not-content`
+ * itself rather than inheriting it from an ancestor, so `.not-content` is
+ * listed in the `:where()` alongside the descendant form.
+ *
+ * Without the guard the caption rules leak onto the code-frame title bar:
+ * `text-transform: uppercase` has nothing in Expressive Code's own CSS to
+ * reset it, so filenames render as `SRC/CAPABILITIES.TS`, and `margin-top`
+ * adds a stray gap above every frame. Filenames have to stay literal.
+ */
+
+.sl-markdown-content figure:not(:where(.not-content, .not-content *)) {
+  margin-block: 2rem;
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-md);
+  background-color: var(--ink-surface);
+  padding: 1rem;
+}
+
+/* The diagram shipped with the docs is drawn on the brand ramp but is still a
+   light-only line drawing, so it keeps its own plate in both themes. */
+.sl-markdown-content
+  figure:not(:where(.not-content, .not-content *))
+  img[src$=".svg"] {
+  border-radius: var(--ivk-radius-sm);
+  background-color: var(--ivk-figure-plate);
+  padding: 0.75rem;
+}
+
+/* A caption is prose, not a label: sentence case at reading size. It also
+   uses `--ink-muted` rather than `--bp-label`, which would not clear AA
+   against the figure plate. */
+.sl-markdown-content figcaption:not(:where(.not-content, .not-content *)) {
+  margin-top: 0.875rem;
+  color: var(--ink-muted);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  text-align: center;
+}
+
+/* ================================================================== *
+ * 4. Header
+ * ================================================================== */
+
+header.header {
+  border-bottom: 1px solid var(--ink-line);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+.site-title {
+  gap: 0.5rem;
+  color: var(--ink-fg);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  text-transform: lowercase;
+}
+
+/* The mark is a 51:43 drawing: fix the height, let the width follow.
+   1.125rem matches the landing page's nav lockup. */
+.site-title svg {
+  width: auto;
+  height: 1.125rem;
+  flex: none;
+}
+
+.social-icons::after {
+  border-inline-end-color: var(--ink-line);
+}
+
+.social-icons a {
+  color: var(--ink-muted);
+  transition: color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+.social-icons a:hover {
+  color: var(--ink-fg);
+}
+
+/* Search trigger */
+site-search button[data-open-modal] {
+  border-color: var(--ink-line);
+  border-radius: var(--ivk-radius-pill);
+  background-color: transparent;
+  color: var(--ink-muted);
+  font-size: 0.8125rem;
+  transition:
+    border-color var(--ivk-dur-fast) var(--ivk-ease),
+    color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+site-search button[data-open-modal]:hover {
+  border-color: var(--ink-faint);
+  color: var(--ink-fg);
+}
+
+site-search button > kbd {
+  border: 1px solid var(--ink-line);
+  border-radius: 4px;
+  background-color: var(--ink-surface-2);
+  /* The Ctrl/⌘ K hint is informative, not decoration: `--ink-body` is the
+     lightest token that clears AA on `--ink-surface-2` in both themes. */
+  color: var(--ink-body);
+  font-family: var(--sl-font-mono);
+  font-size: 0.625rem;
+}
+
+/* Theme select */
+starlight-theme-select label {
+  color: var(--ink-muted);
+}
+
+starlight-theme-select label:hover {
+  color: var(--ink-fg);
+}
+
+starlight-theme-select select {
+  font-size: 0.8125rem;
+}
+
+starlight-theme-select option {
+  background-color: var(--ink-bg);
+  color: var(--ink-body);
+}
+
+/* Mobile menu button — a hairline plate, not a filled circle. */
+starlight-menu-button button {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-sm);
+  background-color: var(--ink-surface-2);
+  color: var(--ink-body);
+  box-shadow: none;
+}
+
+starlight-menu-button [aria-expanded="true"] button {
+  border-color: var(--ink-faint);
+  background-color: var(--ink-surface-2);
+  color: var(--ink-fg);
+}
+
+/* Skip link */
+.sl-skip-link:focus {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-sm);
+  background-color: var(--ink-bg);
+  color: var(--ink-fg);
+  box-shadow: var(--shadow-raised);
+}
+
+/* ================================================================== *
+ * 5. Search dialog
+ * ================================================================== */
+
+site-search dialog {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-md);
+  background-color: var(--ink-bg);
+  box-shadow: var(--shadow-raised);
+}
+
+site-search button[data-close-modal] {
+  color: var(--ink-muted);
+}
+
+#starlight__search {
+  --pagefind-ui-primary: var(--ink-fg);
+  --pagefind-ui-text: var(--ink-body);
+  --pagefind-ui-background: var(--ink-bg);
+  --pagefind-ui-border: var(--ink-line);
+  --pagefind-ui-border-width: 1px;
+  --pagefind-ui-border-radius: 0.375rem;
+  --pagefind-ui-tag: var(--ink-surface-2);
+}
+
+#starlight__search .pagefind-ui__search-input {
+  color: var(--ink-fg);
+}
+
+#starlight__search .pagefind-ui__result-title:not(
+    :where(.pagefind-ui__result-nested *)
+  ),
+#starlight__search .pagefind-ui__result-nested,
+#starlight__search .pagefind-ui__result-tags {
+  background-color: var(--ink-surface);
+}
+
+/* ================================================================== *
+ * 6. Left sidebar
+ * ================================================================== */
+
+.sidebar-pane {
+  border-inline-end: 1px solid var(--ink-line);
+}
+
+.sidebar-content {
+  gap: 1.25rem;
+}
+
+/* Group headings read as blueprint annotations; the annotation block above
+   supplies the mono/uppercase treatment and the `--ink-muted` colour. */
+
+.sidebar-content summary {
+  padding-block: 0.35rem;
+}
+
+.sidebar-content .caret {
+  color: var(--ink-faint);
+  transition: transform var(--ivk-dur-base) var(--ivk-ease);
+}
+
+/* Top-level links (entries with no group) stay sentence-cased. */
+.sidebar-content ul.top-level > li > a.large {
+  color: var(--ink-fg);
+  font-weight: 500;
+}
+
+.sidebar-content a {
+  border-radius: var(--ivk-radius-sm);
+  color: var(--ink-muted);
+  transition:
+    color var(--ivk-dur-fast) var(--ivk-ease),
+    background-color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+/*
+ * Below 50rem this sidebar *is* the full-screen mobile navigation, and
+ * Starlight deliberately keeps it at reading size there — shrinking it
+ * unconditionally would drop the links to 13px and their tap targets to
+ * ~26px. Mirror Starlight's own breakpoint and only tighten on desktop.
+ */
+@media (min-width: 50rem) {
+  .sidebar-content a {
+    font-size: 0.8125rem;
+  }
+
+  .sidebar-content ul.top-level > li > a.large {
+    font-size: var(--sl-text-sm);
+  }
+}
+
+.sidebar-content a:hover,
+.sidebar-content a:focus {
+  background-color: color-mix(in srgb, var(--ink-surface-2) 60%, transparent);
+  color: var(--ink-fg);
+}
+
+.sidebar-content a[aria-current="page"],
+.sidebar-content a[aria-current="page"]:hover,
+.sidebar-content a[aria-current="page"]:focus {
+  background-color: color-mix(in srgb, var(--accent-low) 45%, transparent);
+  color: var(--accent-text);
+  font-weight: 500;
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.sidebar-content ul ul li {
+  border-inline-start-color: var(--ink-line);
+}
+
+/* ================================================================== *
+ * 7. Right sidebar (table of contents)
+ * ================================================================== */
+
+.right-sidebar {
+  border-inline-start: 1px solid var(--ink-line);
+  scrollbar-width: thin;
+  scrollbar-color: var(--ink-line) transparent;
+}
+
+/* Colour and label treatment come from the annotation block. */
+.right-sidebar-panel h2 {
+  margin-bottom: 0.75rem;
+}
+
+starlight-toc nav a {
+  border-radius: var(--ivk-radius-sm);
+  padding-block: 0.3rem;
+  color: var(--ink-muted);
+  font-size: 0.8125rem;
+  transition: color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+starlight-toc nav a:hover {
+  color: var(--ink-fg);
+}
+
+starlight-toc nav a[aria-current="true"] {
+  color: var(--accent-text);
+  font-weight: 500;
+}
+
+/* Mobile table of contents */
+mobile-starlight-toc nav {
+  border-top: 1px solid var(--ink-line);
+  background-color: color-mix(in srgb, var(--ink-bg) 88%, transparent);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+mobile-starlight-toc summary {
+  border-bottom: 1px solid var(--ink-line);
+}
+
+mobile-starlight-toc .toggle {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-sm);
+  background-color: var(--ink-surface);
+  color: var(--ink-muted);
+}
+
+mobile-starlight-toc details[open] .toggle,
+mobile-starlight-toc details .toggle:hover {
+  border-color: var(--ink-faint);
+  color: var(--ink-fg);
+}
+
+mobile-starlight-toc .dropdown {
+  border-color: var(--ink-line);
+  background-color: var(--ink-bg);
+  box-shadow: var(--shadow-raised);
+}
+
+/* ================================================================== *
+ * 8. Content panels, pagination, footer
+ * ================================================================== */
+
+.content-panel + .content-panel {
+  border-top-color: var(--ink-line);
+}
+
+.pagination-links a {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-md);
+  color: var(--ink-muted);
+  box-shadow: none;
+  transition:
+    transform var(--ivk-dur-base) var(--ivk-ease),
+    border-color var(--ivk-dur-base) var(--ivk-ease),
+    background-color var(--ivk-dur-base) var(--ivk-ease);
+}
+
+.pagination-links a:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--ink-faint) 60%, transparent);
+  background-color: color-mix(in srgb, var(--ink-surface-2) 50%, transparent);
+}
+
+.pagination-links a > span {
+  font-family: var(--sl-font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: var(--ivk-track-label);
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.pagination-links .link-title {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: var(--ink-fg);
+  font-family: var(--sl-font);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: var(--ivk-track-display);
+  text-transform: none;
+}
+
+footer .meta {
+  margin-top: 2.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--ink-line);
+  /* Small print, but still readable: `--ink-faint` fails AA in both themes. */
+  color: var(--ink-muted);
+  font-size: 0.75rem;
+}
+
+footer .meta a {
+  color: var(--ink-muted);
+  transition: color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+footer .meta a:hover {
+  color: var(--accent-text);
+}
+
+footer .meta time {
+  font-family: var(--sl-font-mono);
+}
+
+/* ================================================================== *
+ * 9. Asides
+ * ================================================================== */
+
+.starlight-aside {
+  --ivk-aside-line: var(--accent);
+  --ivk-aside-tint: var(--accent-low);
+  border: 1px solid var(--ink-line);
+  border-inline-start: 2px solid var(--ivk-aside-line);
+  border-radius: var(--ivk-radius-sm);
+  padding: 1rem;
+  background-color: color-mix(in srgb, var(--ivk-aside-tint) 22%, transparent);
+  color: var(--ink-body);
+}
+
+.starlight-aside--note,
+.starlight-aside--tip {
+  --ivk-aside-line: var(--accent);
+  --ivk-aside-tint: var(--accent-low);
+  --sl-color-asides-text-accent: var(--accent-text);
+}
+
+.starlight-aside--caution {
+  --ivk-aside-line: var(--sl-color-orange);
+  --ivk-aside-tint: var(--sl-color-orange-low);
+  --sl-color-asides-text-accent: var(--sl-color-orange-high);
+}
+
+.starlight-aside--danger {
+  --ivk-aside-line: var(--sl-color-red);
+  --ivk-aside-tint: var(--sl-color-red-low);
+  --sl-color-asides-text-accent: var(--sl-color-red-high);
+}
+
+.starlight-aside__title {
+  color: var(--ink-fg);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: var(--ivk-track-display);
+}
+
+.starlight-aside__icon {
+  color: var(--ivk-aside-line);
+  font-size: 1.1em;
+}
+
+.starlight-aside__content {
+  font-size: 0.875rem;
+  line-height: 1.625;
+}
+
+@media (min-width: 40rem) {
+  .starlight-aside {
+    padding: 1rem 1.25rem;
+  }
+}
+
+/* ================================================================== *
+ * 10. Cards, link cards, link buttons, badges
+ * ================================================================== */
+
+.card-grid > article.card {
+  /* Neutralises Starlight's rotating per-position icon hues. */
+  --sl-card-border: var(--ink-line);
+  --sl-card-bg: var(--ink-surface-2);
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-md);
+  background-color: transparent;
+  padding: 1.75rem 1.5rem;
+  box-shadow: none;
+  transition:
+    transform var(--ivk-dur-base) var(--ivk-ease),
+    border-color var(--ivk-dur-base) var(--ivk-ease),
+    background-color var(--ivk-dur-base) var(--ivk-ease);
+}
+
+.card-grid > article.card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--ink-faint) 60%, transparent);
+  background-color: color-mix(in srgb, var(--ink-surface-2) 50%, transparent);
+}
+
+.card .title {
+  gap: 0.75rem;
+  color: var(--ink-fg);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: var(--ivk-track-display);
+}
+
+/* The icon plate: hairline square, recessed fill, accent glyph. */
+.card .icon {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-sm);
+  background-color: var(--ink-surface-2);
+  color: var(--accent-text);
+  padding: 0.3em;
+}
+
+.card .body {
+  color: var(--ink-muted);
+  font-size: 0.875rem;
+  line-height: 1.625;
+}
+
+.sl-link-card {
+  border: 1px solid var(--ink-line);
+  border-radius: var(--ivk-radius-md);
+  box-shadow: none;
+  transition:
+    transform var(--ivk-dur-base) var(--ivk-ease),
+    border-color var(--ivk-dur-base) var(--ivk-ease),
+    background-color var(--ivk-dur-base) var(--ivk-ease);
+}
+
+.sl-link-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--ink-faint) 60%, transparent);
+  background-color: color-mix(in srgb, var(--ink-surface-2) 50%, transparent);
+}
+
+.sl-link-card .title {
+  color: var(--ink-fg);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: var(--ivk-track-display);
+}
+
+.sl-link-card .description {
+  color: var(--ink-muted);
+  font-size: 0.875rem;
+}
+
+.sl-link-card .icon {
+  color: var(--ink-faint);
+}
+
+.sl-link-button {
+  border-radius: var(--ivk-radius-pill);
+  padding: 0.5rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition:
+    background-color var(--ivk-dur-fast) var(--ivk-ease),
+    border-color var(--ivk-dur-fast) var(--ivk-ease),
+    color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+.sl-link-button.primary,
+.sl-link-button.primary:hover {
+  border-color: var(--accent);
+  background-color: var(--accent);
+  color: var(--accent-fg);
+}
+
+/*
+ * Dark lightens the fill to `--accent-text` on hover, so the label has to
+ * flip with it: white on #6f93ff is only 2.88:1. `--ink-bg` gives 6.91:1 in
+ * dark, and in light `--ink-bg` is #ffffff so the resting 5.73:1 is kept.
+ */
+.sl-link-button.primary:hover {
+  border-color: var(--accent-text);
+  background-color: var(--accent-text);
+  color: var(--ink-bg);
+}
+
+.sl-link-button.secondary {
+  border-color: var(--ink-line);
+  background-color: transparent;
+  color: var(--ink-fg);
+}
+
+.sl-link-button.secondary:hover {
+  border-color: var(--ink-faint);
+  background-color: var(--ink-surface-2);
+}
+
+.sl-link-button.minimal {
+  color: var(--accent-text);
+}
+
+.sl-badge {
+  border-radius: var(--ivk-radius-pill);
+  padding: 0.2rem 0.625rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.025em;
+}
+
+/* ================================================================== *
+ * 11. Steps and tabs
+ * ================================================================== */
+
+/* The step marker mirrors the icon plate rather than a generic gray disc. */
+.sl-steps > li::before {
+  border-radius: var(--ivk-radius-sm);
+  background-color: var(--ink-surface-2);
+  box-shadow: inset 0 0 0 1px var(--ink-line);
+  color: var(--ink-fg);
+  font-family: var(--sl-font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.sl-steps > li::after {
+  background-color: var(--ink-line);
+}
+
+/* Tabs reproduce the landing page's code-panel tab strip: hairline dividers
+   and a 1px accent underline riding on the strip's own border. */
+starlight-tabs [role="tablist"] {
+  border-bottom: 1px solid var(--ink-line);
+}
+
+.tab > [role="tab"] {
+  --sl-tab-color-border: transparent;
+  border-inline-end: 1px solid var(--ink-line);
+  padding: 0.55rem 1rem;
+  box-shadow: 0 1px 0 var(--sl-tab-color-border);
+  color: var(--ink-muted);
+  font-size: 0.8125rem;
+  transition:
+    color var(--ivk-dur-fast) var(--ivk-ease),
+    background-color var(--ivk-dur-fast) var(--ivk-ease);
+}
+
+.tab:first-child > [role="tab"] {
+  border-inline-start: 1px solid var(--ink-line);
+}
+
+.tab > [role="tab"]:hover {
+  background-color: var(--ink-surface-2);
+  color: var(--ink-fg);
+}
+
+.tab [role="tab"][aria-selected="true"] {
+  --sl-tab-color-border: var(--accent);
+  background-color: var(--ink-surface-raised);
+  color: var(--ink-fg);
+  font-weight: 500;
+}
+
+.tablist-wrapper {
+  scrollbar-width: thin;
+  scrollbar-color: var(--ink-line) transparent;
+}
+
+/* ================================================================== *
+ * 12. Code blocks
+ * ================================================================== */
+
+/*
+ * Colours, fonts and frame geometry are configured in `astro.config.mjs`
+ * under `expressiveCode`. Only the hairline scrollbar recipe lives here,
+ * because it needs the `::-webkit-scrollbar` pseudo-elements.
+ */
+.expressive-code pre,
+.expressive-code .frame {
+  scrollbar-width: thin;
+  scrollbar-color: var(--ink-line) transparent;
+}
+
+.expressive-code pre::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+
+.expressive-code pre::-webkit-scrollbar-thumb {
+  border-radius: 3px;
+  background-color: var(--ink-line);
+}
+
+.expressive-code pre::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Frame titles sit at annotation size without being uppercased — filenames
+   have to stay literal. */
+.expressive-code .frame .title {
+  font-size: 0.6875rem;
+  letter-spacing: 0.02em;
+}
+
+/* ================================================================== *
+ * 13. Splash hero (index page)
+ * ================================================================== */
 
 .hero {
-  padding-block: clamp(3rem, 9vw, 7rem);
+  padding-block: clamp(3rem, 9vw, 6.5rem);
 }
 
 .hero .copy {
   align-items: flex-start;
   text-align: left;
+  gap: 1.25rem;
 }
 
 .hero h1 {
-  max-width: 13ch;
-  font-weight: 650;
-  letter-spacing: -0.06em;
-  line-height: 0.98;
+  max-width: 16ch;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 1.02;
 }
 
 .hero .tagline {
-  max-width: 42rem;
-  color: var(--sl-color-gray-2);
-  font-size: clamp(1.05rem, 2vw, 1.3rem);
-  line-height: 1.55;
+  max-width: 44rem;
+  color: var(--ink-muted);
+  font-size: clamp(1rem, 1.6vw, 1.125rem);
+  line-height: 1.625;
 }
 
-.hero .actions a {
-  border-radius: 0.5rem;
-  font-weight: 550;
-}
-
-.hero .actions a.primary {
-  color: var(--sl-color-black);
-  background: var(--sl-color-white);
-}
-
-.card-grid > article {
-  border-color: var(--sl-color-gray-5);
-  border-radius: 0.65rem;
-  background: color-mix(in srgb, var(--sl-color-black) 95%, transparent);
-  box-shadow: none;
-  transition:
-    border-color 150ms ease,
-    transform 150ms ease;
-}
-
-.card-grid > article:hover {
-  border-color: var(--sl-color-gray-3);
-  transform: translateY(-2px);
-}
+/* ================================================================== *
+ * 14. Layout
+ * ================================================================== */
 
 @media (min-width: 72rem) {
   .main-pane {
@@ -178,12 +939,36 @@ header.header {
   }
 }
 
+/* ================================================================== *
+ * 15. Reduced motion
+ * ================================================================== */
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
   }
 
-  .card-grid > article {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  /*
+   * Structural collapse: hover lifts are removed entirely rather than merely
+   * shortened, so nothing ever animates a transform.
+   */
+  .card-grid > article.card,
+  .sl-link-card,
+  .pagination-links a {
     transition: none;
+  }
+
+  .card-grid > article.card:hover,
+  .sl-link-card:hover,
+  .pagination-links a:hover {
+    transform: none;
   }
 }

--- a/apps/docs/src/styles/tokens.css
+++ b/apps/docs/src/styles/tokens.css
@@ -1,0 +1,358 @@
+/*
+ * Invokta design tokens — ported verbatim from the lp-invokta landing page.
+ *
+ * Two layers live here:
+ *   1. The first-class `--ink-* / --accent-* / --bp-* / --code-* / --ivk-*`
+ *      token set. Component CSS in `global.css` and `InvocationFlow.astro`
+ *      reads these names, never raw hex.
+ *   2. A mapping of those tokens onto Starlight's `--sl-*` variables so the
+ *      framework's own components inherit the palette for free.
+ *
+ * Theme resolution is driven entirely by `data-theme` on <html>, which
+ * Starlight already writes pre-paint from the `starlight-theme` localStorage
+ * key — the same contract the landing page uses, so the two sites stay in
+ * sync. There is deliberately no `prefers-color-scheme` query in this file.
+ *
+ * Starlight's convention is `:root` = dark and `:root[data-theme='light']` =
+ * light, which is the inverse of the landing page's base. Values are assigned
+ * by theme name, not by block order.
+ *
+ * `::backdrop` is included in both blocks so the search dialog's backdrop
+ * cannot desync from the page palette.
+ */
+
+/* ------------------------------------------------------------------ *
+ * Dark theme (the document default)
+ * ------------------------------------------------------------------ */
+:root,
+::backdrop {
+  color-scheme: dark;
+
+  /* Surfaces */
+  --ink-bg: #09090b;
+  --ink-surface: #0e0e11;
+  --ink-surface-2: #18181b;
+  --ink-surface-raised: #18181b;
+
+  /* Text — note that `--ink-body` and `--ink-muted` are deliberately equal
+     in dark and different in light. That asymmetry is intentional. */
+  --ink-fg: #fafafa;
+  --ink-body: #a1a1aa;
+  --ink-muted: #a1a1aa;
+  --ink-faint: #71717a;
+
+  /* Lines */
+  --ink-line: #27272a;
+  --ink-line-soft: #1c1c1f;
+  --ink-grid: #1e1e20;
+
+  /* Accent — dark uses a different blue, not a lightened #3d50f5. */
+  --accent: #3369ff;
+  --accent-hover: #5a85ff;
+  --accent-low: #16224a;
+  --accent-high: #b3c7ff;
+  --accent-spark: #6f93ff;
+  /*
+   * Never colour text with `--accent`; always use `--accent-text`.
+   * Raw #3369ff only reaches 4.4:1 on #09090b, which fails AA at the small
+   * sizes used for links and card copy. The spark value #6f93ff hits 6.9:1,
+   * so dark promotes it into `--accent-text`.
+   */
+  --accent-text: #6f93ff;
+  --accent-fg: #ffffff;
+
+  /* Blueprint decoration layer.
+     Authored as rgb(from <ink token> r g b / a); resolved here so the values
+     survive any CSS transform in the build pipeline.
+     These tints are for aria-hidden decoration only. `--bp-label` in
+     particular sits near 2:1 against either ground, so real text — sidebar
+     group headings, the TOC heading, captions — uses `--ink-muted`. */
+  --bp-rail: rgb(30 30 32 / 0.95); /* --ink-grid @ 95% */
+  --bp-rule: rgb(30 30 32 / 0.85); /* --ink-grid @ 85% */
+  --bp-dot: rgb(113 113 122 / 0.45); /* --ink-faint @ 45% */
+  --bp-label: rgb(113 113 122 / 0.62); /* --ink-faint @ 62% */
+  --bp-cross: rgb(111 147 255 / 0.7); /* --accent-spark @ 70% */
+
+  /*
+   * The single shadow recipe, reserved for surfaces that genuinely lift.
+   * Dark adds a 1px ring because a drop shadow alone is invisible on #09090b.
+   */
+  --shadow-raised:
+    0 1px 2px rgb(0 0 0 / 0.5), 0 16px 40px -12px rgb(0 0 0 / 0.7),
+    0 0 0 1px rgb(39 39 42 / 0.9);
+
+  /* Syntax palette — Night Owl. Mirrors the Expressive Code theme in
+     astro.config.mjs; kept here so non-EC surfaces can reference it. */
+  --code-plain: #d6deeb;
+  --code-comment: #7a8b99;
+  --code-keyword: #c792ea;
+  --code-string: #ecc48d;
+  --code-fn: #82aaff;
+  --code-number: #f78c6c;
+  --code-prop: #7fdbca;
+  --code-punct: #8b96a5;
+
+  /* --- Starlight mapping (dark) ------------------------------------ */
+  --sl-color-white: var(--ink-fg);
+  --sl-color-gray-1: #e4e4e7;
+  --sl-color-gray-2: var(--ink-body);
+  --sl-color-gray-3: var(--ink-faint);
+  --sl-color-gray-4: #3f3f46;
+  --sl-color-gray-5: var(--ink-line);
+  --sl-color-gray-6: var(--ink-surface-2);
+  --sl-color-black: var(--ink-bg);
+
+  --sl-color-accent-low: var(--accent-low);
+  --sl-color-accent: var(--accent);
+  --sl-color-accent-high: var(--accent-high);
+
+  /* Semantic hues, de-rainbowed. Note and tip collapse onto the accent so
+     the palette stays near-monochrome + one blue; caution and danger keep a
+     muted amber and red because they carry real meaning. */
+  --sl-color-blue-low: var(--accent-low);
+  --sl-color-blue: var(--accent);
+  --sl-color-blue-high: var(--accent-text);
+  --sl-color-purple-low: var(--accent-low);
+  --sl-color-purple: var(--accent);
+  --sl-color-purple-high: var(--accent-text);
+  --sl-color-orange-low: #2a1e08;
+  --sl-color-orange: #d9a441;
+  --sl-color-orange-high: #f0c987;
+  --sl-color-red-low: #3a1216;
+  --sl-color-red: #f05a63;
+  --sl-color-red-high: #ffa8ad;
+  --sl-color-green-low: #0e2a1c;
+  --sl-color-green: #3fbf87;
+  --sl-color-green-high: #86e0b6;
+
+  --sl-color-text: var(--ink-body);
+  --sl-color-text-accent: var(--accent-text);
+  --sl-color-text-invert: var(--accent-fg);
+  --sl-color-bg: var(--ink-bg);
+  --sl-color-bg-nav: color-mix(in srgb, var(--ink-bg) 80%, transparent);
+  --sl-color-bg-sidebar: var(--ink-bg);
+  --sl-color-bg-inline-code: var(--ink-surface-2);
+  --sl-color-bg-accent: var(--accent);
+  --sl-color-hairline-light: var(--ink-line);
+  --sl-color-hairline: var(--ink-line);
+  --sl-color-hairline-shade: var(--ink-line);
+  --sl-color-backdrop-overlay: rgb(9 9 11 / 0.72);
+
+  /* Badges — tinted wash, hairline border, accent text (never white on
+     accent, which the stock Starlight badge does). */
+  --sl-badge-default-border: var(--accent-low);
+  --sl-badge-default-bg: color-mix(in srgb, var(--accent-low) 45%, transparent);
+  --sl-badge-default-text: var(--accent-text);
+  --sl-badge-note-border: var(--accent-low);
+  --sl-badge-note-bg: color-mix(in srgb, var(--accent-low) 45%, transparent);
+  --sl-badge-note-text: var(--accent-text);
+  --sl-badge-tip-border: var(--accent-low);
+  --sl-badge-tip-bg: color-mix(in srgb, var(--accent-low) 45%, transparent);
+  --sl-badge-tip-text: var(--accent-text);
+  --sl-badge-caution-border: var(--sl-color-orange-low);
+  --sl-badge-caution-bg: color-mix(
+    in srgb,
+    var(--sl-color-orange-low) 60%,
+    transparent
+  );
+  --sl-badge-caution-text: var(--sl-color-orange-high);
+  --sl-badge-danger-border: var(--sl-color-red-low);
+  --sl-badge-danger-bg: color-mix(
+    in srgb,
+    var(--sl-color-red-low) 60%,
+    transparent
+  );
+  --sl-badge-danger-text: var(--sl-color-red-high);
+  --sl-badge-success-border: var(--sl-color-green-low);
+  --sl-badge-success-bg: color-mix(
+    in srgb,
+    var(--sl-color-green-low) 60%,
+    transparent
+  );
+  --sl-badge-success-text: var(--sl-color-green-high);
+
+  /*
+   * Hairlines carry elevation in this system, so the generic shadow steps
+   * are switched off and only the one real recipe survives.
+   */
+  --sl-shadow-sm: none;
+  --sl-shadow-md: none;
+  --sl-shadow-lg: var(--shadow-raised);
+
+  /*
+   * The illustration in `public/images/how-an-action-engine-works.svg` is a
+   * light-only line drawing, so it is given its own plate in both themes
+   * rather than being recoloured.
+   */
+  --ivk-figure-plate: #ffffff;
+}
+
+/* ------------------------------------------------------------------ *
+ * Light theme
+ * ------------------------------------------------------------------ */
+:root[data-theme="light"],
+[data-theme="light"] ::backdrop {
+  color-scheme: light;
+
+  --ink-bg: #ffffff;
+  --ink-surface: #fafafa;
+  --ink-surface-2: #f4f4f5;
+  --ink-surface-raised: #ffffff;
+
+  --ink-fg: #18181b;
+  --ink-body: #52525b;
+  --ink-muted: #71717a;
+  --ink-faint: #a1a1aa;
+
+  --ink-line: #e4e4e7;
+  --ink-line-soft: #f0f0f1;
+  --ink-grid: #e6e6e9;
+
+  --accent: #3d50f5;
+  --accent-hover: #2a3ce0;
+  --accent-low: #eaecfe;
+  --accent-high: #0f1c8a;
+  --accent-spark: #6e7cf7;
+  /* #3d50f5 already clears AA on #ffffff, so no split is needed here. */
+  --accent-text: #3d50f5;
+  --accent-fg: #ffffff;
+
+  --bp-rail: rgb(230 230 233 / 0.95); /* --ink-grid @ 95% */
+  --bp-rule: rgb(230 230 233 / 0.8); /* --ink-grid @ 80% */
+  --bp-dot: rgb(161 161 170 / 0.4); /* --ink-faint @ 40% */
+  --bp-label: rgb(161 161 170 / 0.72); /* --ink-faint @ 72% */
+  --bp-cross: rgb(110 124 247 / 0.55); /* --accent-spark @ 55% */
+
+  --shadow-raised:
+    0 1px 2px rgb(24 24 27 / 0.04), 0 12px 32px -8px rgb(24 24 27 / 0.1),
+    0 2px 8px -2px rgb(24 24 27 / 0.06);
+
+  /* Night Owl Light. */
+  --code-plain: #403f53;
+  --code-comment: #6b7280;
+  --code-keyword: #8844ae;
+  --code-string: #984e4d;
+  --code-fn: #3b61b0;
+  --code-number: #aa0982;
+  --code-prop: #096e72;
+  --code-punct: #6b7280;
+
+  /* --- Starlight mapping (light) ----------------------------------- */
+  --sl-color-white: var(--ink-fg);
+  --sl-color-gray-1: #27272a;
+  --sl-color-gray-2: var(--ink-body);
+  --sl-color-gray-3: var(--ink-muted);
+  --sl-color-gray-4: var(--ink-faint);
+  --sl-color-gray-5: var(--ink-line);
+  --sl-color-gray-6: var(--ink-surface-2);
+  --sl-color-gray-7: var(--ink-surface);
+  --sl-color-black: var(--ink-bg);
+
+  --sl-color-blue-low: var(--accent-low);
+  --sl-color-blue: var(--accent);
+  --sl-color-blue-high: var(--accent-high);
+  --sl-color-purple-low: var(--accent-low);
+  --sl-color-purple: var(--accent);
+  --sl-color-purple-high: var(--accent-high);
+  --sl-color-orange-low: #fdf1dd;
+  --sl-color-orange: #b45c09;
+  --sl-color-orange-high: #7c3f05;
+  --sl-color-red-low: #fdeaec;
+  --sl-color-red: #c02532;
+  --sl-color-red-high: #8a1620;
+  --sl-color-green-low: #e6f6ee;
+  --sl-color-green: #10794f;
+  --sl-color-green-high: #0a5237;
+
+  --sl-color-bg-inline-code: var(--ink-surface-2);
+  --sl-color-hairline-shade: var(--ink-line);
+  --sl-color-backdrop-overlay: rgb(24 24 27 / 0.4);
+
+  --sl-badge-default-bg: color-mix(in srgb, var(--accent-low) 55%, transparent);
+  --sl-badge-note-bg: color-mix(in srgb, var(--accent-low) 55%, transparent);
+  --sl-badge-tip-bg: color-mix(in srgb, var(--accent-low) 55%, transparent);
+  --sl-badge-caution-bg: color-mix(
+    in srgb,
+    var(--sl-color-orange-low) 70%,
+    transparent
+  );
+  --sl-badge-danger-bg: color-mix(
+    in srgb,
+    var(--sl-color-red-low) 70%,
+    transparent
+  );
+  --sl-badge-success-bg: color-mix(
+    in srgb,
+    var(--sl-color-green-low) 70%,
+    transparent
+  );
+  --sl-badge-caution-text: var(--sl-color-orange-high);
+  --sl-badge-danger-text: var(--sl-color-red-high);
+  --sl-badge-success-text: var(--sl-color-green-high);
+}
+
+/* ------------------------------------------------------------------ *
+ * Theme-independent scalars: type, shape, layout, motion
+ * ------------------------------------------------------------------ */
+:root {
+  /* Fonts */
+  --sl-font: "Inter Tight", "Inter", ui-sans-serif, system-ui, sans-serif;
+  --sl-font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Typography signature */
+  --ivk-track-display: -0.035em;
+  --ivk-track-body: -0.01em;
+  --ivk-track-label: 0.14em;
+  --ivk-leading-tight: 1.04;
+  --ivk-leading-body: 1.6;
+
+  /* Shape */
+  --ivk-radius-sm: 0.375rem; /* 6px — panels, buttons(ghost), plates */
+  --ivk-radius-md: 0.75rem; /* 12px — cards */
+  --ivk-radius-lg: 1.25rem; /* 20px — large surfaces */
+  --ivk-radius-pill: 999px;
+  --ivk-radius-xs: 0.125rem; /* 2px — the tiny tag badge only */
+
+  /* Layout — the readable column matches the landing page's 56rem. */
+  --ivk-frame-width: 76rem;
+  --sl-content-width: 56rem;
+  --sl-nav-height: 3.5rem;
+
+  /* Signature five-column blueprint grid (% of viewport). Brand-kit values —
+     do not round. */
+  --ivk-col-1: 9.2%;
+  --ivk-col-2: 20.5%;
+  --ivk-col-3: 52.6%;
+  --ivk-col-4: 84.5%;
+  --ivk-col-5: 95.8%;
+
+  /* Motion */
+  --ivk-ease: cubic-bezier(0.2, 0, 0, 1);
+  --ivk-dur-fast: 120ms;
+  --ivk-dur-base: 200ms;
+
+  /*
+   * Heading sizes are declared as clamps on the semantic `--sl-text-h*`
+   * roles rather than on the raw `--sl-text-*` scale. Starlight remaps
+   * h1..h4 one step up at >=50em, which produced a visible discontinuity
+   * with the old `--sl-text-5xl` override; clamping removes it.
+   */
+  --sl-text-h1: clamp(2.25rem, 1.55rem + 2.9vw, 3.5rem);
+  --sl-text-h2: clamp(1.625rem, 1.34rem + 1.2vw, 2.125rem);
+  --sl-text-h3: clamp(1.25rem, 1.11rem + 0.6vw, 1.5rem);
+  --sl-text-h4: 1.125rem;
+  --sl-text-h5: 1rem;
+
+  --sl-line-height: 1.65;
+  --sl-line-height-headings: 1.1;
+
+  --sl-text-code: 0.8125rem;
+  --sl-text-code-sm: 0.8125em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ivk-dur-fast: 1ms;
+    --ivk-dur-base: 1ms;
+  }
+}

--- a/apps/docs/yarn.lock
+++ b/apps/docs/yarn.lock
@@ -590,15 +590,15 @@
   dependencies:
     "@expressive-code/core" "^0.44.1"
 
-"@fontsource-variable/geist-mono@5.3.0":
+"@fontsource/inter-tight@5.3.0":
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@fontsource-variable/geist-mono/-/geist-mono-5.3.0.tgz#ef4ce98a5d7485a4944ead6f799346dc33eddc63"
-  integrity sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==
+  resolved "https://registry.yarnpkg.com/@fontsource/inter-tight/-/inter-tight-5.3.0.tgz#ba4071c249fe7e4e01cd454f5981fc9ec9c119f0"
+  integrity sha512-uRwIrjKSUcCKIFeO2qm3yECA9phwge6Y1qQZvUmwqFgiIVWUELwwuq7pFlmlpPtO33ZtFQVOXQGNuvna1JPs6A==
 
-"@fontsource-variable/geist@5.3.0":
+"@fontsource/jetbrains-mono@5.3.0":
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@fontsource-variable/geist/-/geist-5.3.0.tgz#59084c5e2ffa77c6e3c63bc06f3af62ba4dbbdc5"
-  integrity sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==
+  resolved "https://registry.yarnpkg.com/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz#87bfd849f24b536ed72e89b56ae0d42223697f74"
+  integrity sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==
 
 "@img/colour@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## What changed

- Introduced shared light and dark design tokens, branded typography, and custom Expressive Code themes.
- Restyled Starlight navigation, content surfaces, cards, tables, code blocks, and responsive layouts.
- Updated the site title treatment, brand mark, favicon, social image, and invocation-flow illustration to match the Invokta visual system.

## Why

The documentation UI needed to align with Invokta's current visual language while keeping the existing information architecture and public documentation content intact.

## Impact

Readers get a consistent branded experience across light and dark modes, including improved code presentation and responsive behavior. This change does not alter public runtime contracts or documentation routes.

## Validation

- `yarn validate` in `apps/docs`
- 15 documentation tests passed
- `astro check`: 0 errors, warnings, or hints
- Static build completed successfully for 35 pages