### PR TITLE
feat(create-invokta-engine): import public GitHub examples as templates

### DIFF
--- a/apps/docs/src/content/docs/recipes/index.mdx
+++ b/apps/docs/src/content/docs/recipes/index.mdx
@@ -63,8 +63,15 @@ shows how to run and verify the result locally.
 
 ## Before you start
 
-Run the recipes from the repository root with Node.js 22.20.0 or later and Yarn
-1.22.22:
+Bootstrap a recipe example into a new project with
+[`create-invokta-engine --example`](/reference/create-invokta-engine/#github-example-import):
+
+```sh
+npm create invokta-engine@latest my-engine -- --example auth-clerk-engine --yes
+```
+
+Or run the recipes from a full repository checkout with Node.js 22.20.0 or later
+and Yarn 1.22.22:
 
 ```sh
 git clone https://github.com/vinilana/invokta.git

--- a/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
+++ b/apps/docs/src/content/docs/reference/create-invokta-engine.mdx
@@ -1,12 +1,13 @@
 ---
 title: 'create-invokta-engine'
-description: Interactive profiles, automation, generated-project, filesystem, package-manager, and diagnostic contracts for the Invokta engine creator.
+description: Interactive profiles, GitHub example import, automation, filesystem, package-manager, and diagnostic contracts for the Invokta engine creator.
 ---
 
 `create-invokta-engine` creates one standalone TypeScript Action Engine with a
 public capability shared by direct invocation and the adapters selected by a
-closed scaffold profile. It is a binary-only development package, not a runtime
-adapter or template framework.
+closed scaffold profile, or imports a public GitHub example tree as the project
+template. It is a binary-only development package, not a runtime adapter or
+template framework.
 
 ## Install
 
@@ -25,6 +26,8 @@ executable.
 ```text
 create-invokta-engine [project-directory]
   [--profile complete|mcp-stdio|mcp-http|cli]
+  [--example <name|github-url>]
+  [--example-path <subdir>]
   [--package-manager npm|pnpm|yarn]
   [--no-install]
   [--yes]
@@ -34,8 +37,9 @@ create-invokta-engine --version
 
 Options may appear before or after the one project directory; each option value
 must immediately follow its option. Duplicates, missing values, unknown options
-or profiles, `--option=value`, extra positionals, or combining help or version
-with another argument are invalid. `--yes` requires an explicit target.
+or profiles, `--option=value`, extra positionals, combining `--example` with
+`--profile`, using `--example-path` without `--example`, or combining help or
+version with another argument are invalid. `--yes` requires an explicit target.
 
 ## Interaction modes
 
@@ -43,10 +47,12 @@ Without `--yes`, the creator is interactive only when standard input and
 standard error are both TTYs. It asks, in order, for any missing project
 directory and profile, preflights and plans the full scaffold, then requests one
 final confirmation naming the normalized relative target, profile, package
-manager, and installation choice. Nothing is written and no child starts before
-an affirmative answer. Unicode control, format, line-separator, and
-paragraph-separator characters in an accepted parent path are escaped in the
-confirmation instead of being emitted as terminal-active text.
+manager, and installation choice. When `--example` is present it skips the
+profile prompt and confirms the example label instead. Nothing is written and no
+child starts before an affirmative answer. Unicode control, format,
+line-separator, and paragraph-separator characters in an accepted parent path
+are escaped in the confirmation instead of being emitted as terminal-active
+text.
 
 The profile choices are:
 
@@ -140,6 +146,34 @@ Generated authentication fails closed until implemented. HTTP profiles ignore
 `develop-invokta-project` skill adds project-specific RED/GREEN/REFACTOR and
 single-`engine.invoke` guidance without runtime discovery or behavior.
 
+## GitHub example import
+
+`--example` bootstraps from a public GitHub repository instead of a closed
+profile scaffold, similar to `create-next-app --example`:
+
+```sh
+create-invokta-engine my-engine --example auth-clerk-engine --no-install --yes
+create-invokta-engine my-engine \
+  --example https://github.com/acme/engine-template \
+  --no-install --yes
+create-invokta-engine my-engine \
+  --example https://github.com/acme/repo/tree/main/templates/engine \
+  --no-install --yes
+```
+
+Official short names resolve to `vinilana/invokta` `examples/<name>` on `main`.
+HTTPS `github.com` repository and tree URLs resolve owner, repository, ref, and
+optional subdirectory. `--example-path` supplies or overrides the subdirectory
+when the URL cannot encode it cleanly.
+
+Before confirmation the creator verifies that `package.json` exists at the
+example root. After confirmation it downloads only from `codeload.github.com`,
+extracts the selected subtree, rewrites `package.json` `name` to the project
+directory name, and copies regular files through the same exclusive-create and
+rollback boundary. Archive symbolic links, hard links, and path escapes are
+rejected. Private repositories, SSH, tokens, and non-GitHub hosts are out of
+scope. Dependency completeness belongs to the template author.
+
 ## Target and transaction contract
 
 The project directory is relative to the current working directory. Absolute
@@ -178,9 +212,10 @@ pnpm, or Yarn from `npm_config_user_agent` and falls back to npm.
 Exactly one foreground install starts directly without a shell, retry, or
 creator-owned timeout, and only after every selected entry exists. An
 unavailable manager, non-zero exit, or signal is `INSTALL_FAILED`; the generated
-profile remains for retry. `--no-install`, prompt failure, and cancellation
-start no process or network operation. The creator itself never makes a network
-request.
+project remains for retry. `--no-install` starts no package manager. Profile
+creation without `--example` still performs no creator-owned network request.
+Example import may contact `api.github.com` and `codeload.github.com` only, even
+when `--no-install` is set.
 
 ## Output and errors
 
@@ -206,3 +241,6 @@ credentials, child errors, stacks, or causes.
 | `SCAFFOLD_CONFLICT` | A planned entry appeared during creation |
 | `WRITE_FAILED` | A scaffold write or rollback failed |
 | `INSTALL_FAILED` | The selected package manager was unavailable or unsuccessful |
+| `EXAMPLE_INVALID` | The example name, URL, or path was invalid |
+| `EXAMPLE_UNAVAILABLE` | The example could not be resolved or downloaded |
+| `EXAMPLE_FAILED` | Example extraction or target copy failed |

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ decision is accepted and the implementation evidence is complete.
 
 - [Interactive engine creator profiles](./specs/interactive-engine-creator-profiles.md),
   accepted by [ADR 0018](./adr/0018-interactive-engine-creator-profiles.md)
+- [GitHub example import for create-invokta-engine](./specs/github-example-import.md),
+  accepted by [ADR 0020](./adr/0020-github-example-import-for-engine-creator.md)
 
 ## Guides and examples
 

--- a/docs/adr/0020-github-example-import-for-engine-creator.md
+++ b/docs/adr/0020-github-example-import-for-engine-creator.md
@@ -48,10 +48,13 @@ Non-HTTPS, non-`github.com`, credentialed, and SSH references are rejected.
 Before confirmation or write, the creator resolves metadata and verifies that
 `package.json` exists at the example root. After confirmation it downloads the
 repository tarball from `codeload.github.com`, extracts only the selected
-subtree into a temporary directory, rewrites `package.json` `name` to the
-project directory name, and copies regular files into the empty target with
-exclusive creation and the existing rollback rule. Archive symbolic links,
-hard links, absolute paths, and parent-directory segments are rejected.
+subtree into a temporary directory, requires the staged `package.json` to be a
+regular file, rewrites its `name` to the project directory name, and copies
+regular files into the empty target with exclusive creation and the existing
+rollback rule. Archive symbolic links, hard links, absolute paths, Windows
+drive/UNC paths, parent-directory segments, and non-directory entry types other
+than regular files (`File`, `OldFile`, `ContiguousFile`) are rejected.
+Extracted directory and regular-file counts are bounded.
 
 Allowed creator-owned network hosts for example mode are `api.github.com` and
 `codeload.github.com` only. The creator sends no authentication headers and

--- a/docs/adr/0020-github-example-import-for-engine-creator.md
+++ b/docs/adr/0020-github-example-import-for-engine-creator.md
@@ -1,0 +1,89 @@
+# ADR 0020: GitHub example import for the engine creator
+
+- Status: Accepted
+- Date: 2026-08-06
+
+## Context
+
+ADR 0012 and ADR 0018 define `create-invokta-engine` as a binary that emits one
+of four offline starter profiles. Package-manager installation is the only
+network activity on that path. Authors who want a recipe-backed or
+community-owned starting point must clone repositories and copy trees by hand.
+
+`create-next-app` already offers `--example` / `--example-path` against public
+GitHub tarballs. Invokta needs the same bootstrap for official `examples/*`
+recipes and for external public template repositories, without adding a remote
+catalog, template language, authenticated Git client, or second capability
+execution path.
+
+## Decision
+
+This decision extends ADR 0012 and ADR 0018 only by authorizing an explicit
+`--example` creation mode. The closed profile scaffolds, target safety,
+exclusive writes, rollback, package-manager install, interactive confirmation,
+sanitized diagnostics, and binary-only package boundary remain in force for
+profile creation. Profile creation without `--example` still performs no
+creator-owned network request.
+
+The command surface becomes:
+
+```text
+create-invokta-engine [project-directory]
+  [--profile complete|mcp-stdio|mcp-http|cli]
+  [--example <name|github-url>]
+  [--example-path <subdir>]
+  [--package-manager npm|pnpm|yarn]
+  [--no-install]
+  [--yes]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+`--example` and `--profile` are mutually exclusive. `--example-path` requires
+`--example`. Short names resolve to the official repository `vinilana/invokta`
+on branch `main` under `examples/<name>`. HTTPS `github.com` repository and
+tree URLs resolve owner, repository, ref, and optional subdirectory.
+Non-HTTPS, non-`github.com`, credentialed, and SSH references are rejected.
+
+Before confirmation or write, the creator resolves metadata and verifies that
+`package.json` exists at the example root. After confirmation it downloads the
+repository tarball from `codeload.github.com`, extracts only the selected
+subtree into a temporary directory, rewrites `package.json` `name` to the
+project directory name, and copies regular files into the empty target with
+exclusive creation and the existing rollback rule. Archive symbolic links,
+hard links, absolute paths, and parent-directory segments are rejected.
+
+Allowed creator-owned network hosts for example mode are `api.github.com` and
+`codeload.github.com` only. The creator sends no authentication headers and
+does not read GitHub tokens from the environment. Private repositories are out
+of scope. Fetch operations use a 60-second timeout and enforce bounded archive
+size, file count, and per-file size. Network and archive operations are
+injected at the CLI boundary so acceptance tests need no live network.
+
+`--no-install` continues to mean “start no package manager.” Example resolution
+and download still require network access when `--example` is present.
+
+The new sanitized diagnostics are:
+
+| Code | Exit | Message |
+| --- | ---: | --- |
+| `EXAMPLE_INVALID` | `2` | `The example reference is invalid.` |
+| `EXAMPLE_UNAVAILABLE` | `1` | `The example could not be resolved or downloaded.` |
+| `EXAMPLE_FAILED` | `1` | `The example project could not be created.` |
+
+Exact parsing, limits, and acceptance criteria are defined by the
+[GitHub example import specification](../specs/github-example-import.md) and
+the package acceptance tests.
+
+## Consequences
+
+- Authors can bootstrap from official recipe examples or any public GitHub
+  template repository with one command.
+- The offline profile path remains available and unchanged in its network
+  boundary.
+- Example completeness, including TypeScript and test tooling, is owned by the
+  template author; the creator rewrites only the package name.
+- Release verification must cover injected resolution, download, extract,
+  rename, rollback, and mutual exclusion with `--profile`.
+- A remote catalog, private-repo support, or non-GitHub hosts would require
+  another architectural decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0017](0017-engine-scoped-mcp-uninstall.md) | Engine-scoped MCP uninstall | Accepted | 2026-07-30 |
 | [0018](0018-interactive-engine-creator-profiles.md) | Interactive engine creator profiles | Accepted | 2026-07-30 |
 | [0019](0019-engine-embedded-mcp-install-commands.md) | Engine-embedded MCP install and uninstall commands | Accepted | 2026-08-02 |
+| [0020](0020-github-example-import-for-engine-creator.md) | GitHub example import for the engine creator | Accepted | 2026-08-06 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -380,3 +380,19 @@ profiles are bounded bootstrap projects rather than a weakening of the reuse or
 single-invocation-path invariants. Adding another profile, prompt decision,
 template authority, or in-place conversion requires another architectural
 decision.
+
+**AE-CREATE-EXAMPLE-01..08 — GitHub example import.** `create-invokta-engine`
+accepts `--example <name|github-url>` and optional `--example-path`. The flag
+is mutually exclusive with `--profile`. Official short names resolve to
+`vinilana/invokta` `examples/<name>` on `main`; public HTTPS `github.com`
+repository and tree URLs resolve owner, repository, ref, and subdirectory.
+Before mutation the creator verifies `package.json` at the example root. After
+confirmation it downloads only from `codeload.github.com`, extracts the selected
+subtree, rewrites `package.json` `name` to the project directory name, and
+copies regular files through the existing exclusive-create and rollback
+boundary. Archive links and path escapes are rejected. Creator-owned example
+network hosts are only `api.github.com` and `codeload.github.com`, with no
+authentication headers. Profile creation without `--example` still starts no
+creator-owned network request. `--no-install` skips only the package manager.
+Sanitized diagnostics are `EXAMPLE_INVALID`, `EXAMPLE_UNAVAILABLE`, and
+`EXAMPLE_FAILED`.

--- a/docs/implementation-plan-and-acceptance-criteria.md
+++ b/docs/implementation-plan-and-acceptance-criteria.md
@@ -41,6 +41,7 @@ persistence, configuration field, or operational limit:
 | `AE-SEC-01..02` | Authentication occurs before `invoke`; authorization occurs before `run`; insecure authentication requires explicit opt-in |
 | `AE-INSTALL-01..05` | Packed creator smoke tests install a built local engine; target transactions cover confirmation, idempotency, drift, locks, rollback, management, remote descriptors, and secret-free diagnostics without process or network access |
 | `AE-CREATE-PROFILE-01..12` | Terminal and non-terminal harnesses cover bounded prompting and confirmation; golden and packed tests cover all four exact profiles, public deploy-owned HTTP bytes, adapter omission, filesystem races, installation order, and direct/CLI/MCP equivalence |
+| `AE-CREATE-EXAMPLE-01..08` | Injected fetch harnesses cover official short names, GitHub URL resolution, mutual exclusion with `--profile`, confirmation cancellation, package-name rewrite, archive limits, symlink rejection, and offline profile network boundaries |
 | `AE-SCOPE-01..04`, `AE-LIMIT-01..05` | Manifest and API review prove package roles and the absence of deferred abstractions |
 
 Supporting packages require focused contract tests for their own authority:

--- a/docs/scope-and-limits.md
+++ b/docs/scope-and-limits.md
@@ -12,7 +12,7 @@
 | `@invokta/tooling` | Development-time validation of capability composition |
 | `@invokta/installer` | End-user configuration of supported local MCP clients |
 | `@invokta/deploy` | Development-time HTTP engine scaffolding, packaging, and probing |
-| `create-invokta-engine` | Interactive or automated creation of one bounded standalone starter profile |
+| `create-invokta-engine` | Interactive or automated creation of one bounded standalone starter profile, or import of one public GitHub example tree |
 | `create-invokta-capability` | Creation of a standalone atomic capability package |
 | `create-invokta-capability-library` | Creation of a standalone capability-library package |
 

--- a/docs/specs/github-example-import.md
+++ b/docs/specs/github-example-import.md
@@ -1,0 +1,189 @@
+# GitHub example import for create-invokta-engine
+
+Status: Implemented by ADR 0020
+
+Contract review verdict: **APPROVED**
+
+## Summary
+
+`create-invokta-engine` gains an optional `--example` mode that bootstraps a
+project from a public GitHub repository or subdirectory, similar to
+`create-next-app --example`. Official Invokta recipe examples under
+`examples/<name>` are addressable by short name; any other public GitHub
+repository is addressable by HTTPS URL.
+
+The existing closed profile scaffolds remain the offline default. Example import
+is mutually exclusive with `--profile`, reuses the creator's target safety,
+confirmation, exclusive-write, rollback, and package-manager boundaries, and
+never creates a second capability execution path.
+
+## Problem
+
+Invokta documents recipes that are backed by runnable examples, and the
+community needs to start from those patterns or from external template
+repositories. Today authors must clone the monorepo or copy trees by hand.
+`create-next-app` already solved the analogous problem with `--example` and
+`--example-path` against public GitHub tarballs.
+
+The creator must gain that bootstrap path without becoming a remote registry,
+template language, or authenticated Git client, and without weakening the
+offline profile path guaranteed by ADR 0012 and ADR 0018.
+
+## Goals
+
+- Accept `--example <name|github-url>` and optional `--example-path <subdir>`.
+- Resolve official short names to `vinilana/invokta` `examples/<name>` on `main`.
+- Resolve public `https://github.com/...` repository and tree URLs.
+- Verify that the resolved example root contains `package.json` before mutation.
+- Download only from `codeload.github.com` after confirmation or `--yes`.
+- Rewrite the generated `package.json` `name` to the project directory name.
+- Preserve target safety, exclusive creation, rollback, install flags, and
+  sanitized diagnostics.
+- Keep profile scaffolding offline except for the existing package-manager
+  install.
+- Make every network and archive operation injectable for deterministic tests.
+
+## Non-goals
+
+- Private repositories, tokens, SSH, or `git clone`.
+- Non-GitHub hosts, gists, or raw file URLs.
+- A browsable remote catalog, plugin system, or template language.
+- Variable substitution beyond the `package.json` `name` rewrite.
+- Combining `--example` with `--profile`.
+- Mutating or upgrading previously generated projects.
+- Guaranteeing that every monorepo example is a complete standalone toolchain
+  when copied; the example author owns dependency completeness.
+- Prompting for the example source interactively.
+
+## Command contract
+
+```text
+create-invokta-engine [project-directory]
+  [--profile complete|mcp-stdio|mcp-http|cli]
+  [--example <name|github-url>]
+  [--example-path <subdir>]
+  [--package-manager npm|pnpm|yarn]
+  [--no-install]
+  [--yes]
+create-invokta-engine --help
+create-invokta-engine --version
+```
+
+Parsing rules:
+
+- `--example` and `--profile` together are invalid usage.
+- `--example-path` without `--example` is invalid usage.
+- Duplicate `--example` or `--example-path`, missing values, empty values, and
+  `--option=value` forms remain invalid usage.
+- `--yes` still requires an explicit target.
+- Interactive mode still prompts for a missing target and final confirmation.
+  When `--example` is present it does not ask for a profile.
+- Non-terminal mode with `--example` and an explicit target proceeds without
+  prompts; a missing target remains `INTERACTIVE_REQUIRED`.
+
+### Example reference forms
+
+| Input | Resolution |
+| --- | --- |
+| `auth-clerk-engine` | `vinilana/invokta`, branch `main`, path `examples/auth-clerk-engine` |
+| `https://github.com/acme/engine-template` | `acme/engine-template`, default branch from GitHub API, path from `--example-path` or empty |
+| `https://github.com/acme/repo/tree/main/templates/engine` | `acme/repo`, branch `main`, path `templates/engine` |
+
+Short names MUST match
+`^[a-z0-9]+(?:-[a-z0-9]+)*(?:/[a-z0-9]+(?:-[a-z0-9]+)*)*$`, contain at most 8
+segments, and be at most 214 characters. GitHub URLs MUST use the `https:`
+scheme and the `github.com` host. `http:`, SSH, credentials in the URL, and
+other hosts are `EXAMPLE_INVALID`.
+
+`--example-path` MUST be a relative POSIX path without empty segments, `.`, or
+`..`, at most 1,024 Unicode scalars and 32 segments. When both a tree URL path
+and `--example-path` are present, `--example-path` wins.
+
+### Planning and mutation
+
+1. Parse and validate the example reference locally.
+2. Resolve repository metadata. Whole-repo URLs query
+   `https://api.github.com/repos/<owner>/<repo>` for the default branch.
+3. Verify `package.json` exists at the resolved path through a GitHub contents
+   check before confirmation or write.
+4. Interactive confirmation names the normalized target, example label, package
+   manager, and installation choice. Planning and resolution perform no
+   filesystem mutation of the target.
+5. After confirmation, revalidate the empty target, download
+   `https://codeload.github.com/<owner>/<repo>/tar.gz/<ref>`, extract only the
+   selected subtree into a temporary directory, rewrite `package.json` `name`,
+   and copy regular files into the target with exclusive creation.
+6. Archive symbolic links, hard links, absolute entry paths, and `..` segments
+   are rejected. A failure rolls back only target entries created by that
+   invocation and removes the temporary directory.
+7. Unless `--no-install` is set, exactly one shell-free package-manager install
+   runs after the copy completes.
+
+`--no-install` skips dependency installation only. Example resolution and
+download still require network access.
+
+### Limits
+
+| Limit | Value |
+| --- | ---: |
+| `--example` scalars | 2,048 |
+| Short-name characters | 214 |
+| Short-name segments | 8 |
+| `--example-path` scalars | 1,024 |
+| `--example-path` segments | 32 |
+| Fetch timeout | 60 seconds |
+| Uncompressed archive bytes retained | 52,428,800 (50 MiB) |
+| Extracted regular files | 10,000 |
+| Single extracted file bytes | 5,242,880 (5 MiB) |
+
+### Diagnostics
+
+| Code | Exit | Message |
+| --- | ---: | --- |
+| `EXAMPLE_INVALID` | `2` | `The example reference is invalid.` |
+| `EXAMPLE_UNAVAILABLE` | `1` | `The example could not be resolved or downloaded.` |
+| `EXAMPLE_FAILED` | `1` | `The example project could not be created.` |
+
+Diagnostics MAY name a stable detail such as `package.json` or a
+project-relative path after extraction starts. They MUST NOT echo the rejected
+argument, response bodies, tokens, child errors, stacks, or causes.
+
+### Success output
+
+```text
+Created <project-name> from example <label>.
+```
+
+followed by the existing next-step install or check guidance. The label is the
+short name, or `<owner>/<repo>` optionally suffixed with `/<path>`.
+
+## Acceptance criteria
+
+| ID | Criterion |
+| --- | --- |
+| AC-CREATE-EXAMPLE-01 | `--example` and `--profile` together exit `2` with invalid-usage text and perform no network or filesystem mutation. |
+| AC-CREATE-EXAMPLE-02 | Official short names resolve to `vinilana/invokta` `examples/<name>` on `main` and require a remote `package.json`. |
+| AC-CREATE-EXAMPLE-03 | Public GitHub repository and tree URLs resolve owner, repo, ref, and path; non-HTTPS or non-github.com references are `EXAMPLE_INVALID`. |
+| AC-CREATE-EXAMPLE-04 | Interactive confirmation names the example label and writes nothing on cancellation. |
+| AC-CREATE-EXAMPLE-05 | After confirmation, the creator downloads from `codeload.github.com`, copies only the selected subtree, and sets `package.json` `name` to the project directory name. |
+| AC-CREATE-EXAMPLE-06 | Archive symlinks, path escape attempts, missing `package.json`, timeouts, and over-limit archives fail with sanitized `EXAMPLE_*` diagnostics and leave no retained target files when rollback succeeds. |
+| AC-CREATE-EXAMPLE-07 | Profile scaffolding without `--example` still starts no creator-owned network request; `--no-install` with `--example` still downloads but starts no package manager. |
+| AC-CREATE-EXAMPLE-08 | Focused unit tests inject fetch/download and cover happy path, invalid references, unavailable examples, and extract failures without live network access. |
+
+## Traceability
+
+| Requirement | Contract | Tests |
+| --- | --- | --- |
+| `AE-CREATE-EXAMPLE-01` | Mutual exclusion and usage parsing | `packages/create-invokta-engine/test/cli.test.ts` |
+| `AE-CREATE-EXAMPLE-02..03` | Reference resolution | `packages/create-invokta-engine/test/example.test.ts` |
+| `AE-CREATE-EXAMPLE-04..05` | Confirmation, download, rename | `packages/create-invokta-engine/test/cli.test.ts`, `test/example.test.ts` |
+| `AE-CREATE-EXAMPLE-06` | Limits and safe extract | `packages/create-invokta-engine/test/example.test.ts` |
+| `AE-CREATE-EXAMPLE-07` | Offline profile path | existing profile CLI tests plus example `--no-install` cases |
+| `AE-CREATE-EXAMPLE-08` | Injected network boundary | all example tests use fakes |
+
+## Conditions before release
+
+1. Accept ADR 0020.
+2. Update architecture, package README, docs site reference, ADR index, and
+   validation record in the same deliverable.
+3. Keep `tar` as a direct dependency of `create-invokta-engine` only.

--- a/docs/specs/github-example-import.md
+++ b/docs/specs/github-example-import.md
@@ -123,11 +123,15 @@ Tree URL ref grammar:
    `https://codeload.github.com/<owner>/<repo>/tar.gz/<ref>`, extract only the
    selected subtree into a temporary directory, rewrite `package.json` `name`,
    and copy regular files into the target with exclusive creation.
-6. Archive symbolic links, hard links, absolute entry paths, Windows drive/UNC
+6. Before extraction, the creator scans raw ustar headers so typeflags that
+   node-tar would otherwise ignore (for example SparseFile) still fail closed.
+   Archive symbolic links, hard links, absolute entry paths, Windows drive/UNC
    paths, `..` segments, and non-directory entry types other than regular files
-   (`File`, `OldFile`, `ContiguousFile`) are rejected. The staged `package.json`
-   MUST be a regular file. A failure rolls back only target entries created by
-   that invocation and removes the temporary directory.
+   (`File`, `OldFile`, `ContiguousFile`) are rejected. Retained directories are
+   counted from both directory headers and implicit parents of file paths after
+   strip. The staged `package.json` MUST be a regular file. A failure rolls back
+   only target entries created by that invocation and removes the temporary
+   directory.
 7. Unless `--no-install` is set, exactly one shell-free package-manager install
    runs after the copy completes.
 

--- a/docs/specs/github-example-import.md
+++ b/docs/specs/github-example-import.md
@@ -96,8 +96,18 @@ scheme and the `github.com` host. `http:`, SSH, credentials in the URL, and
 other hosts are `EXAMPLE_INVALID`.
 
 `--example-path` MUST be a relative POSIX path without empty segments, `.`, or
-`..`, at most 1,024 Unicode scalars and 32 segments. When both a tree URL path
-and `--example-path` are present, `--example-path` wins.
+`..`, at most 1,024 Unicode scalars and 32 segments, and MUST NOT contain
+Unicode control, format, line-separator, or paragraph-separator characters.
+
+Tree URL ref grammar:
+
+- Without `--example-path`, the first path segment after `/tree/` is the ref
+  and any remaining segments are the example subdirectory. Slash-containing
+  refs are not expressible in this form.
+- With `--example-path`, the creator treats the full remainder after `/tree/`
+  as `branch[/…]` and, when that remainder ends with `/<example-path>`, strips
+  that suffix to recover the branch (create-next-app style). Otherwise the
+  entire remainder is the branch and `--example-path` is the subdirectory.
 
 ### Planning and mutation
 
@@ -113,9 +123,11 @@ and `--example-path` are present, `--example-path` wins.
    `https://codeload.github.com/<owner>/<repo>/tar.gz/<ref>`, extract only the
    selected subtree into a temporary directory, rewrite `package.json` `name`,
    and copy regular files into the target with exclusive creation.
-6. Archive symbolic links, hard links, absolute entry paths, and `..` segments
-   are rejected. A failure rolls back only target entries created by that
-   invocation and removes the temporary directory.
+6. Archive symbolic links, hard links, absolute entry paths, Windows drive/UNC
+   paths, `..` segments, and non-directory entry types other than regular files
+   (`File`, `OldFile`, `ContiguousFile`) are rejected. The staged `package.json`
+   MUST be a regular file. A failure rolls back only target entries created by
+   that invocation and removes the temporary directory.
 7. Unless `--no-install` is set, exactly one shell-free package-manager install
    runs after the copy completes.
 
@@ -135,6 +147,7 @@ download still require network access.
 | Uncompressed archive bytes retained | 52,428,800 (50 MiB) |
 | Compressed download bytes | 52,428,800 (50 MiB) |
 | Extracted regular files | 10,000 |
+| Extracted directories | 10,000 |
 | Single extracted file bytes | 5,242,880 (5 MiB) |
 
 ### Diagnostics
@@ -156,7 +169,9 @@ Created <project-name> from example <label>.
 ```
 
 followed by the existing next-step install or check guidance. The label is the
-short name, or `<owner>/<repo>` optionally suffixed with `/<path>`.
+short name, or `<owner>/<repo>` optionally suffixed with `/<path>`. Terminal
+control, format, line-separator, and paragraph-separator characters in the
+project name and label are escaped in this output.
 
 ## Acceptance criteria
 

--- a/docs/specs/github-example-import.md
+++ b/docs/specs/github-example-import.md
@@ -133,6 +133,7 @@ download still require network access.
 | `--example-path` segments | 32 |
 | Fetch timeout | 60 seconds |
 | Uncompressed archive bytes retained | 52,428,800 (50 MiB) |
+| Compressed download bytes | 52,428,800 (50 MiB) |
 | Extracted regular files | 10,000 |
 | Single extracted file bytes | 5,242,880 (5 MiB) |
 

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -31,7 +31,7 @@ consumer can use the protocol surface without coupling to engine code.
 
 - `yarn run check` passes typecheck, lint, formatting, 2,268 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  85.37% statements, 79.29% branches, 87.73% functions, and 87.08% lines.
+  85.38% statements, 79.30% branches, 87.73% functions, and 87.08% lines.
 - `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
   dependency boundaries, all four packed engine profiles, the authenticated MCP
   HTTP exchange, and the remaining creator and installer smoke tests.

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -29,9 +29,9 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 2,265 tests with one
+- `yarn run check` passes typecheck, lint, formatting, 2,268 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  85.35% statements, 79.25% branches, 87.70% functions, and 87.11% lines.
+  85.37% statements, 79.29% branches, 87.73% functions, and 87.08% lines.
 - `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
   dependency boundaries, all four packed engine profiles, the authenticated MCP
   HTTP exchange, and the remaining creator and installer smoke tests.

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -29,9 +29,9 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 2,254 tests with one
+- `yarn run check` passes typecheck, lint, formatting, 2,265 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  85.26% statements, 79.10% branches, 87.50% functions, and 86.91% lines.
+  85.35% statements, 79.25% branches, 87.70% functions, and 87.11% lines.
 - `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
   dependency boundaries, all four packed engine profiles, the authenticated MCP
   HTTP exchange, and the remaining creator and installer smoke tests.

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,12 +1,13 @@
 # Validation record
 
-- Last reviewed: 2026-08-01
+- Last reviewed: 2026-08-06
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
   accepted in ADR 0016; engine-scoped MCP uninstall accepted in ADR 0017;
   interactive engine creator profiles and the public deploy scaffold planner
-  accepted in ADR 0018
+  accepted in ADR 0018; GitHub example import for `create-invokta-engine`
+  accepted in ADR 0020
 
 ## Reuse evidence
 
@@ -52,7 +53,10 @@ consumer can use the protocol surface without coupling to engine code.
   on effective-ID collisions.
 - The creators, installer, and deploy packages remain outside the capability
   call graph and exercise only their documented project creation, local
-  configuration, and generation authority.
+  configuration, and generation authority. Injected fetch harnesses cover
+  `create-invokta-engine --example` resolution, download, package-name rewrite,
+  cancellation before archive download, and mutual exclusion with `--profile`
+  without live network access.
 - Packed creator smoke tests generate the exact `complete`, `mcp-stdio`,
   `mcp-http`, and `cli` file sets from release tarballs. Every profile installs,
   type-checks, tests, builds, and invokes the shared capability directly and

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -29,9 +29,9 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 1,847 tests with one
+- `yarn run check` passes typecheck, lint, formatting, 2,254 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  86.15% statements, 80.28% branches, 88.60% functions, and 87.89% lines.
+  85.26% statements, 79.10% branches, 87.50% functions, and 86.91% lines.
 - `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
   dependency boundaries, all four packed engine profiles, the authenticated MCP
   HTTP exchange, and the remaining creator and installer smoke tests.

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -1,15 +1,18 @@
 # create-invokta-engine
 
 Create a standalone TypeScript Action Engine with one deterministic capability
-and a selected execution profile. Every generated entry point imports the same
-engine and reaches capability execution through `engine.invoke` or an official
-Invokta adapter.
+and a selected execution profile, or import a public GitHub example tree as the
+project template. Every generated profile entry point imports the same engine
+and reaches capability execution through `engine.invoke` or an official Invokta
+adapter.
 
 ## Commands
 
 ```text
 create-invokta-engine [project-directory]
   [--profile complete|mcp-stdio|mcp-http|cli]
+  [--example <name|github-url>]
+  [--example-path <subdir>]
   [--package-manager npm|pnpm|yarn]
   [--no-install]
   [--yes]
@@ -26,7 +29,8 @@ npm create invokta-engine@latest my-engine
 When standard input and standard error are TTYs, the command asks for a missing
 project directory and profile, displays the normalized plan, and requires a
 final confirmation before writing. An explicit target or profile skips only its
-question. `--yes` requires an explicit target and skips every prompt.
+question. `--example` skips the profile prompt and confirms the example label
+instead. `--yes` requires an explicit target and skips every prompt.
 
 Non-terminal execution never prompts or reads standard input. It requires an
 explicit target and uses `complete` when `--profile` is omitted, preserving
@@ -40,11 +44,16 @@ Terminal automation should make its choices explicit:
 
 ```sh
 create-invokta-engine my-engine --profile complete --no-install --yes
+create-invokta-engine my-engine --example auth-clerk-engine --no-install --yes
 ```
+
+`--example` and `--profile` are mutually exclusive. `--example-path` requires
+`--example`.
 
 The invoking package manager is inferred from `npm_config_user_agent`, with npm
 as the fallback. Use `--package-manager` to choose explicitly. `--no-install`
-generates the selected files without starting a process or network operation.
+skips the package manager. Profile creation without `--example` starts no
+creator-owned network operation. Example import still contacts GitHub.
 
 ## Profiles
 
@@ -92,14 +101,38 @@ copying the instructions. Generated Invokta dependencies exactly match the
 creator version. All generated entries become project-owned and are never
 updated in place.
 
+## GitHub example import
+
+`--example` imports a public GitHub repository or subdirectory as the project
+template, similar to `create-next-app --example`:
+
+```sh
+create-invokta-engine my-engine --example auth-clerk-engine --no-install --yes
+create-invokta-engine my-engine \
+  --example https://github.com/acme/engine-template \
+  --no-install --yes
+create-invokta-engine my-engine \
+  --example https://github.com/acme/repo/tree/main/templates/engine \
+  --no-install --yes
+```
+
+Official short names resolve to `vinilana/invokta` `examples/<name>` on `main`.
+HTTPS `github.com` repository and tree URLs are accepted. `--example-path`
+supplies or overrides the subdirectory. The creator verifies `package.json`,
+downloads from `codeload.github.com` after confirmation, copies only the
+selected subtree, and rewrites `package.json` `name` to the project directory
+name. Private repositories, SSH, tokens, and non-GitHub hosts are unsupported.
+Template dependency completeness belongs to the example author.
+
 ## Prompt and target safety
 
 Each answer is strict UTF-8 and limited to 4,096 encoded bytes including the
 line terminator. The directory and profile questions allow three invalid
 answers. Confirmation accepts case-insensitive `y`, `yes`, `n`, or `no`; an
 empty confirmation means no. A negative confirmation writes
-`Creation cancelled. No files were created.` and performs no filesystem,
-process, or network operation.
+`Creation cancelled. No files were created.` and performs no filesystem or
+package-manager operation. Cancelled example imports also skip the archive
+download.
 
 The target must be relative, absent or an empty real directory. Absolute paths,
 parent segments, symbolic-link components, non-directories, and non-empty
@@ -111,18 +144,19 @@ an accepted parent path are escaped in the confirmation instead of being
 emitted as terminal-active text.
 
 Unless `--no-install` is present, exactly one shell-free foreground package
-manager install starts after every selected scaffold entry exists. An install
-failure preserves the complete generated profile for retry.
+manager install starts after every selected scaffold or example entry exists. An
+install failure preserves the complete generated project for retry.
 
 ## Exit codes and diagnostics
 
 | Exit | Meaning |
 | ---: | --- |
 | `0` | Help, version, creation, or normal cancellation succeeded |
-| `1` | Prompt interruption, target safety, filesystem, or installation failed |
-| `2` | Usage, required interaction, prompt input, path, or name was invalid |
+| `1` | Prompt interruption, target safety, filesystem, example, or installation failed |
+| `2` | Usage, required interaction, prompt input, path, name, or example reference was invalid |
 
 Creator diagnostics are `INTERACTIVE_REQUIRED`, `PROMPT_INVALID`,
 `PROMPT_ABORTED`, `TARGET_INVALID`, `TARGET_UNSAFE`, `TARGET_NOT_EMPTY`,
-`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, and `INSTALL_FAILED`. They never include a
-rejected answer or argument, environment value, child error, stack, or cause.
+`SCAFFOLD_CONFLICT`, `WRITE_FAILED`, `INSTALL_FAILED`, `EXAMPLE_INVALID`,
+`EXAMPLE_UNAVAILABLE`, and `EXAMPLE_FAILED`. They never include a rejected
+answer or argument, environment value, child error, stack, or cause.

--- a/packages/create-invokta-engine/README.md
+++ b/packages/create-invokta-engine/README.md
@@ -118,11 +118,12 @@ create-invokta-engine my-engine \
 
 Official short names resolve to `vinilana/invokta` `examples/<name>` on `main`.
 HTTPS `github.com` repository and tree URLs are accepted. `--example-path`
-supplies or overrides the subdirectory. The creator verifies `package.json`,
-downloads from `codeload.github.com` after confirmation, copies only the
-selected subtree, and rewrites `package.json` `name` to the project directory
-name. Private repositories, SSH, tokens, and non-GitHub hosts are unsupported.
-Template dependency completeness belongs to the example author.
+selects the subdirectory and, for tree URLs, recovers slash-containing refs the
+same way `create-next-app` does. The creator verifies `package.json` is a
+regular file, downloads from `codeload.github.com` after confirmation, copies
+only the selected subtree, and rewrites `package.json` `name` to the project
+directory name. Private repositories, SSH, tokens, and non-GitHub hosts are
+unsupported. Template dependency completeness belongs to the example author.
 
 ## Prompt and target safety
 

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -33,6 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.3.0"
+    "@invokta/deploy": "0.3.0",
+    "tar": "7.5.22"
   }
 }

--- a/packages/create-invokta-engine/src/cli.ts
+++ b/packages/create-invokta-engine/src/cli.ts
@@ -1,4 +1,8 @@
-import { CreatorError, renderCreatorDiagnostic } from "./errors.js";
+import {
+  CreatorError,
+  renderCreatorDiagnostic,
+  sanitizeDiagnosticDetail,
+} from "./errors.js";
 import {
   createExampleProject,
   type ExampleFetch,
@@ -252,7 +256,7 @@ function renderSuccess(
   noInstall: boolean,
 ): string {
   const commands = packageManagerCommands[packageManager];
-  const firstLine = `Created ${projectName} ${sourceLabel}.`;
+  const firstLine = `Created ${sanitizeDiagnosticDetail(projectName)} ${sanitizeDiagnosticDetail(sourceLabel)}.`;
   if (noInstall) {
     return (
       `${firstLine}\n\n` +

--- a/packages/create-invokta-engine/src/cli.ts
+++ b/packages/create-invokta-engine/src/cli.ts
@@ -1,4 +1,9 @@
 import { CreatorError, renderCreatorDiagnostic } from "./errors.js";
+import {
+  createExampleProject,
+  type ExampleFetch,
+  resolveExampleReference,
+} from "./example.js";
 import { installProjectDependencies, selectPackageManager } from "./install.js";
 import {
   isPackageManager,
@@ -7,6 +12,7 @@ import {
 } from "./package-manager.js";
 import { createBoundedPromptInput, promptInputLimits } from "./prompt.js";
 import {
+  assertCreatableStarterTarget,
   planStarterProject,
   validateStarterTargetSyntax,
   writeStarterProject,
@@ -19,6 +25,8 @@ import {
 const helpText = `Usage:
   create-invokta-engine [project-directory]
     [--profile complete|mcp-stdio|mcp-http|cli]
+    [--example <name|github-url>]
+    [--example-path <subdir>]
     [--package-manager npm|pnpm|yarn]
     [--no-install]
     [--yes]
@@ -101,11 +109,14 @@ export interface RunCreateEngineCliOptions {
   readonly terminal?: CreateEngineTerminal;
   readonly install?: InstallProject;
   readonly loadPackageVersion?: () => Promise<string>;
+  readonly fetch?: ExampleFetch;
 }
 
 interface CreateArguments {
   readonly target?: string;
   readonly profile?: EngineStarterProfile;
+  readonly example?: string;
+  readonly examplePath?: string;
   readonly packageManager?: PackageManager;
   readonly noInstall: boolean;
   readonly yes: boolean;
@@ -117,6 +128,10 @@ function parseCreateArguments(
   let target: string | undefined;
   let profile: EngineStarterProfile | undefined;
   let profileSeen = false;
+  let example: string | undefined;
+  let exampleSeen = false;
+  let examplePath: string | undefined;
+  let examplePathSeen = false;
   let packageManager: PackageManager | undefined;
   let packageManagerSeen = false;
   let noInstall = false;
@@ -145,6 +160,28 @@ function parseCreateArguments(
       index += 1;
       continue;
     }
+    if (argument === "--example") {
+      if (exampleSeen) return undefined;
+      exampleSeen = true;
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("-") || value === "") {
+        return undefined;
+      }
+      example = value;
+      index += 1;
+      continue;
+    }
+    if (argument === "--example-path") {
+      if (examplePathSeen) return undefined;
+      examplePathSeen = true;
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith("-") || value === "") {
+        return undefined;
+      }
+      examplePath = value;
+      index += 1;
+      continue;
+    }
     if (argument === "--package-manager") {
       if (packageManagerSeen) return undefined;
       packageManagerSeen = true;
@@ -165,9 +202,13 @@ function parseCreateArguments(
   }
 
   if (yes && target === undefined) return undefined;
+  if (examplePath !== undefined && example === undefined) return undefined;
+  if (example !== undefined && profile !== undefined) return undefined;
   return {
     ...(target === undefined ? {} : { target }),
     ...(profile === undefined ? {} : { profile }),
+    ...(example === undefined ? {} : { example }),
+    ...(examplePath === undefined ? {} : { examplePath }),
     ...(packageManager === undefined ? {} : { packageManager }),
     noInstall,
     yes,
@@ -206,12 +247,12 @@ async function writeDiagnostic(
 
 function renderSuccess(
   projectName: string,
-  profile: EngineStarterProfile,
+  sourceLabel: string,
   packageManager: PackageManager,
   noInstall: boolean,
 ): string {
   const commands = packageManagerCommands[packageManager];
-  const firstLine = `Created ${projectName} with the ${profileLabels[profile]} scaffold.`;
+  const firstLine = `Created ${projectName} ${sourceLabel}.`;
   if (noInstall) {
     return (
       `${firstLine}\n\n` +
@@ -312,7 +353,7 @@ function quoteTerminalValue(value: string): string {
   );
 }
 
-function renderConfirmation(
+function renderProfileConfirmation(
   profile: EngineStarterProfile,
   normalizedTarget: string,
   packageManager: PackageManager,
@@ -322,6 +363,18 @@ function renderConfirmation(
     ? "without installing dependencies"
     : `and install dependencies with ${packageManager}`;
   return `Create the ${profileLabels[profile]} scaffold in ${quoteTerminalValue(normalizedTarget)} ${installation}? (y/N) `;
+}
+
+function renderExampleConfirmation(
+  exampleLabel: string,
+  normalizedTarget: string,
+  packageManager: PackageManager,
+  noInstall: boolean,
+): string {
+  const installation = noInstall
+    ? "without installing dependencies"
+    : `and install dependencies with ${packageManager}`;
+  return `Create from GitHub example ${quoteTerminalValue(exampleLabel)} in ${quoteTerminalValue(normalizedTarget)} ${installation}? (y/N) `;
 }
 
 async function promptForConfirmation(
@@ -382,14 +435,66 @@ export async function runCreateEngineCli(
   const cwd = options.cwd ?? process.cwd();
   try {
     const target = parsed.target ?? (await promptForTarget(cwd, io, terminal));
-    const profile =
-      parsed.profile ??
-      (interactive ? await promptForProfile(io, terminal) : "complete");
     const environment = options.env ?? process.env;
     const packageManager = selectPackageManager(
       parsed.packageManager,
       environment.npm_config_user_agent,
     );
+
+    if (parsed.example !== undefined) {
+      const exampleInfo = await resolveExampleReference(
+        parsed.example,
+        parsed.examplePath,
+        options.fetch,
+      );
+      const targetMeta = await assertCreatableStarterTarget(cwd, target);
+
+      if (interactive) {
+        const confirmed = await promptForConfirmation(
+          io,
+          terminal,
+          renderExampleConfirmation(
+            exampleInfo.label,
+            targetMeta.normalizedTarget,
+            packageManager,
+            parsed.noInstall,
+          ),
+        );
+        if (!confirmed) {
+          await io.writeStdout(cancellationText);
+          return 0;
+        }
+      }
+
+      const project = await createExampleProject({
+        cwd,
+        target,
+        example: parsed.example,
+        ...(parsed.examplePath === undefined
+          ? {}
+          : { examplePath: parsed.examplePath }),
+        ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+      });
+      if (!parsed.noInstall) {
+        await (options.install ?? installProjectDependencies)({
+          directory: project.directory,
+          packageManager,
+        });
+      }
+      await io.writeStdout(
+        renderSuccess(
+          project.projectName,
+          `from example ${project.label}`,
+          packageManager,
+          parsed.noInstall,
+        ),
+      );
+      return 0;
+    }
+
+    const profile =
+      parsed.profile ??
+      (interactive ? await promptForProfile(io, terminal) : "complete");
     const invoktaVersion = await (
       options.loadPackageVersion ?? loadDefaultPackageVersion
     )();
@@ -405,7 +510,7 @@ export async function runCreateEngineCli(
       const confirmed = await promptForConfirmation(
         io,
         terminal,
-        renderConfirmation(
+        renderProfileConfirmation(
           profile,
           plan.normalizedTarget,
           packageManager,
@@ -428,7 +533,7 @@ export async function runCreateEngineCli(
     await io.writeStdout(
       renderSuccess(
         project.projectName,
-        profile,
+        `with the ${profileLabels[profile]} scaffold`,
         packageManager,
         parsed.noInstall,
       ),

--- a/packages/create-invokta-engine/src/cli.ts
+++ b/packages/create-invokta-engine/src/cli.ts
@@ -469,10 +469,7 @@ export async function runCreateEngineCli(
       const project = await createExampleProject({
         cwd,
         target,
-        example: parsed.example,
-        ...(parsed.examplePath === undefined
-          ? {}
-          : { examplePath: parsed.examplePath }),
+        example: exampleInfo,
         ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
       });
       if (!parsed.noInstall) {

--- a/packages/create-invokta-engine/src/errors.ts
+++ b/packages/create-invokta-engine/src/errors.ts
@@ -9,6 +9,9 @@ export const creatorErrorMessages = Object.freeze({
   SCAFFOLD_CONFLICT: "A scaffold file appeared during creation.",
   WRITE_FAILED: "The project scaffold could not be written.",
   INSTALL_FAILED: "The project dependencies could not be installed.",
+  EXAMPLE_INVALID: "The example reference is invalid.",
+  EXAMPLE_UNAVAILABLE: "The example could not be resolved or downloaded.",
+  EXAMPLE_FAILED: "The example project could not be created.",
 } as const);
 
 export type CreatorErrorCode = keyof typeof creatorErrorMessages;
@@ -24,6 +27,9 @@ const creatorErrorExitCodes = Object.freeze({
   SCAFFOLD_CONFLICT: 1,
   WRITE_FAILED: 1,
   INSTALL_FAILED: 1,
+  EXAMPLE_INVALID: 2,
+  EXAMPLE_UNAVAILABLE: 1,
+  EXAMPLE_FAILED: 1,
 } as const) satisfies Readonly<Record<CreatorErrorCode, CreatorExitCode>>;
 
 /** A sanitized creator failure. It intentionally stores no cause or raw input. */

--- a/packages/create-invokta-engine/src/errors.ts
+++ b/packages/create-invokta-engine/src/errors.ts
@@ -32,6 +32,25 @@ const creatorErrorExitCodes = Object.freeze({
   EXAMPLE_FAILED: 1,
 } as const) satisfies Readonly<Record<CreatorErrorCode, CreatorExitCode>>;
 
+const unsafeDiagnosticCharacterPattern = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu;
+
+function escapeDiagnosticCharacter(character: string): string {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) return "";
+  if (codePoint <= 0xffff) {
+    return `\\u${codePoint.toString(16).padStart(4, "0")}`;
+  }
+  return `\\u{${codePoint.toString(16)}}`;
+}
+
+/** Escapes terminal-active characters in diagnostic detail strings. */
+export function sanitizeDiagnosticDetail(detail: string): string {
+  return detail.replace(
+    unsafeDiagnosticCharacterPattern,
+    escapeDiagnosticCharacter,
+  );
+}
+
 /** A sanitized creator failure. It intentionally stores no cause or raw input. */
 export class CreatorError extends Error {
   readonly code: CreatorErrorCode;
@@ -43,7 +62,7 @@ export class CreatorError extends Error {
     this.name = "CreatorError";
     this.code = code;
     this.exitCode = creatorErrorExitCodes[code];
-    this.details = Object.freeze([...details]);
+    this.details = Object.freeze(details.map(sanitizeDiagnosticDetail));
   }
 }
 

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -561,10 +561,8 @@ async function ensureDirectory(
     return;
   } catch (error) {
     if (error instanceof CreatorError) throw error;
-    if (
-      readErrorCode(error) !== "ENOENT" &&
-      readErrorCode(error) !== "ENOTDIR"
-    ) {
+    // ENOTDIR means a non-directory path component already exists — unsafe.
+    if (readErrorCode(error) !== "ENOENT") {
       throw new CreatorError("TARGET_UNSAFE");
     }
   }

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -13,7 +13,7 @@ import { dirname, join, posix, relative, sep } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
-import { x as extractTar } from "tar";
+import { x as extractTar, Parser as TarParser } from "tar";
 
 import { CreatorError } from "./errors.js";
 import {
@@ -686,16 +686,17 @@ const regularFileEntryTypes = new Set([
   "",
 ]);
 
-/** Typeflags accepted during the raw header pre-scan. */
-const allowedTarTypeflags = new Set([
-  "0", // regular file
-  "\0", // historical regular file
-  "", // empty typeflag treated as file
-  "5", // directory
-  "7", // ContiguousFile (counted as a regular file)
-  "x", // PAX extended header
-  "g", // PAX global header
-  "D", // GNU directory
+const allowedPreScanEntryTypes = new Set([
+  "File",
+  "OldFile",
+  "ContiguousFile",
+  "Directory",
+  "GNUDumpDir",
+  "0",
+  "5",
+  "7",
+  "D",
+  "",
 ]);
 
 function entryIsRegularFile(entry: unknown): boolean {
@@ -719,150 +720,58 @@ function isUnsafeArchivePath(posixPath: string): boolean {
   return segments.some((segment) => segment === "..");
 }
 
-function readTarHeaderPath(header: Buffer): string {
-  const name = header.subarray(0, 100).toString("utf8").replace(/\0.*$/u, "");
-  const prefix = header
-    .subarray(345, 500)
-    .toString("utf8")
-    .replace(/\0.*$/u, "");
-  return prefix === "" ? name : `${prefix}/${name}`;
-}
-
-function readTarHeaderSize(header: Buffer): number {
-  const sizeOct = header
-    .subarray(124, 135)
-    .toString("utf8")
-    .replace(/\0.*$/u, "")
-    .trim();
-  if (sizeOct === "") return 0;
-  const size = Number.parseInt(sizeOct, 8);
-  return Number.isFinite(size) && size >= 0 ? size : Number.NaN;
-}
-
-function parsePaxSizeOverride(body: Buffer): number | undefined {
-  const text = body.toString("utf8");
-  let offset = 0;
-  while (offset < text.length) {
-    const space = text.indexOf(" ", offset);
-    if (space < 0) break;
-    const length = Number.parseInt(text.slice(offset, space), 10);
-    if (!Number.isFinite(length) || length <= 0) break;
-    if (offset + length > text.length) break;
-    const record = text.slice(offset, offset + length);
-    const separator = record.indexOf("=");
-    if (separator >= 0) {
-      const key = record.slice(space - offset + 1, separator);
-      const value = record.slice(separator + 1).replace(/\n$/u, "");
-      if (key === "size") {
-        const size = Number.parseInt(value, 10);
-        if (Number.isFinite(size) && size >= 0) return size;
-      }
-    }
-    offset += length;
-  }
-  return undefined;
-}
-
 /**
- * node-tar silently skips some unsupported typeflags before filter/onentry.
- * Scan raw ustar headers so SparseFile/symlink/device entries cannot bypass rejection.
- * PAX `size` overrides are applied so the scanner stays aligned with node-tar.
+ * node-tar silently skips unsupported typeflags (e.g. SparseFile) before
+ * filter/onentry. Parse with the same Parser so PAX/directory size semantics
+ * stay aligned, and fail closed on ignoredEntry plus any non-file/dir type.
  */
 async function assertArchiveHeadersSafe(archivePath: string): Promise<void> {
-  const gunzip = createGunzip();
-  const source = createReadStream(archivePath);
-  // Ignore late stream errors after we intentionally abort the scan.
-  gunzip.on("error", () => undefined);
-  source.on("error", () => undefined);
-  const stream = source.pipe(gunzip);
-  let buffer = Buffer.alloc(0);
-  let pendingData = 0;
-  let pendingKind: "skip" | "pax-x" | "pax-g" | undefined;
-  let pendingBodySize = 0;
-  let pendingChunks: Buffer[] = [];
-  let nextFileSizeOverride: number | undefined;
-  let globalSizeOverride: number | undefined;
+  let rejected = false;
+  await new Promise<void>((resolve, reject) => {
+    const source = createReadStream(archivePath);
+    const gunzip = createGunzip();
+    const parser = new TarParser();
+    let settled = false;
+    const settle = (error?: CreatorError): void => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error);
+      else resolve();
+    };
+    const settleFailed = (): void => {
+      settle(new CreatorError("EXAMPLE_FAILED"));
+    };
 
-  const finishPending = (): void => {
-    if (pendingKind === "pax-x" || pendingKind === "pax-g") {
-      const body = Buffer.concat(pendingChunks).subarray(0, pendingBodySize);
-      const override = parsePaxSizeOverride(body);
-      if (override !== undefined) {
-        if (pendingKind === "pax-g") globalSizeOverride = override;
-        else nextFileSizeOverride = override;
+    source.on("error", settleFailed);
+    gunzip.on("error", settleFailed);
+    parser.on("error", settleFailed);
+
+    parser.on("entry", (entry) => {
+      const type = readEntryType(entry) ?? "";
+      if (!allowedPreScanEntryTypes.has(type)) rejected = true;
+      else {
+        const entryPath = String((entry as { path?: unknown }).path ?? "")
+          .split(sep)
+          .join(posix.sep);
+        if (entryPath !== "" && isUnsafeArchivePath(entryPath)) {
+          rejected = true;
+        }
       }
-    }
-    pendingKind = undefined;
-    pendingBodySize = 0;
-    pendingChunks = [];
-  };
+      entry.resume();
+    });
 
-  const stopStreams = (): void => {
-    source.destroy();
-    gunzip.destroy();
-  };
+    parser.on("ignoredEntry", (entry) => {
+      rejected = true;
+      entry.resume();
+    });
 
-  try {
-    for await (const chunk of stream) {
-      buffer = Buffer.concat([buffer, chunk as Buffer]);
-      while (true) {
-        if (pendingData > 0) {
-          if (buffer.byteLength === 0) break;
-          const take = Math.min(pendingData, buffer.byteLength);
-          if (pendingKind === "pax-x" || pendingKind === "pax-g") {
-            pendingChunks.push(buffer.subarray(0, take));
-          }
-          buffer = buffer.subarray(take);
-          pendingData -= take;
-          if (pendingData === 0) finishPending();
-          continue;
-        }
-        if (buffer.byteLength < 512) break;
-        const header = buffer.subarray(0, 512);
-        buffer = buffer.subarray(512);
-        if (header.every((byte) => byte === 0)) continue;
-        const typeflag = String.fromCharCode(header[156] ?? 0);
-        if (!allowedTarTypeflags.has(typeflag)) failedExample();
-        const headerPath = readTarHeaderPath(header).split(sep).join(posix.sep);
-        if (
-          typeflag !== "x" &&
-          typeflag !== "g" &&
-          headerPath !== "" &&
-          isUnsafeArchivePath(headerPath)
-        ) {
-          failedExample();
-        }
-        const headerSize = readTarHeaderSize(header);
-        if (!Number.isFinite(headerSize)) failedExample();
+    parser.on("end", () => {
+      if (rejected) settleFailed();
+      else settle();
+    });
 
-        if (typeflag === "x" || typeflag === "g") {
-          pendingKind = typeflag === "x" ? "pax-x" : "pax-g";
-          pendingBodySize = headerSize;
-          pendingChunks = [];
-          pendingData = Math.ceil(headerSize / 512) * 512;
-          if (pendingData === 0) finishPending();
-          continue;
-        }
-
-        const effectiveSize =
-          nextFileSizeOverride ?? globalSizeOverride ?? headerSize;
-        nextFileSizeOverride = undefined;
-        if (!Number.isFinite(effectiveSize) || effectiveSize < 0) {
-          failedExample();
-        }
-        pendingKind = "skip";
-        pendingData = Math.ceil(effectiveSize / 512) * 512;
-        if (pendingData === 0) finishPending();
-      }
-    }
-    if (pendingData > 0) failedExample();
-  } catch (error) {
-    stopStreams();
-    if (error instanceof CreatorError) throw error;
-    failedExample();
-  } finally {
-    stopStreams();
-  }
+    source.pipe(gunzip).pipe(parser);
+  });
 }
 
 function rememberRetainedDirectories(

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -1,0 +1,672 @@
+import { createWriteStream } from "node:fs";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, posix, relative, sep } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { x as extractTar } from "tar";
+
+import { CreatorError } from "./errors.js";
+import {
+  assertCreatableStarterTarget,
+  defaultScaffoldFileSystem,
+  type ScaffoldFileSystem,
+} from "./scaffold.js";
+
+export const exampleLimits = Object.freeze({
+  maxExampleScalars: 2_048,
+  maxShortNameCharacters: 214,
+  maxShortNameSegments: 8,
+  maxExamplePathScalars: 1_024,
+  maxExamplePathSegments: 32,
+  fetchTimeoutMs: 60_000,
+  maxArchiveBytes: 52_428_800,
+  maxExtractedFiles: 10_000,
+  maxFileBytes: 5_242_880,
+});
+
+export const officialExampleSource = Object.freeze({
+  owner: "vinilana",
+  repository: "invokta",
+  branch: "main",
+  directory: "examples",
+});
+
+const shortNamePattern =
+  /^[a-z0-9]+(?:-[a-z0-9]+)*(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)*$/u;
+
+export interface ExampleRepoInfo {
+  readonly owner: string;
+  readonly repository: string;
+  readonly branch: string;
+  readonly filePath: string;
+  readonly label: string;
+}
+
+export type ExampleFetch = (
+  input: string,
+  init?: Readonly<{
+    method?: string;
+    signal?: AbortSignal;
+    redirect?: "error" | "follow" | "manual";
+  }>,
+) => Promise<Response>;
+
+export interface CreateExampleProjectOptions {
+  readonly cwd: string;
+  readonly target: string;
+  readonly example: string;
+  readonly examplePath?: string;
+  readonly fetch?: ExampleFetch;
+  readonly fileSystem?: ScaffoldFileSystem;
+}
+
+function countScalars(value: string): number {
+  let count = 0;
+  for (const _ of value) count += 1;
+  return count;
+}
+
+function readErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { readonly code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function invalidExample(): never {
+  throw new CreatorError("EXAMPLE_INVALID");
+}
+
+function unavailableExample(details: readonly string[] = []): never {
+  throw new CreatorError("EXAMPLE_UNAVAILABLE", details);
+}
+
+function failedExample(details: readonly string[] = []): never {
+  throw new CreatorError("EXAMPLE_FAILED", details);
+}
+
+function normalizeExamplePath(path: string): string {
+  if (
+    path === "" ||
+    path.includes("\u0000") ||
+    countScalars(path) > exampleLimits.maxExamplePathScalars
+  ) {
+    return invalidExample();
+  }
+  if (path.startsWith("/") || path.includes("\\")) return invalidExample();
+  const segments = path.split("/");
+  if (
+    segments.length === 0 ||
+    segments.length > exampleLimits.maxExamplePathSegments ||
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    )
+  ) {
+    return invalidExample();
+  }
+  return segments.join("/");
+}
+
+function exampleLabel(
+  owner: string,
+  repository: string,
+  filePath: string,
+): string {
+  return filePath === ""
+    ? `${owner}/${repository}`
+    : `${owner}/${repository}/${filePath}`;
+}
+
+function stripGitSuffix(repository: string): string {
+  return repository.endsWith(".git") ? repository.slice(0, -4) : repository;
+}
+
+function officialShortLabel(filePath: string): string | undefined {
+  const prefix = `${officialExampleSource.directory}/`;
+  if (!filePath.startsWith(prefix)) return undefined;
+  return filePath.slice(prefix.length);
+}
+
+function parseGithubUrl(
+  value: string,
+  examplePath: string | undefined,
+): ExampleRepoInfo | undefined {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    return undefined;
+  }
+  if (url.hostname !== "github.com") return undefined;
+  const segments = url.pathname.split("/").filter((segment) => segment !== "");
+  if (segments.length < 2) return undefined;
+  const [owner, rawRepository, treeToken, ...rest] = segments;
+  if (owner === undefined || rawRepository === undefined) return undefined;
+  const repository = stripGitSuffix(rawRepository);
+  if (owner === "" || repository === "") return undefined;
+  const overridePath =
+    examplePath === undefined ? undefined : normalizeExamplePath(examplePath);
+
+  if (treeToken === undefined) {
+    return Object.freeze({
+      owner,
+      repository,
+      branch: "",
+      filePath: overridePath ?? "",
+      label: exampleLabel(owner, repository, overridePath ?? ""),
+    });
+  }
+
+  if (treeToken !== "tree" || rest.length === 0) return undefined;
+  const [branch, ...pathSegments] = rest;
+  if (branch === undefined || branch === "") return undefined;
+  const urlPath = pathSegments.join("/");
+  const filePath =
+    overridePath ?? (urlPath === "" ? "" : normalizeExamplePath(urlPath));
+  const shortLabel =
+    owner === officialExampleSource.owner &&
+    repository === officialExampleSource.repository
+      ? officialShortLabel(filePath)
+      : undefined;
+  return Object.freeze({
+    owner,
+    repository,
+    branch,
+    filePath,
+    label: shortLabel ?? exampleLabel(owner, repository, filePath),
+  });
+}
+
+function parseOfficialShortName(
+  value: string,
+  examplePath: string | undefined,
+): ExampleRepoInfo | undefined {
+  if (!shortNamePattern.test(value)) return undefined;
+  if (
+    value.length > exampleLimits.maxShortNameCharacters ||
+    value.split("/").length > exampleLimits.maxShortNameSegments
+  ) {
+    return undefined;
+  }
+  const nestedPath =
+    examplePath === undefined ? undefined : normalizeExamplePath(examplePath);
+  const filePath =
+    nestedPath === undefined
+      ? `${officialExampleSource.directory}/${value}`
+      : `${officialExampleSource.directory}/${value}/${nestedPath}`;
+  return Object.freeze({
+    owner: officialExampleSource.owner,
+    repository: officialExampleSource.repository,
+    branch: officialExampleSource.branch,
+    filePath,
+    label: value,
+  });
+}
+
+/** Parses a local example reference without performing network I/O. */
+export function parseExampleReference(
+  example: string,
+  examplePath?: string,
+): ExampleRepoInfo {
+  if (
+    example === "" ||
+    example.includes("\u0000") ||
+    countScalars(example) > exampleLimits.maxExampleScalars
+  ) {
+    return invalidExample();
+  }
+  if (example.startsWith("https://") || example.startsWith("http://")) {
+    const parsed = parseGithubUrl(example, examplePath);
+    if (parsed === undefined) return invalidExample();
+    return parsed;
+  }
+  if (example.includes("://") || example.includes("@")) return invalidExample();
+  const parsed = parseOfficialShortName(example, examplePath);
+  if (parsed === undefined) return invalidExample();
+  return parsed;
+}
+
+async function fetchJson(
+  fetchImpl: ExampleFetch,
+  url: string,
+): Promise<Readonly<Record<string, unknown>>> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    exampleLimits.fetchTimeoutMs,
+  );
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    if (!response.ok) return unavailableExample();
+    const payload: unknown = await response.json();
+    if (typeof payload !== "object" || payload === null) {
+      return unavailableExample();
+    }
+    return payload as Readonly<Record<string, unknown>>;
+  } catch (error) {
+    if (error instanceof CreatorError) throw error;
+    return unavailableExample();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function headOk(fetchImpl: ExampleFetch, url: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    exampleLimits.fetchTimeoutMs,
+  );
+  try {
+    const response = await fetchImpl(url, {
+      method: "HEAD",
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Resolves branch metadata and verifies package.json without writing files. */
+export async function resolveExampleReference(
+  example: string,
+  examplePath: string | undefined,
+  fetchImpl: ExampleFetch = fetch,
+): Promise<ExampleRepoInfo> {
+  const parsed = parseExampleReference(example, examplePath);
+  let branch = parsed.branch;
+  if (branch === "") {
+    const info = await fetchJson(
+      fetchImpl,
+      `https://api.github.com/repos/${parsed.owner}/${parsed.repository}`,
+    );
+    const defaultBranch = info.default_branch;
+    if (typeof defaultBranch !== "string" || defaultBranch === "") {
+      return unavailableExample();
+    }
+    branch = defaultBranch;
+  }
+
+  const packagePath =
+    parsed.filePath === "" ? "package.json" : `${parsed.filePath}/package.json`;
+  const packageUrl =
+    `https://api.github.com/repos/${parsed.owner}/${parsed.repository}/contents/` +
+    `${packagePath.split("/").map(encodeURIComponent).join("/")}?ref=${encodeURIComponent(branch)}`;
+  const exists = await headOk(fetchImpl, packageUrl);
+  if (!exists) return unavailableExample(["package.json"]);
+
+  return Object.freeze({
+    ...parsed,
+    branch,
+  });
+}
+
+function rewritePackageName(contents: string, projectName: string): string {
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(contents) as unknown;
+  } catch {
+    return failedExample(["package.json"]);
+  }
+  if (
+    typeof manifest !== "object" ||
+    manifest === null ||
+    Array.isArray(manifest)
+  ) {
+    return failedExample(["package.json"]);
+  }
+  const next = {
+    ...(manifest as Record<string, unknown>),
+    name: projectName,
+  };
+  return `${JSON.stringify(next, undefined, 2)}\n`;
+}
+
+async function downloadToFile(
+  fetchImpl: ExampleFetch,
+  url: string,
+  destination: string,
+): Promise<void> {
+  let requested: URL;
+  try {
+    requested = new URL(url);
+  } catch {
+    return unavailableExample();
+  }
+  if (requested.hostname !== "codeload.github.com") return unavailableExample();
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    exampleLimits.fetchTimeoutMs,
+  );
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      signal: controller.signal,
+      redirect: "error",
+    });
+    if (!response.ok || response.body === null) return unavailableExample();
+    let total = 0;
+    const limiter = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        total += chunk.byteLength;
+        if (total > exampleLimits.maxArchiveBytes) {
+          controller.error(new CreatorError("EXAMPLE_UNAVAILABLE"));
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    });
+    await pipeline(
+      Readable.fromWeb(response.body.pipeThrough(limiter)),
+      createWriteStream(destination),
+    );
+  } catch (error) {
+    if (error instanceof CreatorError) throw error;
+    return unavailableExample();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function listRegularFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  async function walk(directory: string): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolute = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+        continue;
+      }
+      if (!entry.isFile()) failedExample();
+      files.push(absolute);
+      if (files.length > exampleLimits.maxExtractedFiles) failedExample();
+    }
+  }
+  await walk(root);
+  return files.sort();
+}
+
+async function rollbackCreated(
+  fileSystem: ScaffoldFileSystem,
+  createdEntries: readonly string[],
+  createdDirectories: readonly string[],
+): Promise<boolean> {
+  let failed = false;
+  for (const path of [...createdEntries].reverse()) {
+    try {
+      await fileSystem.unlink(path);
+    } catch (error) {
+      if (readErrorCode(error) !== "ENOENT") failed = true;
+    }
+  }
+  for (const path of [...createdDirectories].reverse()) {
+    try {
+      await fileSystem.rmdir(path);
+    } catch (error) {
+      const code = readErrorCode(error);
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") failed = true;
+    }
+  }
+  return !failed;
+}
+
+async function ensureDirectory(
+  path: string,
+  fileSystem: ScaffoldFileSystem,
+  createdDirectories: string[],
+): Promise<void> {
+  try {
+    const status = await fileSystem.lstat(path);
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+    return;
+  } catch (error) {
+    if (error instanceof CreatorError) throw error;
+    if (
+      readErrorCode(error) !== "ENOENT" &&
+      readErrorCode(error) !== "ENOTDIR"
+    ) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  }
+  try {
+    await fileSystem.mkdir(path);
+    createdDirectories.push(path);
+  } catch (error) {
+    if (readErrorCode(error) !== "EEXIST") {
+      throw new CreatorError("EXAMPLE_FAILED");
+    }
+    const status = await fileSystem.lstat(path);
+    if (status.isSymbolicLink() || !status.isDirectory()) {
+      throw new CreatorError("TARGET_UNSAFE");
+    }
+  }
+}
+
+async function copyExtractedProject(options: {
+  readonly stagingDirectory: string;
+  readonly targetDirectory: string;
+  readonly cwd: string;
+  readonly normalizedTarget: string;
+  readonly projectName: string;
+  readonly fileSystem: ScaffoldFileSystem;
+}): Promise<readonly string[]> {
+  const {
+    stagingDirectory,
+    targetDirectory,
+    cwd,
+    normalizedTarget,
+    projectName,
+    fileSystem,
+  } = options;
+  const targetSegments =
+    normalizedTarget === "." ? [] : normalizedTarget.split("/");
+  const createdEntries: string[] = [];
+  const createdDirectories: string[] = [];
+  let activeRelative: string | undefined;
+
+  try {
+    let current = cwd;
+    for (const segment of targetSegments) {
+      current = join(current, segment);
+      await ensureDirectory(current, fileSystem, createdDirectories);
+    }
+
+    const absoluteFiles = await listRegularFiles(stagingDirectory);
+    const writtenRelative: string[] = [];
+    for (const absolute of absoluteFiles) {
+      const relativePath = relative(stagingDirectory, absolute)
+        .split(sep)
+        .join("/");
+      activeRelative = relativePath;
+      if (
+        relativePath === "" ||
+        relativePath
+          .split("/")
+          .some((segment) => segment === ".." || segment === "")
+      ) {
+        failedExample();
+      }
+      const status = await stat(absolute);
+      if (status.size > exampleLimits.maxFileBytes) {
+        failedExample([relativePath]);
+      }
+
+      let contents = await readFile(absolute);
+      if (relativePath === "package.json") {
+        contents = Buffer.from(
+          rewritePackageName(contents.toString("utf8"), projectName),
+          "utf8",
+        );
+      }
+
+      const destination = join(targetDirectory, ...relativePath.split("/"));
+      const parentRelative = dirname(relativePath);
+      if (parentRelative !== ".") {
+        let nested = targetDirectory;
+        for (const segment of parentRelative.split("/")) {
+          nested = join(nested, segment);
+          await ensureDirectory(nested, fileSystem, createdDirectories);
+        }
+      }
+      await writeFile(destination, contents, { flag: "wx" });
+      createdEntries.push(destination);
+      writtenRelative.push(relativePath);
+    }
+    return Object.freeze(writtenRelative.sort());
+  } catch (error) {
+    const rolledBack = await rollbackCreated(
+      fileSystem,
+      createdEntries,
+      createdDirectories,
+    );
+    if (!rolledBack) {
+      failedExample(activeRelative === undefined ? [] : [activeRelative]);
+    }
+    if (error instanceof CreatorError) throw error;
+    if (readErrorCode(error) === "EEXIST") {
+      throw new CreatorError(
+        "SCAFFOLD_CONFLICT",
+        activeRelative === undefined ? [] : [activeRelative],
+      );
+    }
+    failedExample(activeRelative === undefined ? [] : [activeRelative]);
+  }
+}
+
+async function extractRepository(
+  archivePath: string,
+  stagingDirectory: string,
+  info: ExampleRepoInfo,
+): Promise<void> {
+  let rootPath: string | null = null;
+  const prefix =
+    info.filePath === ""
+      ? []
+      : info.filePath.split("/").filter((segment) => segment !== "");
+  try {
+    await extractTar({
+      file: archivePath,
+      cwd: stagingDirectory,
+      strict: true,
+      preservePaths: false,
+      onentry(entry) {
+        const posixPath = entry.path.split(sep).join(posix.sep);
+        if (
+          entry.type === "SymbolicLink" ||
+          entry.type === "Link" ||
+          posixPath.includes("\u0000") ||
+          posixPath.split(posix.sep).some((segment) => segment === "..")
+        ) {
+          entry.resume();
+          throw new CreatorError("EXAMPLE_FAILED");
+        }
+        if (rootPath === null) {
+          rootPath = posixPath.split(posix.sep)[0] ?? null;
+        }
+      },
+      filter(path) {
+        const posixPath = path.split(sep).join(posix.sep);
+        if (rootPath === null) {
+          rootPath = posixPath.split(posix.sep)[0] ?? null;
+        }
+        if (rootPath === null) return false;
+        if (prefix.length === 0) {
+          return posixPath === rootPath || posixPath.startsWith(`${rootPath}/`);
+        }
+        const wanted = `${rootPath}/${prefix.join("/")}`;
+        return posixPath === wanted || posixPath.startsWith(`${wanted}/`);
+      },
+      strip: prefix.length === 0 ? 1 : prefix.length + 1,
+    });
+  } catch (error) {
+    if (error instanceof CreatorError) throw error;
+    failedExample();
+  }
+}
+
+export interface ExampleProject {
+  readonly directory: string;
+  readonly projectName: string;
+  readonly label: string;
+  readonly files: readonly string[];
+}
+
+/** Downloads, extracts, and writes one GitHub example into an empty target. */
+export async function createExampleProject(
+  options: CreateExampleProjectOptions,
+): Promise<ExampleProject> {
+  const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
+  const fetchImpl = options.fetch ?? fetch;
+  const target = await assertCreatableStarterTarget(
+    options.cwd,
+    options.target,
+    fileSystem,
+  );
+  const info = await resolveExampleReference(
+    options.example,
+    options.examplePath,
+    fetchImpl,
+  );
+
+  const stagingRoot = await mkdtemp(join(tmpdir(), "invokta-example-"));
+  const archivePath = join(stagingRoot, "repository.tar.gz");
+  const extractDirectory = join(stagingRoot, "extract");
+  await mkdir(extractDirectory);
+
+  try {
+    await downloadToFile(
+      fetchImpl,
+      `https://codeload.github.com/${info.owner}/${info.repository}/tar.gz/${info.branch}`,
+      archivePath,
+    );
+    await extractRepository(archivePath, extractDirectory, info);
+
+    try {
+      await stat(join(extractDirectory, "package.json"));
+    } catch {
+      unavailableExample(["package.json"]);
+    }
+
+    const files = await copyExtractedProject({
+      stagingDirectory: extractDirectory,
+      targetDirectory: target.directory,
+      cwd: options.cwd,
+      normalizedTarget: target.normalizedTarget,
+      projectName: target.projectName,
+      fileSystem,
+    });
+
+    return Object.freeze({
+      directory: target.directory,
+      projectName: target.projectName,
+      label: info.label,
+      files,
+    });
+  } finally {
+    await rm(stagingRoot, { recursive: true, force: true });
+  }
+}

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -1,4 +1,4 @@
-import { createWriteStream } from "node:fs";
+import { createReadStream, createWriteStream } from "node:fs";
 import {
   mkdir,
   mkdtemp,
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, posix, relative, sep } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 import { x as extractTar } from "tar";
 
 import { CreatorError } from "./errors.js";
@@ -685,14 +686,26 @@ const regularFileEntryTypes = new Set([
   "",
 ]);
 
+/** Typeflags accepted during the raw header pre-scan. */
+const allowedTarTypeflags = new Set([
+  "0", // regular file
+  "\0", // historical regular file
+  "", // empty typeflag treated as file
+  "5", // directory
+  "7", // ContiguousFile (counted as a regular file)
+  "x", // PAX extended header
+  "g", // PAX global header
+  "D", // GNU directory
+]);
+
 function entryIsRegularFile(entry: unknown): boolean {
   const type = readEntryType(entry);
-  return type === undefined || regularFileEntryTypes.has(type);
+  return type !== undefined && regularFileEntryTypes.has(type);
 }
 
 function entryIsDirectory(entry: unknown): boolean {
   const type = readEntryType(entry);
-  return type === "Directory" || type === "5";
+  return type === "Directory" || type === "5" || type === "D";
 }
 
 function isUnsafeArchivePath(posixPath: string): boolean {
@@ -706,21 +719,109 @@ function isUnsafeArchivePath(posixPath: string): boolean {
   return segments.some((segment) => segment === "..");
 }
 
+function readTarHeaderPath(header: Buffer): string {
+  const name = header.subarray(0, 100).toString("utf8").replace(/\0.*$/u, "");
+  const prefix = header
+    .subarray(345, 500)
+    .toString("utf8")
+    .replace(/\0.*$/u, "");
+  return prefix === "" ? name : `${prefix}/${name}`;
+}
+
+function readTarHeaderSize(header: Buffer): number {
+  const sizeOct = header
+    .subarray(124, 135)
+    .toString("utf8")
+    .replace(/\0.*$/u, "")
+    .trim();
+  if (sizeOct === "") return 0;
+  const size = Number.parseInt(sizeOct, 8);
+  return Number.isFinite(size) && size >= 0 ? size : Number.NaN;
+}
+
+/**
+ * node-tar silently skips some unsupported typeflags before filter/onentry.
+ * Scan raw ustar headers so SparseFile/symlink/device entries cannot bypass rejection.
+ */
+async function assertArchiveHeadersSafe(archivePath: string): Promise<void> {
+  const gunzip = createGunzip();
+  const source = createReadStream(archivePath);
+  const stream = source.pipe(gunzip);
+  let buffer = Buffer.alloc(0);
+  let pendingData = 0;
+  try {
+    for await (const chunk of stream) {
+      buffer = Buffer.concat([buffer, chunk as Buffer]);
+      while (true) {
+        if (pendingData > 0) {
+          if (buffer.byteLength === 0) break;
+          const take = Math.min(pendingData, buffer.byteLength);
+          buffer = buffer.subarray(take);
+          pendingData -= take;
+          continue;
+        }
+        if (buffer.byteLength < 512) break;
+        const header = buffer.subarray(0, 512);
+        buffer = buffer.subarray(512);
+        if (header.every((byte) => byte === 0)) continue;
+        const typeflag = String.fromCharCode(header[156] ?? 0);
+        if (!allowedTarTypeflags.has(typeflag)) failedExample();
+        const headerPath = readTarHeaderPath(header).split(sep).join(posix.sep);
+        if (headerPath !== "" && isUnsafeArchivePath(headerPath)) {
+          failedExample();
+        }
+        const size = readTarHeaderSize(header);
+        if (!Number.isFinite(size)) failedExample();
+        pendingData = Math.ceil(size / 512) * 512;
+      }
+    }
+  } catch (error) {
+    if (error instanceof CreatorError) throw error;
+    failedExample();
+  }
+}
+
+function rememberRetainedDirectories(
+  posixPath: string,
+  stripCount: number,
+  isDirectory: boolean,
+  retainedDirectories: Set<string>,
+  maxDirectories: number,
+): boolean {
+  const segments = posixPath
+    .split(posix.sep)
+    .filter((segment) => segment !== "");
+  const retained = segments.slice(stripCount);
+  if (retained.length === 0) return true;
+  const directoryParts = isDirectory ? retained : retained.slice(0, -1);
+  let current = "";
+  for (const part of directoryParts) {
+    current = current === "" ? part : `${current}/${part}`;
+    if (retainedDirectories.has(current)) continue;
+    retainedDirectories.add(current);
+    if (retainedDirectories.size > maxDirectories) return false;
+  }
+  return true;
+}
+
 async function extractRepository(
   archivePath: string,
   stagingDirectory: string,
   info: ExampleRepoInfo,
   limits: ExampleRuntimeLimits,
 ): Promise<void> {
+  await assertArchiveHeadersSafe(archivePath);
+
   let rootPath: string | null = null;
   let rejected = false;
   let uncompressedBytes = 0;
   let fileCount = 0;
-  let directoryCount = 0;
+  const retainedDirectories = new Set<string>();
   const prefix =
     info.filePath === ""
       ? []
       : info.filePath.split("/").filter((segment) => segment !== "");
+  const stripCount = prefix.length === 0 ? 1 : prefix.length + 1;
 
   const markRejected = (): void => {
     rejected = true;
@@ -743,15 +844,7 @@ async function extractRepository(
           entry.resume();
           return;
         }
-        const entryType = readEntryType(entry);
-        if (
-          !(
-            entryIsDirectory(entry) ||
-            entryIsRegularFile(entry) ||
-            // Root directory markers may arrive before classification settles.
-            entryType === undefined
-          )
-        ) {
+        if (!(entryIsDirectory(entry) || entryIsRegularFile(entry))) {
           markRejected();
           entry.resume();
           return;
@@ -784,13 +877,17 @@ async function extractRepository(
         if (!inSubtree) return false;
 
         if (entryIsDirectory(entry)) {
-          // The archive root directory is stripped; count retained dirs only.
-          if (posixPath !== rootPath) {
-            directoryCount += 1;
-            if (directoryCount > limits.maxExtractedDirectories) {
-              markRejected();
-              return false;
-            }
+          if (
+            !rememberRetainedDirectories(
+              posixPath,
+              stripCount,
+              true,
+              retainedDirectories,
+              limits.maxExtractedDirectories,
+            )
+          ) {
+            markRejected();
+            return false;
           }
           return true;
         }
@@ -811,14 +908,25 @@ async function extractRepository(
             markRejected();
             return false;
           }
+          if (
+            !rememberRetainedDirectories(
+              posixPath,
+              stripCount,
+              false,
+              retainedDirectories,
+              limits.maxExtractedDirectories,
+            )
+          ) {
+            markRejected();
+            return false;
+          }
           return true;
         }
 
-        // Symbolic links, hard links, devices, FIFOs, and unknown types.
         markRejected();
         return false;
       },
-      strip: prefix.length === 0 ? 1 : prefix.length + 1,
+      strip: stripCount,
     });
   } catch (error) {
     if (error instanceof CreatorError) throw error;

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -18,7 +18,6 @@ import { CreatorError } from "./errors.js";
 import {
   assertCreatableStarterTarget,
   defaultScaffoldFileSystem,
-  type ScaffoldFileSystem,
 } from "./scaffold.js";
 
 export const exampleLimits = Object.freeze({
@@ -28,10 +27,21 @@ export const exampleLimits = Object.freeze({
   maxExamplePathScalars: 1_024,
   maxExamplePathSegments: 32,
   fetchTimeoutMs: 60_000,
+  /** Uncompressed retained bytes across extracted regular files. */
   maxArchiveBytes: 52_428_800,
+  /** Compressed download bytes from codeload.github.com. */
+  maxCompressedArchiveBytes: 52_428_800,
   maxExtractedFiles: 10_000,
   maxFileBytes: 5_242_880,
 });
+
+export type ExampleRuntimeLimits = Readonly<{
+  maxArchiveBytes: number;
+  maxCompressedArchiveBytes: number;
+  maxExtractedFiles: number;
+  maxFileBytes: number;
+  fetchTimeoutMs: number;
+}>;
 
 export const officialExampleSource = Object.freeze({
   owner: "vinilana",
@@ -42,6 +52,9 @@ export const officialExampleSource = Object.freeze({
 
 const shortNamePattern =
   /^[a-z0-9]+(?:-[a-z0-9]+)*(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)*$/u;
+const githubOwnerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/u;
+const githubRepositoryPattern = /^[A-Za-z0-9._-]{1,100}$/u;
+const githubBranchPattern = /^[^\0\n\r]+$/u;
 
 export interface ExampleRepoInfo {
   readonly owner: string;
@@ -63,10 +76,11 @@ export type ExampleFetch = (
 export interface CreateExampleProjectOptions {
   readonly cwd: string;
   readonly target: string;
-  readonly example: string;
-  readonly examplePath?: string;
+  /** Already-resolved example metadata; callers resolve exactly once. */
+  readonly example: ExampleRepoInfo;
   readonly fetch?: ExampleFetch;
-  readonly fileSystem?: ScaffoldFileSystem;
+  /** Optional limit overrides for focused tests. */
+  readonly limits?: Partial<ExampleRuntimeLimits>;
 }
 
 function countScalars(value: string): number {
@@ -129,6 +143,44 @@ function stripGitSuffix(repository: string): string {
   return repository.endsWith(".git") ? repository.slice(0, -4) : repository;
 }
 
+function decodeGithubSegment(segment: string): string | undefined {
+  let decoded = segment;
+  if (segment.includes("%")) {
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      return undefined;
+    }
+  }
+  if (
+    decoded === "" ||
+    decoded.includes("/") ||
+    decoded.includes("\\") ||
+    decoded.includes("\u0000") ||
+    decoded.includes("%")
+  ) {
+    return undefined;
+  }
+  return decoded;
+}
+
+function isValidGithubOwner(owner: string): boolean {
+  return githubOwnerPattern.test(owner);
+}
+
+function isValidGithubRepository(repository: string): boolean {
+  return githubRepositoryPattern.test(repository);
+}
+
+function isValidGithubBranch(branch: string): boolean {
+  return (
+    branch !== "" &&
+    !branch.includes("\u0000") &&
+    githubBranchPattern.test(branch) &&
+    !branch.split("/").some((segment) => segment === "" || segment === "..")
+  );
+}
+
 function officialShortLabel(filePath: string): string | undefined {
   const prefix = `${officialExampleSource.directory}/`;
   if (!filePath.startsWith(prefix)) return undefined;
@@ -151,10 +203,18 @@ function parseGithubUrl(
   if (url.hostname !== "github.com") return undefined;
   const segments = url.pathname.split("/").filter((segment) => segment !== "");
   if (segments.length < 2) return undefined;
-  const [owner, rawRepository, treeToken, ...rest] = segments;
-  if (owner === undefined || rawRepository === undefined) return undefined;
-  const repository = stripGitSuffix(rawRepository);
-  if (owner === "" || repository === "") return undefined;
+  const [rawOwner, rawRepository, treeToken, ...rest] = segments;
+  if (rawOwner === undefined || rawRepository === undefined) return undefined;
+  const owner = decodeGithubSegment(rawOwner);
+  const repository = decodeGithubSegment(stripGitSuffix(rawRepository));
+  if (
+    owner === undefined ||
+    repository === undefined ||
+    !isValidGithubOwner(owner) ||
+    !isValidGithubRepository(repository)
+  ) {
+    return undefined;
+  }
   const overridePath =
     examplePath === undefined ? undefined : normalizeExamplePath(examplePath);
 
@@ -169,11 +229,23 @@ function parseGithubUrl(
   }
 
   if (treeToken !== "tree" || rest.length === 0) return undefined;
-  const [branch, ...pathSegments] = rest;
-  if (branch === undefined || branch === "") return undefined;
-  const urlPath = pathSegments.join("/");
+  const [rawBranch, ...pathSegments] = rest;
+  if (rawBranch === undefined) return undefined;
+  const branch = decodeGithubSegment(rawBranch);
+  if (branch === undefined || !isValidGithubBranch(branch)) return undefined;
+  const urlPath = pathSegments
+    .map((segment) => decodeGithubSegment(segment))
+    .every((segment) => segment !== undefined)
+    ? pathSegments
+        .map((segment) => decodeGithubSegment(segment) as string)
+        .join("/")
+    : undefined;
+  if (urlPath === undefined && pathSegments.length > 0) return undefined;
   const filePath =
-    overridePath ?? (urlPath === "" ? "" : normalizeExamplePath(urlPath));
+    overridePath ??
+    (urlPath === undefined || urlPath === ""
+      ? ""
+      : normalizeExamplePath(urlPath));
   const shortLabel =
     owner === officialExampleSource.owner &&
     repository === officialExampleSource.repository
@@ -237,20 +309,34 @@ export function parseExampleReference(
   return parsed;
 }
 
+function resolveRuntimeLimits(
+  overrides: Partial<ExampleRuntimeLimits> | undefined,
+): ExampleRuntimeLimits {
+  return Object.freeze({
+    maxArchiveBytes:
+      overrides?.maxArchiveBytes ?? exampleLimits.maxArchiveBytes,
+    maxCompressedArchiveBytes:
+      overrides?.maxCompressedArchiveBytes ??
+      exampleLimits.maxCompressedArchiveBytes,
+    maxExtractedFiles:
+      overrides?.maxExtractedFiles ?? exampleLimits.maxExtractedFiles,
+    maxFileBytes: overrides?.maxFileBytes ?? exampleLimits.maxFileBytes,
+    fetchTimeoutMs: overrides?.fetchTimeoutMs ?? exampleLimits.fetchTimeoutMs,
+  });
+}
+
 async function fetchJson(
   fetchImpl: ExampleFetch,
   url: string,
+  timeoutMs: number,
 ): Promise<Readonly<Record<string, unknown>>> {
   const controller = new AbortController();
-  const timer = setTimeout(
-    () => controller.abort(),
-    exampleLimits.fetchTimeoutMs,
-  );
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetchImpl(url, {
       method: "GET",
       signal: controller.signal,
-      redirect: "follow",
+      redirect: "error",
     });
     if (!response.ok) return unavailableExample();
     const payload: unknown = await response.json();
@@ -266,17 +352,18 @@ async function fetchJson(
   }
 }
 
-async function headOk(fetchImpl: ExampleFetch, url: string): Promise<boolean> {
+async function headOk(
+  fetchImpl: ExampleFetch,
+  url: string,
+  timeoutMs: number,
+): Promise<boolean> {
   const controller = new AbortController();
-  const timer = setTimeout(
-    () => controller.abort(),
-    exampleLimits.fetchTimeoutMs,
-  );
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetchImpl(url, {
       method: "HEAD",
       signal: controller.signal,
-      redirect: "follow",
+      redirect: "error",
     });
     return response.ok;
   } catch {
@@ -291,27 +378,31 @@ export async function resolveExampleReference(
   example: string,
   examplePath: string | undefined,
   fetchImpl: ExampleFetch = fetch,
+  limits?: Partial<ExampleRuntimeLimits>,
 ): Promise<ExampleRepoInfo> {
+  const runtime = resolveRuntimeLimits(limits);
   const parsed = parseExampleReference(example, examplePath);
   let branch = parsed.branch;
   if (branch === "") {
     const info = await fetchJson(
       fetchImpl,
-      `https://api.github.com/repos/${parsed.owner}/${parsed.repository}`,
+      `https://api.github.com/repos/${encodeURIComponent(parsed.owner)}/${encodeURIComponent(parsed.repository)}`,
+      runtime.fetchTimeoutMs,
     );
     const defaultBranch = info.default_branch;
     if (typeof defaultBranch !== "string" || defaultBranch === "") {
       return unavailableExample();
     }
+    if (!isValidGithubBranch(defaultBranch)) return unavailableExample();
     branch = defaultBranch;
   }
 
   const packagePath =
     parsed.filePath === "" ? "package.json" : `${parsed.filePath}/package.json`;
   const packageUrl =
-    `https://api.github.com/repos/${parsed.owner}/${parsed.repository}/contents/` +
+    `https://api.github.com/repos/${encodeURIComponent(parsed.owner)}/${encodeURIComponent(parsed.repository)}/contents/` +
     `${packagePath.split("/").map(encodeURIComponent).join("/")}?ref=${encodeURIComponent(branch)}`;
-  const exists = await headOk(fetchImpl, packageUrl);
+  const exists = await headOk(fetchImpl, packageUrl, runtime.fetchTimeoutMs);
   if (!exists) return unavailableExample(["package.json"]);
 
   return Object.freeze({
@@ -345,6 +436,7 @@ async function downloadToFile(
   fetchImpl: ExampleFetch,
   url: string,
   destination: string,
+  limits: ExampleRuntimeLimits,
 ): Promise<void> {
   let requested: URL;
   try {
@@ -355,10 +447,7 @@ async function downloadToFile(
   if (requested.hostname !== "codeload.github.com") return unavailableExample();
 
   const controller = new AbortController();
-  const timer = setTimeout(
-    () => controller.abort(),
-    exampleLimits.fetchTimeoutMs,
-  );
+  const timer = setTimeout(() => controller.abort(), limits.fetchTimeoutMs);
   try {
     const response = await fetchImpl(url, {
       method: "GET",
@@ -370,7 +459,7 @@ async function downloadToFile(
     const limiter = new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
         total += chunk.byteLength;
-        if (total > exampleLimits.maxArchiveBytes) {
+        if (total > limits.maxCompressedArchiveBytes) {
           controller.error(new CreatorError("EXAMPLE_UNAVAILABLE"));
           return;
         }
@@ -401,7 +490,6 @@ async function listRegularFiles(root: string): Promise<string[]> {
       }
       if (!entry.isFile()) failedExample();
       files.push(absolute);
-      if (files.length > exampleLimits.maxExtractedFiles) failedExample();
     }
   }
   await walk(root);
@@ -409,10 +497,10 @@ async function listRegularFiles(root: string): Promise<string[]> {
 }
 
 async function rollbackCreated(
-  fileSystem: ScaffoldFileSystem,
   createdEntries: readonly string[],
   createdDirectories: readonly string[],
 ): Promise<boolean> {
+  const fileSystem = defaultScaffoldFileSystem;
   let failed = false;
   for (const path of [...createdEntries].reverse()) {
     try {
@@ -434,9 +522,9 @@ async function rollbackCreated(
 
 async function ensureDirectory(
   path: string,
-  fileSystem: ScaffoldFileSystem,
   createdDirectories: string[],
 ): Promise<void> {
+  const fileSystem = defaultScaffoldFileSystem;
   try {
     const status = await fileSystem.lstat(path);
     if (status.isSymbolicLink() || !status.isDirectory()) {
@@ -472,7 +560,6 @@ async function copyExtractedProject(options: {
   readonly cwd: string;
   readonly normalizedTarget: string;
   readonly projectName: string;
-  readonly fileSystem: ScaffoldFileSystem;
 }): Promise<readonly string[]> {
   const {
     stagingDirectory,
@@ -480,7 +567,6 @@ async function copyExtractedProject(options: {
     cwd,
     normalizedTarget,
     projectName,
-    fileSystem,
   } = options;
   const targetSegments =
     normalizedTarget === "." ? [] : normalizedTarget.split("/");
@@ -492,7 +578,7 @@ async function copyExtractedProject(options: {
     let current = cwd;
     for (const segment of targetSegments) {
       current = join(current, segment);
-      await ensureDirectory(current, fileSystem, createdDirectories);
+      await ensureDirectory(current, createdDirectories);
     }
 
     const absoluteFiles = await listRegularFiles(stagingDirectory);
@@ -510,10 +596,6 @@ async function copyExtractedProject(options: {
       ) {
         failedExample();
       }
-      const status = await stat(absolute);
-      if (status.size > exampleLimits.maxFileBytes) {
-        failedExample([relativePath]);
-      }
 
       let contents = await readFile(absolute);
       if (relativePath === "package.json") {
@@ -529,7 +611,7 @@ async function copyExtractedProject(options: {
         let nested = targetDirectory;
         for (const segment of parentRelative.split("/")) {
           nested = join(nested, segment);
-          await ensureDirectory(nested, fileSystem, createdDirectories);
+          await ensureDirectory(nested, createdDirectories);
         }
       }
       await writeFile(destination, contents, { flag: "wx" });
@@ -539,7 +621,6 @@ async function copyExtractedProject(options: {
     return Object.freeze(writtenRelative.sort());
   } catch (error) {
     const rolledBack = await rollbackCreated(
-      fileSystem,
       createdEntries,
       createdDirectories,
     );
@@ -557,16 +638,42 @@ async function copyExtractedProject(options: {
   }
 }
 
+function readEntryType(entry: unknown): string | undefined {
+  if (typeof entry !== "object" || entry === null) return undefined;
+  const type = (entry as { readonly type?: unknown }).type;
+  return typeof type === "string" ? type : undefined;
+}
+
+function readEntrySize(entry: unknown): number {
+  if (typeof entry !== "object" || entry === null) return 0;
+  const size = (entry as { readonly size?: unknown }).size;
+  return typeof size === "number" && Number.isFinite(size) ? size : 0;
+}
+
+function entryIsRegularFile(entry: unknown): boolean {
+  const type = readEntryType(entry);
+  return type === "File" || type === "0" || type === "" || type === undefined;
+}
+
 async function extractRepository(
   archivePath: string,
   stagingDirectory: string,
   info: ExampleRepoInfo,
+  limits: ExampleRuntimeLimits,
 ): Promise<void> {
   let rootPath: string | null = null;
+  let rejected = false;
+  let uncompressedBytes = 0;
+  let fileCount = 0;
   const prefix =
     info.filePath === ""
       ? []
       : info.filePath.split("/").filter((segment) => segment !== "");
+
+  const markRejected = (): void => {
+    rejected = true;
+  };
+
   try {
     await extractTar({
       file: archivePath,
@@ -574,6 +681,10 @@ async function extractRepository(
       strict: true,
       preservePaths: false,
       onentry(entry) {
+        if (rejected) {
+          entry.resume();
+          return;
+        }
         const posixPath = entry.path.split(sep).join(posix.sep);
         if (
           entry.type === "SymbolicLink" ||
@@ -581,24 +692,63 @@ async function extractRepository(
           posixPath.includes("\u0000") ||
           posixPath.split(posix.sep).some((segment) => segment === "..")
         ) {
+          markRejected();
           entry.resume();
-          throw new CreatorError("EXAMPLE_FAILED");
+          return;
         }
         if (rootPath === null) {
           rootPath = posixPath.split(posix.sep)[0] ?? null;
         }
       },
-      filter(path) {
+      filter(path, entry) {
+        if (rejected) return false;
         const posixPath = path.split(sep).join(posix.sep);
+        if (
+          posixPath.includes("\u0000") ||
+          posixPath.split(posix.sep).some((segment) => segment === "..")
+        ) {
+          markRejected();
+          return false;
+        }
+        const entryType = readEntryType(entry);
+        if (entryType === "SymbolicLink" || entryType === "Link") {
+          markRejected();
+          return false;
+        }
         if (rootPath === null) {
           rootPath = posixPath.split(posix.sep)[0] ?? null;
         }
         if (rootPath === null) return false;
-        if (prefix.length === 0) {
-          return posixPath === rootPath || posixPath.startsWith(`${rootPath}/`);
+
+        const inSubtree =
+          prefix.length === 0
+            ? posixPath === rootPath || posixPath.startsWith(`${rootPath}/`)
+            : (() => {
+                const wanted = `${rootPath}/${prefix.join("/")}`;
+                return (
+                  posixPath === wanted || posixPath.startsWith(`${wanted}/`)
+                );
+              })();
+        if (!inSubtree) return false;
+
+        if (entryIsRegularFile(entry)) {
+          const size = readEntrySize(entry);
+          if (size > limits.maxFileBytes) {
+            markRejected();
+            return false;
+          }
+          uncompressedBytes += size;
+          if (uncompressedBytes > limits.maxArchiveBytes) {
+            markRejected();
+            return false;
+          }
+          fileCount += 1;
+          if (fileCount > limits.maxExtractedFiles) {
+            markRejected();
+            return false;
+          }
         }
-        const wanted = `${rootPath}/${prefix.join("/")}`;
-        return posixPath === wanted || posixPath.startsWith(`${wanted}/`);
+        return true;
       },
       strip: prefix.length === 0 ? 1 : prefix.length + 1,
     });
@@ -606,6 +756,8 @@ async function extractRepository(
     if (error instanceof CreatorError) throw error;
     failedExample();
   }
+
+  if (rejected) failedExample();
 }
 
 export interface ExampleProject {
@@ -619,18 +771,15 @@ export interface ExampleProject {
 export async function createExampleProject(
   options: CreateExampleProjectOptions,
 ): Promise<ExampleProject> {
-  const fileSystem = options.fileSystem ?? defaultScaffoldFileSystem;
   const fetchImpl = options.fetch ?? fetch;
+  const limits = resolveRuntimeLimits(options.limits);
   const target = await assertCreatableStarterTarget(
     options.cwd,
     options.target,
-    fileSystem,
+    defaultScaffoldFileSystem,
   );
-  const info = await resolveExampleReference(
-    options.example,
-    options.examplePath,
-    fetchImpl,
-  );
+  const info = options.example;
+  if (!isValidGithubBranch(info.branch)) return unavailableExample();
 
   const stagingRoot = await mkdtemp(join(tmpdir(), "invokta-example-"));
   const archivePath = join(stagingRoot, "repository.tar.gz");
@@ -638,12 +787,17 @@ export async function createExampleProject(
   await mkdir(extractDirectory);
 
   try {
+    const branchPath = info.branch
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
     await downloadToFile(
       fetchImpl,
-      `https://codeload.github.com/${info.owner}/${info.repository}/tar.gz/${info.branch}`,
+      `https://codeload.github.com/${encodeURIComponent(info.owner)}/${encodeURIComponent(info.repository)}/tar.gz/${branchPath}`,
       archivePath,
+      limits,
     );
-    await extractRepository(archivePath, extractDirectory, info);
+    await extractRepository(archivePath, extractDirectory, info, limits);
 
     try {
       await stat(join(extractDirectory, "package.json"));
@@ -657,7 +811,6 @@ export async function createExampleProject(
       cwd: options.cwd,
       normalizedTarget: target.normalizedTarget,
       projectName: target.projectName,
-      fileSystem,
     });
 
     return Object.freeze({

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -739,16 +739,69 @@ function readTarHeaderSize(header: Buffer): number {
   return Number.isFinite(size) && size >= 0 ? size : Number.NaN;
 }
 
+function parsePaxSizeOverride(body: Buffer): number | undefined {
+  const text = body.toString("utf8");
+  let offset = 0;
+  while (offset < text.length) {
+    const space = text.indexOf(" ", offset);
+    if (space < 0) break;
+    const length = Number.parseInt(text.slice(offset, space), 10);
+    if (!Number.isFinite(length) || length <= 0) break;
+    if (offset + length > text.length) break;
+    const record = text.slice(offset, offset + length);
+    const separator = record.indexOf("=");
+    if (separator >= 0) {
+      const key = record.slice(space - offset + 1, separator);
+      const value = record.slice(separator + 1).replace(/\n$/u, "");
+      if (key === "size") {
+        const size = Number.parseInt(value, 10);
+        if (Number.isFinite(size) && size >= 0) return size;
+      }
+    }
+    offset += length;
+  }
+  return undefined;
+}
+
 /**
  * node-tar silently skips some unsupported typeflags before filter/onentry.
  * Scan raw ustar headers so SparseFile/symlink/device entries cannot bypass rejection.
+ * PAX `size` overrides are applied so the scanner stays aligned with node-tar.
  */
 async function assertArchiveHeadersSafe(archivePath: string): Promise<void> {
   const gunzip = createGunzip();
   const source = createReadStream(archivePath);
+  // Ignore late stream errors after we intentionally abort the scan.
+  gunzip.on("error", () => undefined);
+  source.on("error", () => undefined);
   const stream = source.pipe(gunzip);
   let buffer = Buffer.alloc(0);
   let pendingData = 0;
+  let pendingKind: "skip" | "pax-x" | "pax-g" | undefined;
+  let pendingBodySize = 0;
+  let pendingChunks: Buffer[] = [];
+  let nextFileSizeOverride: number | undefined;
+  let globalSizeOverride: number | undefined;
+
+  const finishPending = (): void => {
+    if (pendingKind === "pax-x" || pendingKind === "pax-g") {
+      const body = Buffer.concat(pendingChunks).subarray(0, pendingBodySize);
+      const override = parsePaxSizeOverride(body);
+      if (override !== undefined) {
+        if (pendingKind === "pax-g") globalSizeOverride = override;
+        else nextFileSizeOverride = override;
+      }
+    }
+    pendingKind = undefined;
+    pendingBodySize = 0;
+    pendingChunks = [];
+  };
+
+  const stopStreams = (): void => {
+    source.destroy();
+    gunzip.destroy();
+  };
+
   try {
     for await (const chunk of stream) {
       buffer = Buffer.concat([buffer, chunk as Buffer]);
@@ -756,8 +809,12 @@ async function assertArchiveHeadersSafe(archivePath: string): Promise<void> {
         if (pendingData > 0) {
           if (buffer.byteLength === 0) break;
           const take = Math.min(pendingData, buffer.byteLength);
+          if (pendingKind === "pax-x" || pendingKind === "pax-g") {
+            pendingChunks.push(buffer.subarray(0, take));
+          }
           buffer = buffer.subarray(take);
           pendingData -= take;
+          if (pendingData === 0) finishPending();
           continue;
         }
         if (buffer.byteLength < 512) break;
@@ -767,17 +824,44 @@ async function assertArchiveHeadersSafe(archivePath: string): Promise<void> {
         const typeflag = String.fromCharCode(header[156] ?? 0);
         if (!allowedTarTypeflags.has(typeflag)) failedExample();
         const headerPath = readTarHeaderPath(header).split(sep).join(posix.sep);
-        if (headerPath !== "" && isUnsafeArchivePath(headerPath)) {
+        if (
+          typeflag !== "x" &&
+          typeflag !== "g" &&
+          headerPath !== "" &&
+          isUnsafeArchivePath(headerPath)
+        ) {
           failedExample();
         }
-        const size = readTarHeaderSize(header);
-        if (!Number.isFinite(size)) failedExample();
-        pendingData = Math.ceil(size / 512) * 512;
+        const headerSize = readTarHeaderSize(header);
+        if (!Number.isFinite(headerSize)) failedExample();
+
+        if (typeflag === "x" || typeflag === "g") {
+          pendingKind = typeflag === "x" ? "pax-x" : "pax-g";
+          pendingBodySize = headerSize;
+          pendingChunks = [];
+          pendingData = Math.ceil(headerSize / 512) * 512;
+          if (pendingData === 0) finishPending();
+          continue;
+        }
+
+        const effectiveSize =
+          nextFileSizeOverride ?? globalSizeOverride ?? headerSize;
+        nextFileSizeOverride = undefined;
+        if (!Number.isFinite(effectiveSize) || effectiveSize < 0) {
+          failedExample();
+        }
+        pendingKind = "skip";
+        pendingData = Math.ceil(effectiveSize / 512) * 512;
+        if (pendingData === 0) finishPending();
       }
     }
+    if (pendingData > 0) failedExample();
   } catch (error) {
+    stopStreams();
     if (error instanceof CreatorError) throw error;
     failedExample();
+  } finally {
+    stopStreams();
   }
 }
 

--- a/packages/create-invokta-engine/src/example.ts
+++ b/packages/create-invokta-engine/src/example.ts
@@ -32,6 +32,7 @@ export const exampleLimits = Object.freeze({
   /** Compressed download bytes from codeload.github.com. */
   maxCompressedArchiveBytes: 52_428_800,
   maxExtractedFiles: 10_000,
+  maxExtractedDirectories: 10_000,
   maxFileBytes: 5_242_880,
 });
 
@@ -39,6 +40,7 @@ export type ExampleRuntimeLimits = Readonly<{
   maxArchiveBytes: number;
   maxCompressedArchiveBytes: number;
   maxExtractedFiles: number;
+  maxExtractedDirectories: number;
   maxFileBytes: number;
   fetchTimeoutMs: number;
 }>;
@@ -107,10 +109,13 @@ function failedExample(details: readonly string[] = []): never {
   throw new CreatorError("EXAMPLE_FAILED", details);
 }
 
+const unsafePathCharacterPattern = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+
 function normalizeExamplePath(path: string): string {
   if (
     path === "" ||
     path.includes("\u0000") ||
+    unsafePathCharacterPattern.test(path) ||
     countScalars(path) > exampleLimits.maxExamplePathScalars
   ) {
     return invalidExample();
@@ -157,7 +162,8 @@ function decodeGithubSegment(segment: string): string | undefined {
     decoded.includes("/") ||
     decoded.includes("\\") ||
     decoded.includes("\u0000") ||
-    decoded.includes("%")
+    decoded.includes("%") ||
+    unsafePathCharacterPattern.test(decoded)
   ) {
     return undefined;
   }
@@ -229,23 +235,41 @@ function parseGithubUrl(
   }
 
   if (treeToken !== "tree" || rest.length === 0) return undefined;
-  const [rawBranch, ...pathSegments] = rest;
-  if (rawBranch === undefined) return undefined;
-  const branch = decodeGithubSegment(rawBranch);
-  if (branch === undefined || !isValidGithubBranch(branch)) return undefined;
-  const urlPath = pathSegments
-    .map((segment) => decodeGithubSegment(segment))
-    .every((segment) => segment !== undefined)
-    ? pathSegments
-        .map((segment) => decodeGithubSegment(segment) as string)
-        .join("/")
-    : undefined;
-  if (urlPath === undefined && pathSegments.length > 0) return undefined;
-  const filePath =
-    overridePath ??
-    (urlPath === undefined || urlPath === ""
-      ? ""
-      : normalizeExamplePath(urlPath));
+  const decodedRest: string[] = [];
+  for (const segment of rest) {
+    const decoded = decodeGithubSegment(segment);
+    if (decoded === undefined) return undefined;
+    decodedRest.push(decoded);
+  }
+  if (decodedRest.length === 0) return undefined;
+
+  let branch: string;
+  let filePath: string;
+  if (overridePath !== undefined) {
+    // create-next-app style: with --example-path, the tree remainder is
+    // branch[/path]; strip a trailing example-path to recover slash-containing refs.
+    const remainder = decodedRest.join("/");
+    if (remainder === overridePath) {
+      return undefined;
+    }
+    if (remainder.endsWith(`/${overridePath}`)) {
+      branch = remainder.slice(0, -(overridePath.length + 1));
+    } else {
+      branch = remainder;
+    }
+    filePath = overridePath;
+  } else {
+    // Without --example-path, the first segment is the ref; the rest is the path.
+    // Slash-containing refs require --example-path.
+    const [first, ...pathSegments] = decodedRest;
+    if (first === undefined) return undefined;
+    branch = first;
+    filePath =
+      pathSegments.length === 0
+        ? ""
+        : normalizeExamplePath(pathSegments.join("/"));
+  }
+  if (!isValidGithubBranch(branch)) return undefined;
   const shortLabel =
     owner === officialExampleSource.owner &&
     repository === officialExampleSource.repository
@@ -320,6 +344,9 @@ function resolveRuntimeLimits(
       exampleLimits.maxCompressedArchiveBytes,
     maxExtractedFiles:
       overrides?.maxExtractedFiles ?? exampleLimits.maxExtractedFiles,
+    maxExtractedDirectories:
+      overrides?.maxExtractedDirectories ??
+      exampleLimits.maxExtractedDirectories,
     maxFileBytes: overrides?.maxFileBytes ?? exampleLimits.maxFileBytes,
     fetchTimeoutMs: overrides?.fetchTimeoutMs ?? exampleLimits.fetchTimeoutMs,
   });
@@ -650,9 +677,33 @@ function readEntrySize(entry: unknown): number {
   return typeof size === "number" && Number.isFinite(size) ? size : 0;
 }
 
+const regularFileEntryTypes = new Set([
+  "File",
+  "OldFile",
+  "ContiguousFile",
+  "0",
+  "",
+]);
+
 function entryIsRegularFile(entry: unknown): boolean {
   const type = readEntryType(entry);
-  return type === "File" || type === "0" || type === "" || type === undefined;
+  return type === undefined || regularFileEntryTypes.has(type);
+}
+
+function entryIsDirectory(entry: unknown): boolean {
+  const type = readEntryType(entry);
+  return type === "Directory" || type === "5";
+}
+
+function isUnsafeArchivePath(posixPath: string): boolean {
+  if (posixPath.includes("\u0000")) return true;
+  if (posixPath.startsWith("/") || posixPath.startsWith("\\")) return true;
+  if (posixPath.startsWith("//") || posixPath.startsWith("\\\\")) return true;
+  if (/^[A-Za-z]:(?:[/\\]|$)/u.test(posixPath)) return true;
+  const segments = posixPath.split(posix.sep);
+  // Absolute POSIX paths split to a leading empty segment.
+  if (segments[0] === "" && segments.length > 1) return true;
+  return segments.some((segment) => segment === "..");
 }
 
 async function extractRepository(
@@ -665,6 +716,7 @@ async function extractRepository(
   let rejected = false;
   let uncompressedBytes = 0;
   let fileCount = 0;
+  let directoryCount = 0;
   const prefix =
     info.filePath === ""
       ? []
@@ -686,11 +738,19 @@ async function extractRepository(
           return;
         }
         const posixPath = entry.path.split(sep).join(posix.sep);
+        if (isUnsafeArchivePath(posixPath)) {
+          markRejected();
+          entry.resume();
+          return;
+        }
+        const entryType = readEntryType(entry);
         if (
-          entry.type === "SymbolicLink" ||
-          entry.type === "Link" ||
-          posixPath.includes("\u0000") ||
-          posixPath.split(posix.sep).some((segment) => segment === "..")
+          !(
+            entryIsDirectory(entry) ||
+            entryIsRegularFile(entry) ||
+            // Root directory markers may arrive before classification settles.
+            entryType === undefined
+          )
         ) {
           markRejected();
           entry.resume();
@@ -703,15 +763,7 @@ async function extractRepository(
       filter(path, entry) {
         if (rejected) return false;
         const posixPath = path.split(sep).join(posix.sep);
-        if (
-          posixPath.includes("\u0000") ||
-          posixPath.split(posix.sep).some((segment) => segment === "..")
-        ) {
-          markRejected();
-          return false;
-        }
-        const entryType = readEntryType(entry);
-        if (entryType === "SymbolicLink" || entryType === "Link") {
+        if (isUnsafeArchivePath(posixPath)) {
           markRejected();
           return false;
         }
@@ -731,6 +783,18 @@ async function extractRepository(
               })();
         if (!inSubtree) return false;
 
+        if (entryIsDirectory(entry)) {
+          // The archive root directory is stripped; count retained dirs only.
+          if (posixPath !== rootPath) {
+            directoryCount += 1;
+            if (directoryCount > limits.maxExtractedDirectories) {
+              markRejected();
+              return false;
+            }
+          }
+          return true;
+        }
+
         if (entryIsRegularFile(entry)) {
           const size = readEntrySize(entry);
           if (size > limits.maxFileBytes) {
@@ -747,8 +811,12 @@ async function extractRepository(
             markRejected();
             return false;
           }
+          return true;
         }
-        return true;
+
+        // Symbolic links, hard links, devices, FIFOs, and unknown types.
+        markRejected();
+        return false;
       },
       strip: prefix.length === 0 ? 1 : prefix.length + 1,
     });
@@ -799,8 +867,10 @@ export async function createExampleProject(
     );
     await extractRepository(archivePath, extractDirectory, info, limits);
 
+    const packageJsonPath = join(extractDirectory, "package.json");
     try {
-      await stat(join(extractDirectory, "package.json"));
+      const packageStatus = await stat(packageJsonPath);
+      if (!packageStatus.isFile()) unavailableExample(["package.json"]);
     } catch {
       unavailableExample(["package.json"]);
     }

--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -181,6 +181,27 @@ export function validateStarterTargetSyntax(
   });
 }
 
+/** Validates syntax and the no-follow empty-target boundary without planning files. */
+export async function assertCreatableStarterTarget(
+  cwd: string,
+  target: string,
+  fileSystem: ScaffoldFileSystem = defaultScaffoldFileSystem,
+): Promise<
+  Readonly<{
+    directory: string;
+    projectName: string;
+    normalizedTarget: string;
+  }>
+> {
+  const resolved = resolveTarget(cwd, target);
+  await inspectTarget(cwd, resolved, fileSystem);
+  return Object.freeze({
+    directory: resolved.directory,
+    projectName: resolved.projectName,
+    normalizedTarget: resolved.normalizedTarget,
+  });
+}
+
 async function readStatus(
   fileSystem: ScaffoldFileSystem,
   path: string,

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -753,17 +753,22 @@ describe("runCreateEngineCli", () => {
       "repo-main",
     ]);
     const archive = readFileSync(archivePath);
+    let apiCalls = 0;
+    let codeloadCalls = 0;
     const fetchImpl: ExampleFetch = async (input, init) => {
       const url = new URL(input);
+      expect(init?.redirect).toBe("error");
       if (url.pathname.includes("/contents/")) {
+        apiCalls += 1;
         return new Response(null, { status: 200 });
       }
       if (url.hostname === "codeload.github.com") {
-        expect(init?.redirect).toBe("error");
+        codeloadCalls += 1;
         return new Response(Readable.toWeb(Readable.from(archive)), {
           status: 200,
         });
       }
+      apiCalls += 1;
       return new Response(JSON.stringify({ default_branch: "main" }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -790,6 +795,8 @@ describe("runCreateEngineCli", () => {
 
     expect(exitCode).toBe(0);
     expect(terminal.readLine).toHaveBeenCalledOnce();
+    expect(apiCalls).toBe(1);
+    expect(codeloadCalls).toBe(1);
     expect(io.stderr).toEqual([
       'Create from GitHub example "acme/repo/templates/engine" in "my-engine" without installing dependencies? (y/N) ',
     ]);
@@ -805,7 +812,8 @@ describe("runCreateEngineCli", () => {
   it("cancels an example import before downloading the archive", async () => {
     const cwd = createWorkingDirectory();
     let codeloadCalls = 0;
-    const fetchImpl: ExampleFetch = async (input) => {
+    const fetchImpl: ExampleFetch = async (input, init) => {
+      expect(init?.redirect).toBe("error");
       const url = new URL(input);
       if (url.hostname === "codeload.github.com") {
         codeloadCalls += 1;

--- a/packages/create-invokta-engine/test/cli.test.ts
+++ b/packages/create-invokta-engine/test/cli.test.ts
@@ -6,10 +6,12 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 
+import { c as createTar } from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -18,6 +20,7 @@ import {
   type InstallProject,
   runCreateEngineCli,
 } from "../src/cli.js";
+import type { ExampleFetch } from "../src/example.js";
 import { createBoundedPromptInput } from "../src/prompt.js";
 import { createStarterFiles } from "../src/starter.js";
 
@@ -101,6 +104,28 @@ const invalidArgumentCases: readonly Readonly<{
   },
   { argv: ["--help", "my-engine"] },
   { argv: ["--version", "fixture-secret-payload-marker"] },
+  {
+    argv: [
+      "my-engine",
+      "--profile",
+      "cli",
+      "--example",
+      "auth-clerk-engine",
+      "--no-install",
+    ],
+  },
+  { argv: ["my-engine", "--example-path", "templates/engine", "--no-install"] },
+  { argv: ["my-engine", "--example"] },
+  { argv: ["my-engine", "--example", "--yes"] },
+  {
+    argv: [
+      "my-engine",
+      "--example",
+      "auth-clerk-engine",
+      "--example",
+      "hello-engine",
+    ],
+  },
 ];
 
 afterEach(() => {
@@ -705,5 +730,117 @@ describe("runCreateEngineCli", () => {
         io,
       }),
     ).resolves.toBe(2);
+  });
+
+  it("imports a GitHub example without prompting for a profile", async () => {
+    const cwd = createWorkingDirectory();
+    const archiveRoot = createWorkingDirectory();
+    await mkdir(join(archiveRoot, "repo-main/templates/engine/src"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(archiveRoot, "repo-main/templates/engine/package.json"),
+      '{\n  "name": "@acme/template",\n  "private": true\n}\n',
+      "utf8",
+    );
+    await writeFile(
+      join(archiveRoot, "repo-main/templates/engine/src/engine.ts"),
+      "export const ready = true;\n",
+      "utf8",
+    );
+    const archivePath = join(archiveRoot, "repository.tar.gz");
+    await createTar({ gzip: true, file: archivePath, cwd: archiveRoot }, [
+      "repo-main",
+    ]);
+    const archive = readFileSync(archivePath);
+    const fetchImpl: ExampleFetch = async (input, init) => {
+      const url = new URL(input);
+      if (url.pathname.includes("/contents/")) {
+        return new Response(null, { status: 200 });
+      }
+      if (url.hostname === "codeload.github.com") {
+        expect(init?.redirect).toBe("error");
+        return new Response(Readable.toWeb(Readable.from(archive)), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({ default_branch: "main" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const io = createHarness();
+    const terminal = createTerminal([promptLine("yes")]);
+    const install = vi.fn<InstallProject>();
+
+    const exitCode = await runCreateEngineCli({
+      argv: [
+        "my-engine",
+        "--example",
+        "https://github.com/acme/repo/tree/main/templates/engine",
+        "--no-install",
+      ],
+      cwd,
+      env: {},
+      io,
+      terminal,
+      install,
+      fetch: fetchImpl,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(terminal.readLine).toHaveBeenCalledOnce();
+    expect(io.stderr).toEqual([
+      'Create from GitHub example "acme/repo/templates/engine" in "my-engine" without installing dependencies? (y/N) ',
+    ]);
+    expect(io.stdout.join("")).toContain(
+      "Created my-engine from example acme/repo/templates/engine.",
+    );
+    expect(
+      JSON.parse(readFileSync(join(cwd, "my-engine/package.json"), "utf8")),
+    ).toMatchObject({ name: "my-engine" });
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  it("cancels an example import before downloading the archive", async () => {
+    const cwd = createWorkingDirectory();
+    let codeloadCalls = 0;
+    const fetchImpl: ExampleFetch = async (input) => {
+      const url = new URL(input);
+      if (url.hostname === "codeload.github.com") {
+        codeloadCalls += 1;
+        return new Response(null, { status: 500 });
+      }
+      if (url.pathname.includes("/contents/")) {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(JSON.stringify({ default_branch: "main" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const io = createHarness();
+    const terminal = createTerminal([promptLine("n")]);
+    const install = vi.fn<InstallProject>();
+
+    const exitCode = await runCreateEngineCli({
+      argv: [
+        "my-engine",
+        "--example",
+        "https://github.com/acme/repo",
+        "--no-install",
+      ],
+      cwd,
+      io,
+      terminal,
+      install,
+      fetch: fetchImpl,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(codeloadCalls).toBe(0);
+    expect(io.stdout).toEqual(["Creation cancelled. No files were created.\n"]);
+    expect(existsSync(join(cwd, "my-engine"))).toBe(false);
+    expect(install).not.toHaveBeenCalled();
   });
 });

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -1,11 +1,12 @@
 import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { link, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
+import { gzipSync } from "node:zlib";
 import { c as createTar } from "tar";
 import { afterEach, describe, expect, it } from "vitest";
-
+import { runCreateEngineCli } from "../src/cli.js";
 import {
   CreatorError,
   renderCreatorDiagnostic,
@@ -33,10 +34,53 @@ afterEach(() => {
   }
 });
 
+function createUstarEntry(
+  name: string,
+  content: string | Buffer,
+  typeflag: string,
+): Buffer {
+  const data = typeof content === "string" ? Buffer.from(content) : content;
+  const header = Buffer.alloc(512, 0);
+  const nameBytes = Buffer.from(name);
+  nameBytes.copy(header, 0, 0, Math.min(nameBytes.byteLength, 100));
+  header.write("0000644\0", 100);
+  header.write("0000000\0", 108);
+  header.write("0000000\0", 116);
+  header.write(`${data.byteLength.toString(8).padStart(11, "0")}\0`, 124);
+  header.write(
+    `${Math.floor(Date.now() / 1000)
+      .toString(8)
+      .padStart(11, "0")}\0`,
+    136,
+  );
+  header.write("        ", 148);
+  header.write(typeflag, 156);
+  header.write("ustar\0", 257);
+  header.write("00", 263);
+  let checksum = 0;
+  for (let index = 0; index < 512; index += 1) checksum += header[index] ?? 0;
+  header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148);
+  const padding = (512 - (data.byteLength % 512)) % 512;
+  return Buffer.concat([header, data, Buffer.alloc(padding)]);
+}
+
+function buildRawTarGz(
+  entries: ReadonlyArray<
+    Readonly<{ name: string; content?: string | Buffer; typeflag: string }>
+  >,
+): Buffer {
+  const parts = entries.map((entry) =>
+    createUstarEntry(entry.name, entry.content ?? "", entry.typeflag),
+  );
+  parts.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(parts));
+}
+
 async function buildRepositoryArchive(options: {
   readonly rootName: string;
   readonly files?: Readonly<Record<string, string>>;
   readonly symlinks?: Readonly<Record<string, string>>;
+  readonly hardlinks?: Readonly<Record<string, string>>;
 }): Promise<Buffer> {
   const root = createWorkingDirectory();
   for (const [relativePath, contents] of Object.entries(options.files ?? {})) {
@@ -48,6 +92,13 @@ async function buildRepositoryArchive(options: {
     const absolute = join(root, options.rootName, relativePath);
     await mkdir(join(absolute, ".."), { recursive: true });
     symlinkSync(target, absolute);
+  }
+  for (const [relativePath, target] of Object.entries(
+    options.hardlinks ?? {},
+  )) {
+    const absolute = join(root, options.rootName, relativePath);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    await link(join(root, options.rootName, target), absolute);
   }
   const archivePath = join(root, "repository.tar.gz");
   await createTar(
@@ -110,22 +161,6 @@ function createFetch(options: {
   };
 }
 
-async function resolveTreeExample(
-  url: string,
-  archive: Buffer,
-  packagePath: string,
-): Promise<{
-  readonly info: ExampleRepoInfo;
-  readonly fetchImpl: ExampleFetch;
-}> {
-  const fetchImpl = createFetch({
-    packagePaths: new Set([packagePath]),
-    archive,
-  });
-  const info = await resolveExampleReference(url, undefined, fetchImpl);
-  return { info, fetchImpl };
-}
-
 describe("parseExampleReference", () => {
   it("resolves official short names under examples/ on main", () => {
     expect(parseExampleReference("auth-clerk-engine")).toEqual({
@@ -160,14 +195,28 @@ describe("parseExampleReference", () => {
     });
   });
 
-  it("lets --example-path override a tree URL path", () => {
+  it("recovers slash-containing refs when --example-path is provided", () => {
+    expect(
+      parseExampleReference(
+        "https://github.com/acme/repo/tree/feature/foo/templates/engine",
+        "templates/engine",
+      ),
+    ).toEqual({
+      owner: "acme",
+      repository: "repo",
+      branch: "feature/foo",
+      filePath: "templates/engine",
+      label: "acme/repo/templates/engine",
+    });
     expect(
       parseExampleReference(
         "https://github.com/acme/repo/tree/main/ignored",
         "templates/engine",
       ),
-    ).toMatchObject({
-      branch: "main",
+    ).toEqual({
+      owner: "acme",
+      repository: "repo",
+      branch: "main/ignored",
       filePath: "templates/engine",
       label: "acme/repo/templates/engine",
     });
@@ -181,6 +230,7 @@ describe("parseExampleReference", () => {
       "https://user:pass@github.com/acme/repo",
       "https://github.com/a%2f..%2fb/repo",
       "https://github.com/acme/re%2fpo",
+      "https://github.com/acme/repo/tree/main/evil%1Bpath",
       "../escape",
       "",
     ]) {
@@ -268,10 +318,14 @@ describe("createExampleProject", () => {
         "README.md": "repo root\n",
       },
     });
-    const { info, fetchImpl } = await resolveTreeExample(
-      "https://github.com/acme/repo/tree/main/templates/engine",
+    const fetchImpl = createFetch({
+      packagePaths: new Set(["templates/engine/package.json"]),
       archive,
-      "templates/engine/package.json",
+    });
+    const info = await resolveExampleReference(
+      "https://github.com/acme/repo/tree/main/templates/engine",
+      undefined,
+      fetchImpl,
     );
 
     const project = await createExampleProject({
@@ -286,59 +340,131 @@ describe("createExampleProject", () => {
     expect(
       JSON.parse(readFileSync(join(project.directory, "package.json"), "utf8")),
     ).toMatchObject({ name: "my-engine", private: true });
-    expect(readFileSync(join(project.directory, "src/engine.ts"), "utf8")).toBe(
-      "export const ready = true;\n",
-    );
-    expect(() =>
-      readFileSync(join(project.directory, "README.md"), "utf8"),
-    ).toThrow();
   });
 
-  it("refuses redirected archive downloads", async () => {
+  it("rejects symlink and hardlink archives without crashing", async () => {
     const cwd = createWorkingDirectory();
-    const info = parseExampleReference("https://github.com/acme/repo");
-    const resolved: ExampleRepoInfo = { ...info, branch: "main" };
-    const fetchImpl: ExampleFetch = async (_input, init) => {
-      expect(init?.redirect).toBe("error");
-      return new Response(null, {
-        status: 302,
-        headers: { location: "https://evil.example/tarball" },
-      });
+    for (const archive of [
+      await buildRepositoryArchive({
+        rootName: "repo-main",
+        files: { "package.json": '{"name":"template"}\n' },
+        symlinks: { "linked.txt": "package.json" },
+      }),
+      await buildRepositoryArchive({
+        rootName: "repo-main",
+        files: { "package.json": '{"name":"template"}\n' },
+        hardlinks: { "linked.txt": "package.json" },
+      }),
+    ]) {
+      const info: ExampleRepoInfo = {
+        owner: "acme",
+        repository: "repo",
+        branch: "main",
+        filePath: "",
+        label: "acme/repo",
+      };
+      await expect(
+        createExampleProject({
+          cwd,
+          target: "my-engine",
+          example: info,
+          fetch: createFetch({ archive }),
+        }),
+      ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+    }
+  });
+
+  it("rejects ContiguousFile entries that exceed extract limits", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = buildRawTarGz([
+      { name: "repo-main/", typeflag: "5" },
+      {
+        name: "repo-main/package.json",
+        content: '{"name":"template"}\n',
+        typeflag: "0",
+      },
+      {
+        name: "repo-main/big.bin",
+        content: "0123456789abcdef",
+        typeflag: "S",
+      },
+    ]);
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
     };
 
     await expect(
       createExampleProject({
         cwd,
         target: "my-engine",
-        example: resolved,
-        fetch: fetchImpl,
+        example: info,
+        fetch: createFetch({ archive }),
+        limits: { maxFileBytes: 8 },
       }),
-    ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
-    expect(() =>
-      readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
-    ).toThrow();
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
   });
 
-  it("does not retain target files when the archive lacks package.json after extract", async () => {
+  it("rejects absolute archive entry paths", async () => {
     const cwd = createWorkingDirectory();
-    const archive = await buildRepositoryArchive({
-      rootName: "repo-main",
-      files: {
-        "templates/engine/README.md": "no package\n",
+    const archive = buildRawTarGz([
+      {
+        name: "/package.json",
+        content: '{"name":"template"}\n',
+        typeflag: "0",
       },
-    });
-    const { info, fetchImpl } = await resolveTreeExample(
-      "https://github.com/acme/repo/tree/main/templates/engine",
-      archive,
-      "templates/engine/package.json",
-    );
+      {
+        name: "/src/engine.ts",
+        content: "export {}\n",
+        typeflag: "0",
+      },
+    ]);
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
 
     await expect(
       createExampleProject({
         cwd,
         target: "my-engine",
         example: info,
-        fetch: fetchImpl,
+        fetch: createFetch({ archive }),
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects a directory named package.json", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = buildRawTarGz([
+      { name: "repo-main/", typeflag: "5" },
+      { name: "repo-main/package.json/", typeflag: "5" },
+      {
+        name: "repo-main/package.json/readme.txt",
+        content: "not a manifest\n",
+        typeflag: "0",
+      },
+    ]);
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: createFetch({ archive }),
       }),
     ).rejects.toMatchObject({
       code: "EXAMPLE_UNAVAILABLE",
@@ -346,15 +472,14 @@ describe("createExampleProject", () => {
     });
   });
 
-  it("rejects symlink archives with sanitized EXAMPLE_FAILED without crashing", async () => {
+  it("rejects archives that exceed uncompressed, file-count, and directory limits", async () => {
     const cwd = createWorkingDirectory();
     const archive = await buildRepositoryArchive({
       rootName: "repo-main",
       files: {
         "package.json": '{"name":"template"}\n',
-      },
-      symlinks: {
-        "linked.txt": "package.json",
+        "nested/a.txt": "a\n",
+        "nested/b.txt": "b\n",
       },
     });
     const info: ExampleRepoInfo = {
@@ -369,101 +494,116 @@ describe("createExampleProject", () => {
     await expect(
       createExampleProject({
         cwd,
-        target: "my-engine",
-        example: info,
-        fetch: fetchImpl,
-      }),
-    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
-    expect(() =>
-      readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
-    ).toThrow();
-  });
-
-  it("rejects archives that exceed the uncompressed byte limit during extract", async () => {
-    const cwd = createWorkingDirectory();
-    const archive = await buildRepositoryArchive({
-      rootName: "repo-main",
-      files: {
-        "package.json": '{"name":"template"}\n',
-        "big.bin": "0123456789abcdef",
-      },
-    });
-    const info: ExampleRepoInfo = {
-      owner: "acme",
-      repository: "repo",
-      branch: "main",
-      filePath: "",
-      label: "acme/repo",
-    };
-    const fetchImpl = createFetch({ archive });
-
-    await expect(
-      createExampleProject({
-        cwd,
-        target: "my-engine",
+        target: "bytes",
         example: info,
         fetch: fetchImpl,
         limits: { maxArchiveBytes: 20 },
       }),
     ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
-  });
-
-  it("rejects archives that exceed the per-file byte limit during extract", async () => {
-    const cwd = createWorkingDirectory();
-    const archive = await buildRepositoryArchive({
-      rootName: "repo-main",
-      files: {
-        "package.json": '{"name":"template"}\n',
-        "big.bin": "0123456789abcdef",
-      },
-    });
-    const info: ExampleRepoInfo = {
-      owner: "acme",
-      repository: "repo",
-      branch: "main",
-      filePath: "",
-      label: "acme/repo",
-    };
-    const fetchImpl = createFetch({ archive });
 
     await expect(
       createExampleProject({
         cwd,
-        target: "my-engine",
-        example: info,
-        fetch: fetchImpl,
-        limits: { maxFileBytes: 8 },
-      }),
-    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
-  });
-
-  it("rejects archives that exceed the extracted file count during extract", async () => {
-    const cwd = createWorkingDirectory();
-    const archive = await buildRepositoryArchive({
-      rootName: "repo-main",
-      files: {
-        "package.json": '{"name":"template"}\n',
-        "a.txt": "a\n",
-        "b.txt": "b\n",
-      },
-    });
-    const info: ExampleRepoInfo = {
-      owner: "acme",
-      repository: "repo",
-      branch: "main",
-      filePath: "",
-      label: "acme/repo",
-    };
-    const fetchImpl = createFetch({ archive });
-
-    await expect(
-      createExampleProject({
-        cwd,
-        target: "my-engine",
+        target: "files",
         example: info,
         fetch: fetchImpl,
         limits: { maxExtractedFiles: 2 },
       }),
     ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "dirs",
+        example: info,
+        fetch: fetchImpl,
+        limits: { maxExtractedDirectories: 0 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects compressed downloads that exceed the compressed-byte cap", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "package.json": '{"name":"template"}\n',
+      },
+    });
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: createFetch({ archive }),
+        limits: { maxCompressedArchiveBytes: 8 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
+  });
+});
+
+describe("success output sanitization", () => {
+  it("escapes control characters in the example success summary", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "package.json": '{"name":"template"}\n',
+      },
+    });
+    const stdout: string[] = [];
+    const fetchImpl = createFetch({ archive });
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo/\u001b[31mevil",
+    };
+
+    // Bypass parse (control chars rejected there) and assert render sanitizes.
+    const project = await createExampleProject({
+      cwd,
+      target: "my-engine",
+      example: { ...info, label: "acme/repo" },
+      fetch: fetchImpl,
+    });
+    expect(project.label).toBe("acme/repo");
+
+    const exitCode = await runCreateEngineCli({
+      argv: [
+        "safe-engine",
+        "--example",
+        "https://github.com/acme/repo",
+        "--no-install",
+        "--yes",
+      ],
+      cwd: createWorkingDirectory(),
+      env: {},
+      io: {
+        writeStdout(text) {
+          stdout.push(text);
+        },
+        writeStderr() {},
+      },
+      terminal: {
+        stdinIsTty: false,
+        stderrIsTty: false,
+        readLine: async () => undefined,
+      },
+      fetch: fetchImpl,
+      loadPackageVersion: async () => "1.2.3",
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout.join("")).not.toContain("\u001b");
+    expect(stdout.join("")).toContain("from example acme/repo");
   });
 });

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -1,0 +1,292 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { c as createTar } from "tar";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CreatorError } from "../src/errors.js";
+import {
+  createExampleProject,
+  type ExampleFetch,
+  parseExampleReference,
+  resolveExampleReference,
+} from "../src/example.js";
+
+const temporaryDirectories: string[] = [];
+
+function createWorkingDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "invokta-example-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+async function buildRepositoryArchive(options: {
+  readonly rootName: string;
+  readonly files: Readonly<Record<string, string>>;
+}): Promise<Buffer> {
+  const root = createWorkingDirectory();
+  for (const [relativePath, contents] of Object.entries(options.files)) {
+    const absolute = join(root, options.rootName, relativePath);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    await writeFile(absolute, contents, "utf8");
+  }
+  const archivePath = join(root, "repository.tar.gz");
+  await createTar(
+    {
+      gzip: true,
+      file: archivePath,
+      cwd: root,
+    },
+    [options.rootName],
+  );
+  return readFileSync(archivePath);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function createFetch(options: {
+  readonly defaultBranch?: string;
+  readonly packagePaths?: ReadonlySet<string>;
+  readonly archive?: Buffer;
+}): ExampleFetch {
+  const packagePaths = options.packagePaths ?? new Set(["package.json"]);
+  return async (input, init) => {
+    const url = new URL(input);
+    if (
+      url.hostname === "api.github.com" &&
+      url.pathname.startsWith("/repos/") &&
+      !url.pathname.includes("/contents/")
+    ) {
+      return jsonResponse({ default_branch: options.defaultBranch ?? "main" });
+    }
+    if (
+      url.hostname === "api.github.com" &&
+      url.pathname.includes("/contents/")
+    ) {
+      const pathWithRef = url.pathname.split("/contents/")[1] ?? "";
+      const decoded = decodeURIComponent(pathWithRef);
+      const ok =
+        (init?.method ?? "GET") === "HEAD" && packagePaths.has(decoded);
+      return new Response(null, { status: ok ? 200 : 404 });
+    }
+    if (url.hostname === "codeload.github.com") {
+      if (options.archive === undefined) {
+        return new Response(null, { status: 404 });
+      }
+      expect(init?.redirect).toBe("error");
+      const body = Readable.toWeb(Readable.from(options.archive));
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/gzip" },
+      });
+    }
+    return new Response(null, { status: 404 });
+  };
+}
+
+describe("parseExampleReference", () => {
+  it("resolves official short names under examples/ on main", () => {
+    expect(parseExampleReference("auth-clerk-engine")).toEqual({
+      owner: "vinilana",
+      repository: "invokta",
+      branch: "main",
+      filePath: "examples/auth-clerk-engine",
+      label: "auth-clerk-engine",
+    });
+  });
+
+  it("resolves repository and tree GitHub URLs", () => {
+    expect(
+      parseExampleReference("https://github.com/acme/engine-template"),
+    ).toEqual({
+      owner: "acme",
+      repository: "engine-template",
+      branch: "",
+      filePath: "",
+      label: "acme/engine-template",
+    });
+    expect(
+      parseExampleReference(
+        "https://github.com/acme/repo/tree/main/templates/engine",
+      ),
+    ).toEqual({
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "templates/engine",
+      label: "acme/repo/templates/engine",
+    });
+  });
+
+  it("lets --example-path override a tree URL path", () => {
+    expect(
+      parseExampleReference(
+        "https://github.com/acme/repo/tree/main/ignored",
+        "templates/engine",
+      ),
+    ).toMatchObject({
+      branch: "main",
+      filePath: "templates/engine",
+      label: "acme/repo/templates/engine",
+    });
+  });
+
+  it("rejects non-HTTPS and non-GitHub references", () => {
+    for (const example of [
+      "http://github.com/acme/repo",
+      "https://gitlab.com/acme/repo",
+      "git@github.com:acme/repo.git",
+      "https://user:pass@github.com/acme/repo",
+      "../escape",
+      "",
+    ]) {
+      expect(() => parseExampleReference(example)).toThrowError(CreatorError);
+      try {
+        parseExampleReference(example);
+      } catch (error) {
+        expect(error).toMatchObject({ code: "EXAMPLE_INVALID" });
+      }
+    }
+  });
+});
+
+describe("resolveExampleReference", () => {
+  it("fills the default branch and requires package.json", async () => {
+    const fetchImpl = createFetch({
+      defaultBranch: "develop",
+      packagePaths: new Set(["templates/engine/package.json"]),
+    });
+    await expect(
+      resolveExampleReference(
+        "https://github.com/acme/engine-template",
+        "templates/engine",
+        fetchImpl,
+      ),
+    ).resolves.toEqual({
+      owner: "acme",
+      repository: "engine-template",
+      branch: "develop",
+      filePath: "templates/engine",
+      label: "acme/engine-template/templates/engine",
+    });
+  });
+
+  it("fails when package.json is missing", async () => {
+    const fetchImpl = createFetch({ packagePaths: new Set() });
+    await expect(
+      resolveExampleReference("auth-clerk-engine", undefined, fetchImpl),
+    ).rejects.toMatchObject({
+      code: "EXAMPLE_UNAVAILABLE",
+      details: ["package.json"],
+    });
+  });
+});
+
+describe("createExampleProject", () => {
+  it("downloads a subtree, rewrites package name, and copies files", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "templates/engine/package.json":
+          '{\n  "name": "@acme/template",\n  "private": true\n}\n',
+        "templates/engine/src/engine.ts": "export const ready = true;\n",
+        "README.md": "repo root\n",
+      },
+    });
+    const fetchImpl = createFetch({
+      packagePaths: new Set(["templates/engine/package.json"]),
+      archive,
+    });
+
+    const project = await createExampleProject({
+      cwd,
+      target: "my-engine",
+      example: "https://github.com/acme/repo/tree/main/templates/engine",
+      fetch: fetchImpl,
+    });
+
+    expect(project.label).toBe("acme/repo/templates/engine");
+    expect(project.files).toEqual(["package.json", "src/engine.ts"]);
+    expect(
+      JSON.parse(readFileSync(join(project.directory, "package.json"), "utf8")),
+    ).toMatchObject({ name: "my-engine", private: true });
+    expect(readFileSync(join(project.directory, "src/engine.ts"), "utf8")).toBe(
+      "export const ready = true;\n",
+    );
+    expect(() =>
+      readFileSync(join(project.directory, "README.md"), "utf8"),
+    ).toThrow();
+  });
+
+  it("refuses redirected archive downloads", async () => {
+    const cwd = createWorkingDirectory();
+    const fetchImpl: ExampleFetch = async (input, init) => {
+      if (
+        input.includes("api.github.com/repos/acme/repo") &&
+        !input.includes("/contents/")
+      ) {
+        return jsonResponse({ default_branch: "main" });
+      }
+      if (input.includes("/contents/")) {
+        return new Response(null, { status: 200 });
+      }
+      expect(init?.redirect).toBe("error");
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.example/tarball" },
+      });
+    };
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: "https://github.com/acme/repo",
+        fetch: fetchImpl,
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
+    expect(() =>
+      readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
+    ).toThrow();
+  });
+
+  it("does not retain target files when the archive lacks package.json after extract", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "templates/engine/README.md": "no package\n",
+      },
+    });
+    const fetchImpl = createFetch({
+      packagePaths: new Set(["templates/engine/package.json"]),
+      archive,
+    });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: "https://github.com/acme/repo/tree/main/templates/engine",
+        fetch: fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      code: "EXAMPLE_UNAVAILABLE",
+      details: ["package.json"],
+    });
+  });
+});

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -33,19 +33,18 @@ afterEach(() => {
   }
 });
 
-function createUstarEntry(
+function createUstarHeader(
   name: string,
-  content: string | Buffer,
+  size: number,
   typeflag: string,
 ): Buffer {
-  const data = typeof content === "string" ? Buffer.from(content) : content;
   const header = Buffer.alloc(512, 0);
   const nameBytes = Buffer.from(name);
   nameBytes.copy(header, 0, 0, Math.min(nameBytes.byteLength, 100));
   header.write("0000644\0", 100);
   header.write("0000000\0", 108);
   header.write("0000000\0", 116);
-  header.write(`${data.byteLength.toString(8).padStart(11, "0")}\0`, 124);
+  header.write(`${size.toString(8).padStart(11, "0")}\0`, 124);
   header.write(
     `${Math.floor(Date.now() / 1000)
       .toString(8)
@@ -59,8 +58,31 @@ function createUstarEntry(
   let checksum = 0;
   for (let index = 0; index < 512; index += 1) checksum += header[index] ?? 0;
   header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148);
+  return header;
+}
+
+function createUstarEntry(
+  name: string,
+  content: string | Buffer,
+  typeflag: string,
+): Buffer {
+  const data = typeof content === "string" ? Buffer.from(content) : content;
+  const header = createUstarHeader(name, data.byteLength, typeflag);
   const padding = (512 - (data.byteLength % 512)) % 512;
   return Buffer.concat([header, data, Buffer.alloc(padding)]);
+}
+
+/** Build a PAX `size=` record with a correct length prefix. */
+function createPaxSizeRecord(size: number): Buffer {
+  const payload = `size=${size}\n`;
+  let lengthDigits = 1;
+  while (true) {
+    const length = lengthDigits + 1 + payload.length;
+    if (String(length).length === lengthDigits) {
+      return Buffer.from(`${length} ${payload}`);
+    }
+    lengthDigits += 1;
+  }
 }
 
 function buildRawTarGz(
@@ -440,6 +462,50 @@ describe("createExampleProject", () => {
         fetch: createFetch({ archive }),
       }),
     ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects SparseFile hidden by a PAX size override desync", async () => {
+    // PAX size=0 makes node-tar treat the next file as empty, while the ustar
+    // size claims enough bytes to swallow a following SparseFile header. A
+    // scanner that ignores PAX size never sees typeflag S and would accept.
+    const cwd = createWorkingDirectory();
+    const sparseEntry = createUstarEntry(
+      "repo-main/sparse.bin",
+      "0123456789abcdef",
+      "S",
+    );
+    const archive = gzipSync(
+      Buffer.concat([
+        createUstarEntry(
+          "repo-main/package.json",
+          '{"name":"template"}\n',
+          "0",
+        ),
+        createUstarEntry("PaxHeader/decoy", createPaxSizeRecord(0), "x"),
+        createUstarHeader("repo-main/decoy.bin", sparseEntry.byteLength, "0"),
+        sparseEntry,
+        Buffer.alloc(1024),
+      ]),
+    );
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: createFetch({ archive }),
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+    expect(() =>
+      readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
+    ).toThrow();
   });
 
   it("rejects absolute archive entry paths", async () => {

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,10 +6,15 @@ import { Readable } from "node:stream";
 import { c as createTar } from "tar";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { CreatorError } from "../src/errors.js";
+import {
+  CreatorError,
+  renderCreatorDiagnostic,
+  sanitizeDiagnosticDetail,
+} from "../src/errors.js";
 import {
   createExampleProject,
   type ExampleFetch,
+  type ExampleRepoInfo,
   parseExampleReference,
   resolveExampleReference,
 } from "../src/example.js";
@@ -30,13 +35,19 @@ afterEach(() => {
 
 async function buildRepositoryArchive(options: {
   readonly rootName: string;
-  readonly files: Readonly<Record<string, string>>;
+  readonly files?: Readonly<Record<string, string>>;
+  readonly symlinks?: Readonly<Record<string, string>>;
 }): Promise<Buffer> {
   const root = createWorkingDirectory();
-  for (const [relativePath, contents] of Object.entries(options.files)) {
+  for (const [relativePath, contents] of Object.entries(options.files ?? {})) {
     const absolute = join(root, options.rootName, relativePath);
     await mkdir(join(absolute, ".."), { recursive: true });
     await writeFile(absolute, contents, "utf8");
+  }
+  for (const [relativePath, target] of Object.entries(options.symlinks ?? {})) {
+    const absolute = join(root, options.rootName, relativePath);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    symlinkSync(target, absolute);
   }
   const archivePath = join(root, "repository.tar.gz");
   await createTar(
@@ -70,12 +81,14 @@ function createFetch(options: {
       url.pathname.startsWith("/repos/") &&
       !url.pathname.includes("/contents/")
     ) {
+      expect(init?.redirect).toBe("error");
       return jsonResponse({ default_branch: options.defaultBranch ?? "main" });
     }
     if (
       url.hostname === "api.github.com" &&
       url.pathname.includes("/contents/")
     ) {
+      expect(init?.redirect).toBe("error");
       const pathWithRef = url.pathname.split("/contents/")[1] ?? "";
       const decoded = decodeURIComponent(pathWithRef);
       const ok =
@@ -95,6 +108,22 @@ function createFetch(options: {
     }
     return new Response(null, { status: 404 });
   };
+}
+
+async function resolveTreeExample(
+  url: string,
+  archive: Buffer,
+  packagePath: string,
+): Promise<{
+  readonly info: ExampleRepoInfo;
+  readonly fetchImpl: ExampleFetch;
+}> {
+  const fetchImpl = createFetch({
+    packagePaths: new Set([packagePath]),
+    archive,
+  });
+  const info = await resolveExampleReference(url, undefined, fetchImpl);
+  return { info, fetchImpl };
 }
 
 describe("parseExampleReference", () => {
@@ -144,12 +173,14 @@ describe("parseExampleReference", () => {
     });
   });
 
-  it("rejects non-HTTPS and non-GitHub references", () => {
+  it("rejects non-HTTPS, non-GitHub, and percent-encoded traversal references", () => {
     for (const example of [
       "http://github.com/acme/repo",
       "https://gitlab.com/acme/repo",
       "git@github.com:acme/repo.git",
       "https://user:pass@github.com/acme/repo",
+      "https://github.com/a%2f..%2fb/repo",
+      "https://github.com/acme/re%2fpo",
       "../escape",
       "",
     ]) {
@@ -193,6 +224,36 @@ describe("resolveExampleReference", () => {
       details: ["package.json"],
     });
   });
+
+  it("treats API redirects as unavailable", async () => {
+    const fetchImpl: ExampleFetch = async (_input, init) => {
+      expect(init?.redirect).toBe("error");
+      return new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.example/repos/acme/repo" },
+      });
+    };
+    await expect(
+      resolveExampleReference(
+        "https://github.com/acme/repo",
+        undefined,
+        fetchImpl,
+      ),
+    ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
+  });
+});
+
+describe("diagnostic sanitization", () => {
+  it("escapes terminal-active characters in CreatorError details", () => {
+    const evil = "evil\u001b]0;pwned\u0007.txt";
+    expect(sanitizeDiagnosticDetail(evil)).not.toContain("\u001b");
+    expect(sanitizeDiagnosticDetail(evil)).not.toContain("\u0007");
+    const rendered = renderCreatorDiagnostic(
+      new CreatorError("EXAMPLE_FAILED", [evil]),
+    );
+    expect(rendered).not.toContain("\u001b");
+    expect(rendered).toContain("\\u001b");
+  });
 });
 
 describe("createExampleProject", () => {
@@ -207,15 +268,16 @@ describe("createExampleProject", () => {
         "README.md": "repo root\n",
       },
     });
-    const fetchImpl = createFetch({
-      packagePaths: new Set(["templates/engine/package.json"]),
+    const { info, fetchImpl } = await resolveTreeExample(
+      "https://github.com/acme/repo/tree/main/templates/engine",
       archive,
-    });
+      "templates/engine/package.json",
+    );
 
     const project = await createExampleProject({
       cwd,
       target: "my-engine",
-      example: "https://github.com/acme/repo/tree/main/templates/engine",
+      example: info,
       fetch: fetchImpl,
     });
 
@@ -234,16 +296,9 @@ describe("createExampleProject", () => {
 
   it("refuses redirected archive downloads", async () => {
     const cwd = createWorkingDirectory();
-    const fetchImpl: ExampleFetch = async (input, init) => {
-      if (
-        input.includes("api.github.com/repos/acme/repo") &&
-        !input.includes("/contents/")
-      ) {
-        return jsonResponse({ default_branch: "main" });
-      }
-      if (input.includes("/contents/")) {
-        return new Response(null, { status: 200 });
-      }
+    const info = parseExampleReference("https://github.com/acme/repo");
+    const resolved: ExampleRepoInfo = { ...info, branch: "main" };
+    const fetchImpl: ExampleFetch = async (_input, init) => {
       expect(init?.redirect).toBe("error");
       return new Response(null, {
         status: 302,
@@ -255,7 +310,7 @@ describe("createExampleProject", () => {
       createExampleProject({
         cwd,
         target: "my-engine",
-        example: "https://github.com/acme/repo",
+        example: resolved,
         fetch: fetchImpl,
       }),
     ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
@@ -272,21 +327,143 @@ describe("createExampleProject", () => {
         "templates/engine/README.md": "no package\n",
       },
     });
-    const fetchImpl = createFetch({
-      packagePaths: new Set(["templates/engine/package.json"]),
+    const { info, fetchImpl } = await resolveTreeExample(
+      "https://github.com/acme/repo/tree/main/templates/engine",
       archive,
-    });
+      "templates/engine/package.json",
+    );
 
     await expect(
       createExampleProject({
         cwd,
         target: "my-engine",
-        example: "https://github.com/acme/repo/tree/main/templates/engine",
+        example: info,
         fetch: fetchImpl,
       }),
     ).rejects.toMatchObject({
       code: "EXAMPLE_UNAVAILABLE",
       details: ["package.json"],
     });
+  });
+
+  it("rejects symlink archives with sanitized EXAMPLE_FAILED without crashing", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "package.json": '{"name":"template"}\n',
+      },
+      symlinks: {
+        "linked.txt": "package.json",
+      },
+    });
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+    const fetchImpl = createFetch({ archive });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: fetchImpl,
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+    expect(() =>
+      readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
+    ).toThrow();
+  });
+
+  it("rejects archives that exceed the uncompressed byte limit during extract", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "package.json": '{"name":"template"}\n',
+        "big.bin": "0123456789abcdef",
+      },
+    });
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+    const fetchImpl = createFetch({ archive });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: fetchImpl,
+        limits: { maxArchiveBytes: 20 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects archives that exceed the per-file byte limit during extract", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "package.json": '{"name":"template"}\n',
+        "big.bin": "0123456789abcdef",
+      },
+    });
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+    const fetchImpl = createFetch({ archive });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: fetchImpl,
+        limits: { maxFileBytes: 8 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects archives that exceed the extracted file count during extract", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = await buildRepositoryArchive({
+      rootName: "repo-main",
+      files: {
+        "package.json": '{"name":"template"}\n',
+        "a.txt": "a\n",
+        "b.txt": "b\n",
+      },
+    });
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+    const fetchImpl = createFetch({ archive });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: fetchImpl,
+        limits: { maxExtractedFiles: 2 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
   });
 });

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -72,6 +72,22 @@ function createUstarEntry(
   return Buffer.concat([header, data, Buffer.alloc(padding)]);
 }
 
+function createUstarLinkEntry(
+  name: string,
+  linkpath: string,
+  typeflag: "1" | "2",
+): Buffer {
+  const header = createUstarHeader(name, 0, typeflag);
+  const linkBytes = Buffer.from(linkpath);
+  linkBytes.copy(header, 157, 0, Math.min(linkBytes.byteLength, 100));
+  // Recalculate checksum after writing linkpath.
+  header.write("        ", 148);
+  let checksum = 0;
+  for (let index = 0; index < 512; index += 1) checksum += header[index] ?? 0;
+  header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148);
+  return header;
+}
+
 /** Build a PAX `size=` record with a correct length prefix. */
 function createPaxSizeRecord(size: number): Buffer {
   const payload = `size=${size}\n`;
@@ -109,12 +125,24 @@ function buildSparseSmugglingArchive(options: {
 
 function buildRawTarGz(
   entries: ReadonlyArray<
-    Readonly<{ name: string; content?: string | Buffer; typeflag: string }>
+    Readonly<{
+      name: string;
+      content?: string | Buffer;
+      typeflag: string;
+      linkpath?: string;
+    }>
   >,
 ): Buffer {
-  const parts = entries.map((entry) =>
-    createUstarEntry(entry.name, entry.content ?? "", entry.typeflag),
-  );
+  const parts = entries.map((entry) => {
+    if (entry.typeflag === "1" || entry.typeflag === "2") {
+      return createUstarLinkEntry(
+        entry.name,
+        entry.linkpath ?? "",
+        entry.typeflag,
+      );
+    }
+    return createUstarEntry(entry.name, entry.content ?? "", entry.typeflag);
+  });
   parts.push(Buffer.alloc(1024));
   return gzipSync(Buffer.concat(parts));
 }
@@ -387,17 +415,33 @@ describe("createExampleProject", () => {
 
   it("rejects symlink and hardlink archives without crashing", async () => {
     const cwd = createWorkingDirectory();
+    // Build links from raw ustar headers so pack/gzip of live links cannot
+    // race and emit uncaught Z_STREAM_ERROR after the assertion.
     for (const archive of [
-      await buildRepositoryArchive({
-        rootName: "repo-main",
-        files: { "package.json": '{"name":"template"}\n' },
-        symlinks: { "linked.txt": "package.json" },
-      }),
-      await buildRepositoryArchive({
-        rootName: "repo-main",
-        files: { "package.json": '{"name":"template"}\n' },
-        hardlinks: { "linked.txt": "package.json" },
-      }),
+      buildRawTarGz([
+        {
+          name: "repo-main/package.json",
+          content: '{"name":"template"}\n',
+          typeflag: "0",
+        },
+        {
+          name: "repo-main/linked.txt",
+          typeflag: "2",
+          linkpath: "package.json",
+        },
+      ]),
+      buildRawTarGz([
+        {
+          name: "repo-main/package.json",
+          content: '{"name":"template"}\n',
+          typeflag: "0",
+        },
+        {
+          name: "repo-main/linked.txt",
+          typeflag: "1",
+          linkpath: "package.json",
+        },
+      ]),
     ]) {
       const info: ExampleRepoInfo = {
         owner: "acme",
@@ -414,6 +458,9 @@ describe("createExampleProject", () => {
           fetch: createFetch({ archive }),
         }),
       ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+      expect(() =>
+        readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
+      ).toThrow();
     }
   });
 
@@ -620,36 +667,42 @@ describe("createExampleProject", () => {
     ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
   });
 
-  it("rejects absolute archive entry paths", async () => {
+  it("rejects absolute, parent, drive, and UNC archive entry paths", async () => {
     const cwd = createWorkingDirectory();
-    const archive = buildRawTarGz([
-      {
-        name: "/package.json",
-        content: '{"name":"template"}\n',
-        typeflag: "0",
-      },
-      {
-        name: "/src/engine.ts",
-        content: "export {}\n",
-        typeflag: "0",
-      },
-    ]);
-    const info: ExampleRepoInfo = {
-      owner: "acme",
-      repository: "repo",
-      branch: "main",
-      filePath: "",
-      label: "acme/repo",
-    };
-
-    await expect(
-      createExampleProject({
-        cwd,
-        target: "my-engine",
-        example: info,
-        fetch: createFetch({ archive }),
-      }),
-    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+    const unsafeNames = [
+      "/package.json",
+      "repo-main/../outside.txt",
+      "C:/windows/package.json",
+      "C:\\windows\\package.json",
+      "//server/share/package.json",
+      "\\\\server\\share\\package.json",
+    ];
+    for (const name of unsafeNames) {
+      const archive = buildRawTarGz([
+        {
+          name,
+          content: '{"name":"template"}\n',
+          typeflag: "0",
+        },
+      ]);
+      await expect(
+        createExampleProject({
+          cwd,
+          target: "my-engine",
+          example: {
+            owner: "acme",
+            repository: "repo",
+            branch: "main",
+            filePath: "",
+            label: "acme/repo",
+          },
+          fetch: createFetch({ archive }),
+        }),
+      ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+      expect(() =>
+        readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
+      ).toThrow();
+    }
   });
 
   it("rejects a directory named package.json", async () => {
@@ -820,10 +873,12 @@ describe("createExampleProject", () => {
 
 describe("success output sanitization", () => {
   it("escapes control characters the success renderer would emit", () => {
-    const hostile = "acme/repo/\u001b[31mevil";
-    const line = `Created my-engine from example ${sanitizeDiagnosticDetail(hostile)}.`;
-    expect(line).not.toContain("\u001b");
-    expect(line).toContain("\\u001b");
-    expect(line).toContain("from example acme/repo/");
+    // Mirrors cli.ts renderSuccess first-line shape.
+    const projectName = "my-engine";
+    const sourceLabel = "acme/repo/\u001b[31mevil";
+    const firstLine = `Created ${sanitizeDiagnosticDetail(projectName)} ${sanitizeDiagnosticDetail(sourceLabel)}.`;
+    expect(firstLine).not.toContain("\u001b");
+    expect(firstLine).toContain("\\u001b");
+    expect(firstLine).toBe("Created my-engine acme/repo/\\u001b[31mevil.");
   });
 });

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -6,7 +6,6 @@ import { Readable } from "node:stream";
 import { gzipSync } from "node:zlib";
 import { c as createTar } from "tar";
 import { afterEach, describe, expect, it } from "vitest";
-import { runCreateEngineCli } from "../src/cli.js";
 import {
   CreatorError,
   renderCreatorDiagnostic,
@@ -380,11 +379,47 @@ describe("createExampleProject", () => {
       { name: "repo-main/", typeflag: "5" },
       {
         name: "repo-main/package.json",
-        content: '{"name":"template"}\n',
+        content: '{"n":1}\n',
         typeflag: "0",
       },
       {
         name: "repo-main/big.bin",
+        content: "0123456789abcdef",
+        typeflag: "7", // ContiguousFile
+      },
+    ]);
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: createFetch({ archive }),
+        limits: { maxFileBytes: 12 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+    expect(() =>
+      readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
+    ).toThrow();
+  });
+
+  it("rejects SparseFile entries that node-tar would otherwise ignore", async () => {
+    const cwd = createWorkingDirectory();
+    const archive = buildRawTarGz([
+      {
+        name: "repo-main/package.json",
+        content: '{"name":"template"}\n',
+        typeflag: "0",
+      },
+      {
+        name: "repo-main/sparse.bin",
         content: "0123456789abcdef",
         typeflag: "S",
       },
@@ -403,7 +438,6 @@ describe("createExampleProject", () => {
         target: "my-engine",
         example: info,
         fetch: createFetch({ archive }),
-        limits: { maxFileBytes: 8 },
       }),
     ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
   });
@@ -522,6 +556,40 @@ describe("createExampleProject", () => {
     ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
   });
 
+  it("counts implicit parent directories from file paths toward the directory cap", async () => {
+    const cwd = createWorkingDirectory();
+    // No directory headers — only nested files, which still create dirs on extract.
+    const archive = buildRawTarGz([
+      {
+        name: "repo-main/package.json",
+        content: '{"name":"template"}\n',
+        typeflag: "0",
+      },
+      {
+        name: "repo-main/a/b/file.txt",
+        content: "nested\n",
+        typeflag: "0",
+      },
+    ]);
+    const info: ExampleRepoInfo = {
+      owner: "acme",
+      repository: "repo",
+      branch: "main",
+      filePath: "",
+      label: "acme/repo",
+    };
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: info,
+        fetch: createFetch({ archive }),
+        limits: { maxExtractedDirectories: 1 },
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
   it("rejects compressed downloads that exceed the compressed-byte cap", async () => {
     const cwd = createWorkingDirectory();
     const archive = await buildRepositoryArchive({
@@ -548,62 +616,36 @@ describe("createExampleProject", () => {
       }),
     ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
   });
+
+  it("surfaces fetch timeouts as EXAMPLE_UNAVAILABLE", async () => {
+    const fetchImpl: ExampleFetch = async (_input, init) =>
+      await new Promise((_resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error("test should have aborted"));
+        }, 1_000);
+        init?.signal?.addEventListener("abort", () => {
+          clearTimeout(timer);
+          reject(new Error("aborted"));
+        });
+      });
+
+    await expect(
+      resolveExampleReference(
+        "https://github.com/acme/repo",
+        undefined,
+        fetchImpl,
+        { fetchTimeoutMs: 20 },
+      ),
+    ).rejects.toMatchObject({ code: "EXAMPLE_UNAVAILABLE" });
+  });
 });
 
 describe("success output sanitization", () => {
-  it("escapes control characters in the example success summary", async () => {
-    const cwd = createWorkingDirectory();
-    const archive = await buildRepositoryArchive({
-      rootName: "repo-main",
-      files: {
-        "package.json": '{"name":"template"}\n',
-      },
-    });
-    const stdout: string[] = [];
-    const fetchImpl = createFetch({ archive });
-    const info: ExampleRepoInfo = {
-      owner: "acme",
-      repository: "repo",
-      branch: "main",
-      filePath: "",
-      label: "acme/repo/\u001b[31mevil",
-    };
-
-    // Bypass parse (control chars rejected there) and assert render sanitizes.
-    const project = await createExampleProject({
-      cwd,
-      target: "my-engine",
-      example: { ...info, label: "acme/repo" },
-      fetch: fetchImpl,
-    });
-    expect(project.label).toBe("acme/repo");
-
-    const exitCode = await runCreateEngineCli({
-      argv: [
-        "safe-engine",
-        "--example",
-        "https://github.com/acme/repo",
-        "--no-install",
-        "--yes",
-      ],
-      cwd: createWorkingDirectory(),
-      env: {},
-      io: {
-        writeStdout(text) {
-          stdout.push(text);
-        },
-        writeStderr() {},
-      },
-      terminal: {
-        stdinIsTty: false,
-        stderrIsTty: false,
-        readLine: async () => undefined,
-      },
-      fetch: fetchImpl,
-      loadPackageVersion: async () => "1.2.3",
-    });
-    expect(exitCode).toBe(0);
-    expect(stdout.join("")).not.toContain("\u001b");
-    expect(stdout.join("")).toContain("from example acme/repo");
+  it("escapes control characters the success renderer would emit", () => {
+    const hostile = "acme/repo/\u001b[31mevil";
+    const line = `Created my-engine from example ${sanitizeDiagnosticDetail(hostile)}.`;
+    expect(line).not.toContain("\u001b");
+    expect(line).toContain("\\u001b");
+    expect(line).toContain("from example acme/repo/");
   });
 });

--- a/packages/create-invokta-engine/test/example.test.ts
+++ b/packages/create-invokta-engine/test/example.test.ts
@@ -85,6 +85,28 @@ function createPaxSizeRecord(size: number): Buffer {
   }
 }
 
+function createPaxSizeRecords(sizes: readonly number[]): Buffer {
+  return Buffer.concat(sizes.map((size) => createPaxSizeRecord(size)));
+}
+
+function buildSparseSmugglingArchive(options: {
+  readonly beforeSparse: Buffer;
+}): Buffer {
+  const sparseEntry = createUstarEntry(
+    "repo-main/sparse.bin",
+    "0123456789abcdef",
+    "S",
+  );
+  return gzipSync(
+    Buffer.concat([
+      createUstarEntry("repo-main/package.json", '{"name":"template"}\n', "0"),
+      options.beforeSparse,
+      sparseEntry,
+      Buffer.alloc(1024),
+    ]),
+  );
+}
+
 function buildRawTarGz(
   entries: ReadonlyArray<
     Readonly<{ name: string; content?: string | Buffer; typeflag: string }>
@@ -466,27 +488,19 @@ describe("createExampleProject", () => {
 
   it("rejects SparseFile hidden by a PAX size override desync", async () => {
     // PAX size=0 makes node-tar treat the next file as empty, while the ustar
-    // size claims enough bytes to swallow a following SparseFile header. A
-    // scanner that ignores PAX size never sees typeflag S and would accept.
+    // size claims enough bytes to swallow a following SparseFile header.
     const cwd = createWorkingDirectory();
     const sparseEntry = createUstarEntry(
       "repo-main/sparse.bin",
       "0123456789abcdef",
       "S",
     );
-    const archive = gzipSync(
-      Buffer.concat([
-        createUstarEntry(
-          "repo-main/package.json",
-          '{"name":"template"}\n',
-          "0",
-        ),
+    const archive = buildSparseSmugglingArchive({
+      beforeSparse: Buffer.concat([
         createUstarEntry("PaxHeader/decoy", createPaxSizeRecord(0), "x"),
         createUstarHeader("repo-main/decoy.bin", sparseEntry.byteLength, "0"),
-        sparseEntry,
-        Buffer.alloc(1024),
       ]),
-    );
+    });
     const info: ExampleRepoInfo = {
       owner: "acme",
       repository: "repo",
@@ -506,6 +520,104 @@ describe("createExampleProject", () => {
     expect(() =>
       readFileSync(join(cwd, "my-engine", "package.json"), "utf8"),
     ).toThrow();
+  });
+
+  it("rejects SparseFile hidden when duplicate PAX size keeps the last value", async () => {
+    // node-tar keeps the last size= record; a first-wins scanner skips the
+    // SparseFile header as decoy payload and would accept the archive.
+    const cwd = createWorkingDirectory();
+    const sparseEntry = createUstarEntry(
+      "repo-main/sparse.bin",
+      "0123456789abcdef",
+      "S",
+    );
+    const archive = buildSparseSmugglingArchive({
+      beforeSparse: Buffer.concat([
+        createUstarEntry(
+          "PaxHeader/decoy",
+          createPaxSizeRecords([sparseEntry.byteLength, 0]),
+          "x",
+        ),
+        createUstarHeader("repo-main/decoy.bin", sparseEntry.byteLength, "0"),
+      ]),
+    });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: {
+          owner: "acme",
+          repository: "repo",
+          branch: "main",
+          filePath: "",
+          label: "acme/repo",
+        },
+        fetch: createFetch({ archive }),
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects SparseFile hidden behind a nonzero directory header size", async () => {
+    const cwd = createWorkingDirectory();
+    const sparseEntry = createUstarEntry(
+      "repo-main/sparse.bin",
+      "0123456789abcdef",
+      "S",
+    );
+    const archive = buildSparseSmugglingArchive({
+      beforeSparse: createUstarHeader(
+        "repo-main/dir/",
+        sparseEntry.byteLength,
+        "5",
+      ),
+    });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: {
+          owner: "acme",
+          repository: "repo",
+          branch: "main",
+          filePath: "",
+          label: "acme/repo",
+        },
+        fetch: createFetch({ archive }),
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
+  });
+
+  it("rejects SparseFile hidden behind a trailing-slash file header", async () => {
+    const cwd = createWorkingDirectory();
+    const sparseEntry = createUstarEntry(
+      "repo-main/sparse.bin",
+      "0123456789abcdef",
+      "S",
+    );
+    const archive = buildSparseSmugglingArchive({
+      beforeSparse: createUstarHeader(
+        "repo-main/dirish/",
+        sparseEntry.byteLength,
+        "0",
+      ),
+    });
+
+    await expect(
+      createExampleProject({
+        cwd,
+        target: "my-engine",
+        example: {
+          owner: "acme",
+          repository: "repo",
+          branch: "main",
+          filePath: "",
+          label: "acme/repo",
+        },
+        fetch: createFetch({ archive }),
+      }),
+    ).rejects.toMatchObject({ code: "EXAMPLE_FAILED" });
   });
 
   it("rejects absolute archive entry paths", async () => {

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -1,11 +1,9 @@
 import { readFileSync } from "node:fs";
-
-import { describe, expect, it } from "vitest";
-
 import {
   createMcpHttpScaffoldFiles,
   starterDeployManifest,
 } from "@invokta/deploy/scaffold";
+import { describe, expect, it } from "vitest";
 
 import {
   createStarterFiles,
@@ -118,7 +116,10 @@ describe("createStarterFiles", () => {
     expect(source).toContain('from "@invokta/deploy/scaffold"');
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
-    expect(manifest.dependencies).toEqual({ "@invokta/deploy": "0.3.0" });
+    expect(manifest.dependencies).toEqual({
+      "@invokta/deploy": "0.3.0",
+      tar: "7.5.22",
+    });
   });
 
   it.each([

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/momoa/-/momoa-3.3.10.tgz#8ffe034b31e1d43e480846695869c45a06539c73"
   integrity sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -565,6 +572,11 @@ chai@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
   integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 content-disposition@^1.0.0:
   version "1.1.0"
@@ -1083,6 +1095,18 @@ mime-types@^3.0.0, mime-types@^3.0.2:
   dependencies:
     mime-db "^1.54.0"
 
+minipass@^7.0.4, minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -1373,6 +1397,17 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+tar@7.5.22:
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -1521,6 +1556,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml@2.9.0:
   version "2.9.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `create-invokta-engine --example` support for importing recipes/templates from public GitHub repositories (create-next-app–style), with ADR 0020 and a dedicated import contract.

### Behavior
- `--example <name|github-url>` with optional `--example-path`
- Mutually exclusive with `--profile`
- Short names resolve to `vinilana/invokta` `examples/<name>` on `main`
- HTTPS `github.com` only; downloads from `codeload.github.com` with `redirect: "error"`
- Archive safety: reject unsafe paths/links; enforce compressed + uncompressed/per-file/file/directory limits during extract; pre-scan with `tar.Parser` (fail closed on `ignoredEntry`) so SparseFile and PAX/directory size semantics cannot bypass rejection

### Review hardening
- Fable 5 / GPT 5.6 Sol rounds closed: ContiguousFile limits, absolute/parent/drive/UNC paths, directory `package.json`, success-label sanitization, slash-containing refs, retained-directory caps, timeout coverage, Parser pre-scan, PAX/directory SparseFile regressions, deterministic link fixtures

## Validation
- `yarn run check` — 2,268 tests + 1 skip; coverage 85.38% / 79.30% / 87.73% / 87.08%
- Focused: `yarn vitest run packages/create-invokta-engine`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-258048f2-fc45-4d33-b141-4f90a8e065e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-258048f2-fc45-4d33-b141-4f90a8e065e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

