### PR TITLE
ci: include dependency audits in canonical check

### DIFF
--- a/.github/workflows/security-and-release.yml
+++ b/.github/workflows/security-and-release.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Run full checks
         run: yarn run check
 
-      - name: Audit dependencies
-        run: yarn audit
-
       - name: Dry-run public packages
         run: |
           for package_directory in ./packages/core ./packages/cli ./packages/mcp ./packages/tooling ./packages/installer ./packages/deploy ./packages/devtools ./packages/create-invokta-engine ./packages/create-invokta-capability ./packages/create-invokta-capability-library; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- `yarn run check` now includes the dependency security audits used by CI for
+  both independently locked projects: the framework root and `apps/docs`. The
+  registry-independent code gate remains available as `yarn check:code`, while
+  both audits are exposed through `yarn check:security`.
 - MCP stdio and HTTP now publish deterministic portable tool aliases that match
   `^[a-zA-Z0-9_-]{1,64}$`, while direct and CLI invocation keep the original
   capability IDs. Tool calls resolve aliases back through the same
@@ -21,6 +25,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Pinned the transitive `nanoid` dependency to 3.3.17 so development and CI
   tooling no longer resolves the vulnerable zero-size custom-generator
   implementation reported through the Vitest dependency chain.
+- Pinned the documentation dependency graph to patched `js-yaml` 4.3.1 and
+  `nanoid` 3.3.17 releases.
 
 ## [0.4.0] - 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ yarn install --frozen-lockfile
 yarn run check
 ```
 
+The canonical check runs the code-quality, test, coverage, and build gates,
+then audits both independently locked dependency graphs—the framework root and
+`apps/docs`—against the configured registry. Use `yarn check:code` only when
+intentionally validating code offline; pull request and release acceptance
+requires the complete `yarn run check` command.
+
 Then follow the [getting-started guide](./docs/getting-started.md) or inspect:
 
 - [`hello-engine`](./examples/hello-engine/) for the shortest complete path;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,6 +6,10 @@
     "node": ">=22.20.0"
   },
   "packageManager": "yarn@1.22.22",
+  "resolutions": {
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.17"
+  },
   "scripts": {
     "dev": "astro dev",
     "test": "node --test test/*.node.mjs",

--- a/apps/docs/yarn.lock
+++ b/apps/docs/yarn.lock
@@ -2172,10 +2172,10 @@ is-plain-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
-js-yaml@^4.1.1, js-yaml@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@4.3.1, js-yaml@^4.1.1, js-yaml@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -2941,10 +2941,10 @@ muggle-string@^0.4.1:
   resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.4.1.tgz#3b366bd43b32f809dc20659534dd30e7c8a0d328"
   integrity sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.17, nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 neotraverse@^1.0.1:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "lint": "biome lint .",
     "format:check": "biome format .",
     "release:verify": "node scripts/verify-release-packages.mjs",
-    "check": "yarn typecheck && yarn lint && yarn format:check && yarn test:coverage && yarn build"
+    "check:code": "yarn typecheck && yarn lint && yarn format:check && yarn test:coverage && yarn build",
+    "check:security": "yarn audit && yarn --cwd apps/docs audit",
+    "check": "yarn check:code && yarn check:security"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.6",

--- a/packages/tooling/test/repository-check.test.ts
+++ b/packages/tooling/test/repository-check.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = new URL("../../..", import.meta.url);
+
+function readRepositoryFile(path: string): string {
+  return readFileSync(new URL(path, repositoryRoot), "utf8");
+}
+
+describe("repository check", () => {
+  it("keeps dependency auditing inside the canonical check", () => {
+    const packageManifest = JSON.parse(readRepositoryFile("package.json")) as {
+      readonly scripts: Readonly<Record<string, string>>;
+    };
+    const workflow = readRepositoryFile(
+      ".github/workflows/security-and-release.yml",
+    );
+
+    expect(packageManifest.scripts["check:code"]).toBe(
+      "yarn typecheck && yarn lint && yarn format:check && yarn test:coverage && yarn build",
+    );
+    expect(packageManifest.scripts["check:security"]).toBe(
+      "yarn audit && yarn --cwd apps/docs audit",
+    );
+    expect(packageManifest.scripts.check).toBe(
+      "yarn check:code && yarn check:security",
+    );
+    expect(workflow).toContain("run: yarn run check");
+    expect(workflow).not.toMatch(/^\s*run: yarn audit\s*$/mu);
+  });
+});


### PR DESCRIPTION
## What changed

- split the canonical repository gate into `check:code` and `check:security`
- make `yarn run check` execute both security audits, covering the root lockfile and the independently locked `apps/docs` project
- remove the duplicate standalone audit step from GitHub Actions so CI and local acceptance use the same command
- add a repository contract test that prevents the audit from drifting outside the canonical check
- pin patched `js-yaml` and `nanoid` releases in the documentation dependency graph
- document the online audit requirement and the offline `check:code` escape hatch

## Why

The previous CI workflow ran `yarn audit` after `yarn run check`, so the canonical local gate could pass while a vulnerable dependency still failed CI. The root audit also ignored `apps/docs/yarn.lock`, which is an independent dependency graph and still contained two high-severity Dependabot alerts.

This change makes the documented acceptance command authoritative and covers both lockfiles.

## Impact

`yarn run check` now requires registry access for its final security gate. Contributors who intentionally need an offline code-only validation can run `yarn check:code`; pull request and release acceptance continues to require the complete check.

## Validation

- RED: the repository contract test failed while `check:security` audited only the root graph
- `npx vitest run packages/tooling/test/repository-check.test.ts`
- `yarn check:security` — zero vulnerabilities across 271 root packages and 537 documentation packages
- `yarn --cwd apps/docs validate` — 15 tests, Astro check with zero diagnostics, 48-page build
- `yarn run check` — 170 test files, 2,624 passed, 1 skipped, coverage and build passed, both audits clean
