### PR TITLE
Add self-hosted OAuth 2.1 engine and OAuth inspection tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   connects or listens. MCP clients that hard-code dotted tool names must refresh
   `tools/list` and use the advertised alias.
 
+### Security
+
+- Pinned the transitive `nanoid` dependency to 3.3.17 so development and CI
+  tooling no longer resolves the vulnerable zero-size custom-generator
+  implementation reported through the Vitest dependency chain.
+
 ## [0.4.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- MCP stdio and HTTP now publish deterministic portable tool aliases that match
+  `^[a-zA-Z0-9_-]{1,64}$`, while direct and CLI invocation keep the original
+  capability IDs. Tool calls resolve aliases back through the same
+  `engine.invoke` path, and ambiguous aliases fail closed before the server
+  connects or listens. MCP clients that hard-code dotted tool names must refresh
+  `tools/list` and use the advertised alias.
+
 ## [0.4.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- MCP stdio and HTTP now publish deterministic portable tool aliases that match
+  `^[a-zA-Z0-9_-]{1,64}$`, while direct and CLI invocation keep the original
+  capability IDs. Tool calls resolve aliases back through the same
+  `engine.invoke` path, and ambiguous aliases fail closed before the server
+  connects or listens. MCP clients that hard-code dotted tool names must refresh
+  `tools/list` and use the advertised alias.
+
+### Security
+
+- Pinned the transitive `nanoid` dependency to 3.3.17 so development and CI
+  tooling no longer resolves the vulnerable zero-size custom-generator
+  implementation reported through the Vitest dependency chain.
+
 ## [0.4.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- MCP stdio and HTTP now publish deterministic portable tool aliases that match
+  `^[a-zA-Z0-9_-]{1,64}$`, while direct and CLI invocation keep the original
+  capability IDs. Tool calls resolve aliases back through the same
+  `engine.invoke` path, and ambiguous aliases fail closed before the server
+  connects or listens. MCP clients that hard-code dotted tool names must refresh
+  `tools/list` and use the advertised alias.
 - Official example imports now rewrite npm lockfile package names together with
   `package.json`, and malformed lockfiles roll back the import.
 - MCP Protected Resource Metadata accepts an HTTP Authorization Server only at
@@ -34,6 +40,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Security
 
+- Pinned the transitive `nanoid` dependency to 3.3.17 so development and CI
+  tooling no longer resolves the vulnerable zero-size custom-generator
+  implementation reported through the Vitest dependency chain.
 - Self-hosted Client ID Metadata Documents remain disabled until the example
   has an SSRF-resistant fetch policy. Discovery inspection never accepts
   credentials, follows redirects, prints raw metadata, or mutates the remote

--- a/apps/docs/src/content/docs/guides/capability-packages.mdx
+++ b/apps/docs/src/content/docs/guides/capability-packages.mdx
@@ -198,7 +198,8 @@ const classifyTicket = importCapability(
 
 `as` replaces the default ID; it does not create an alias. Only
 `operations.classify-ticket` appears in `invoke`, `list`, `describe`, access
-rules, events, CLI commands, and MCP tool names.
+rules, events, and CLI commands. MCP publishes its derived portable alias,
+`operations_classify-ticket`, and resolves calls back to the effective ID.
 
 To expose the same atomic capability under two IDs during a deliberate
 migration, declare two imports explicitly:

--- a/apps/docs/src/content/docs/recipes/auth/api-key.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/api-key.mdx
@@ -212,14 +212,15 @@ API_KEY_ENGINE_KEYS='[{"keyId":"svc_9f21c4a7","secretHash":"<hex sha256>","servi
   node examples/auth-api-key-engine/dist/mcp-http.js
 ```
 
-Call `identity.whoami` with the key whose secret hashes to that digest:
+Call the `identity.whoami` capability through MCP as `identity_whoami` with the
+key whose secret hashes to that digest:
 
 ```sh
 curl -sS http://127.0.0.1:3000/mcp \
   -H 'authorization: Bearer svc_9f21c4a7.<secret>' \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The result reports `principalId: "reports-worker"` and the `keyId` that proved

--- a/apps/docs/src/content/docs/recipes/auth/auth0.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/auth0.mdx
@@ -299,7 +299,7 @@ curl -i --request POST http://127.0.0.1:3000/mcp \
   --header "authorization: Bearer $ACCESS_TOKEN" \
   --header 'accept: application/json, text/event-stream' \
   --header 'content-type: application/json' \
-  --data '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  --data '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The result echoes the `sub`, the scopes, and the RBAC permissions the token

--- a/apps/docs/src/content/docs/recipes/auth/authjs.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/authjs.mdx
@@ -360,7 +360,7 @@ curl --fail-with-body http://127.0.0.1:3000/mcp \
   --header 'Accept: application/json, text/event-stream' \
   --header "Authorization: Bearer $ENGINE_ACCESS_TOKEN" \
   --header 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","id":"whoami-1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  --data '{"jsonrpc":"2.0","id":"whoami-1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 A missing, malformed, expired, foreign-issuer, foreign-audience, or

--- a/apps/docs/src/content/docs/recipes/auth/better-auth.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/better-auth.mdx
@@ -301,7 +301,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $BETTER_AUTH_JWT" \
   -H "accept: application/json, text/event-stream" \
   -H "content-type: application/json" \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 Without the header, or with an expired token, the adapter answers HTTP 401

--- a/apps/docs/src/content/docs/recipes/auth/clerk.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/clerk.mdx
@@ -320,7 +320,7 @@ curl -sS http://127.0.0.1:3010/mcp \
   -H "authorization: Bearer $CLERK_SESSION_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The result reports the Clerk user ID and the session and organization

--- a/apps/docs/src/content/docs/recipes/auth/cognito.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/cognito.mdx
@@ -321,7 +321,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H 'accept: application/json, text/event-stream' \
   -H "authorization: Bearer $COGNITO_ACCESS_TOKEN" \
   -d '{"jsonrpc":"2.0","id":"1","method":"tools/call",
-       "params":{"name":"identity.whoami","arguments":{}}}'
+       "params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The response reports the principal built from `sub`, `client_id`, `scope`, and

--- a/apps/docs/src/content/docs/recipes/auth/firebase.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/firebase.mdx
@@ -395,7 +395,7 @@ curl -i --request POST http://127.0.0.1:3000/mcp \
   --header "authorization: Bearer $FIREBASE_ID_TOKEN" \
   --header 'accept: application/json, text/event-stream' \
   --header 'content-type: application/json' \
-  --data '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  --data '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The result echoes the `uid` and the enumerated attributes the token proved.

--- a/apps/docs/src/content/docs/recipes/auth/jwt-bearer.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/jwt-bearer.mdx
@@ -278,7 +278,7 @@ curl -s http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $ACCESS_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The same request without the header returns HTTP 401 with a `WWW-Authenticate:

--- a/apps/docs/src/content/docs/recipes/auth/mcp-oauth-discovery.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/mcp-oauth-discovery.mdx
@@ -185,7 +185,7 @@ Then trigger the challenge an OAuth-capable client starts from:
 curl -si http://127.0.0.1:3000/mcp \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}' \
   | grep -i www-authenticate
 ```
 

--- a/apps/docs/src/content/docs/recipes/auth/mcp-oauth-discovery.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/mcp-oauth-discovery.mdx
@@ -187,7 +187,7 @@ Then trigger the challenge an OAuth-capable client starts from:
 curl -si http://127.0.0.1:3000/mcp \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}' \
   | grep -i www-authenticate
 ```
 

--- a/apps/docs/src/content/docs/recipes/auth/self-hosted-oauth.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/self-hosted-oauth.mdx
@@ -225,7 +225,8 @@ npm run oauth:probe-dcr -- --url https://mcp.example.com
 ```
 
 Then connect Invokta devtools to the MCP URL with OAuth, complete login and
-consent once, confirm `identity.whoami` appears, and invoke it deliberately.
+consent once, confirm the portable `identity_whoami` tool appears, and invoke
+it deliberately.
 Before an Invokta release, record fresh Gemini, ChatGPT, and local loopback
 client results with the
 [OAuth client interoperability checklist](https://github.com/vinilana/invokta/blob/main/docs/oauth-client-interoperability-checklist.md).

--- a/apps/docs/src/content/docs/recipes/auth/supabase.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/supabase.mdx
@@ -288,7 +288,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The same request without the header returns HTTP 401 before `engine.invoke`

--- a/apps/docs/src/content/docs/recipes/auth/workos.mdx
+++ b/apps/docs/src/content/docs/recipes/auth/workos.mdx
@@ -251,7 +251,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $WORKOS_ACCESS_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The result echoes the verified identity, including `org_id`. Dropping the

--- a/apps/docs/src/content/docs/recipes/mcp-stdio-consumer.mdx
+++ b/apps/docs/src/content/docs/recipes/mcp-stdio-consumer.mdx
@@ -10,8 +10,9 @@ or an Invokta package. It can launch the engine's stdio entry point with the
 official MCP client, discover tools, call one, and own its own conversation or
 workflow state.
 
-This recipe follows `support-harness`, a private one-shot consumer of
-`support.classify-ticket`.
+This recipe follows `support-harness`, a private one-shot consumer of the
+`support.classify-ticket` capability published as
+`support_classify-ticket` over MCP.
 
 ## Build the consumer
 
@@ -57,7 +58,7 @@ This recipe follows `support-harness`, a private one-shot consumer of
    const tools = await client.listTools();
    const toolNames = tools.tools.map(({ name }) => name);
 
-   if (!toolNames.includes("support.classify-ticket")) {
+   if (!toolNames.includes("support_classify-ticket")) {
      throw new Error("Required support tool was not found.");
    }
    ```
@@ -69,7 +70,7 @@ This recipe follows `support-harness`, a private one-shot consumer of
 
    ```ts
    const result = await client.callTool({
-     name: "support.classify-ticket",
+     name: "support_classify-ticket",
      arguments: { ticketId: "T-123" },
    });
 

--- a/apps/docs/src/content/docs/reference/mcp.mdx
+++ b/apps/docs/src/content/docs/reference/mcp.mdx
@@ -26,6 +26,7 @@ transport types are not part of its public API.
 The package root exports:
 
 - `serveMcpStdio` and `ServeMcpStdioOptions`;
+- `toMcpToolName`;
 - `serveMcpHttp` and `ServeMcpHttpOptions`;
 - `McpHttpAuthOptions`;
 - `McpHttpAuthenticationRequest` and `McpHttpHeaderView`;
@@ -36,7 +37,7 @@ The package root exports:
 
 | Capability | MCP tool |
 | --- | --- |
-| Engine map key | `name` |
+| Engine map key | Portable `name` alias |
 | `title` | `title` |
 | `description` | `description` |
 | Input JSON Schema | `inputSchema` |
@@ -48,6 +49,19 @@ The package root exports:
 
 Engine name and version become the MCP server identity. Omitted tool arguments
 default to `{}` before input validation.
+
+Tool names always match `^[a-zA-Z0-9_-]{1,64}$`. Each unsupported character in
+the capability ID becomes `_`. A name longer than 64 characters uses its first
+51 portable characters, `_`, and the first 12 lowercase hexadecimal characters
+of the original ID's SHA-256 digest. An empty ID becomes `_`; an already
+compatible ID remains unchanged. For example,
+`support.classify-ticket` is published as `support_classify-ticket`.
+
+`tools/call` resolves the published alias back to the original capability ID
+before calling `engine.invoke`. If two capability IDs derive the same alias,
+the protocol server fails closed rather than publishing an ambiguous catalog.
+Hosts that need to display or submit the alias outside `tools/list` can derive
+the same value with `toMcpToolName(capabilityId)`.
 
 A successful call returns the validated result as `structuredContent` plus a
 JSON text fallback. Invocation failures return `isError: true` with one safe JSON
@@ -61,6 +75,12 @@ An unknown tool is a protocol `InvalidParams` error rather than an invocation
 `CAPABILITY_NOT_FOUND`. Valid request IDs such as numeric `0` and the empty
 string retain their wire identity, and cancellation reaches only its matching
 request.
+
+<Aside type="caution" title="Migration from dotted MCP tool names">
+  Refresh `tools/list` after upgrading and replace hard-coded MCP tool names
+  with the published aliases. Direct calls, CLI commands, composition, access
+  rules, and events continue to use the original dotted capability IDs.
+</Aside>
 
 ## `serveMcpStdio`
 

--- a/apps/docs/yarn.lock
+++ b/apps/docs/yarn.lock
@@ -1782,9 +1782,9 @@ fast-string-width@^3.0.2:
     fast-string-truncated-width "^3.0.2"
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.2"

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ Each delivered change is normative through its accepted architecture decision:
   [ADR 0023](./adr/0023-ephemeral-oauth-for-installed-mcp-inspection.md)
 - Production MCP OAuth integration boundary —
   [ADR 0024](./adr/0024-production-mcp-oauth-integration-boundary.md)
+- Portable MCP tool names —
+  [ADR 0025](./adr/0025-portable-mcp-tool-names.md)
 
 ## Guides and examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@ Each delivered change is normative through its accepted architecture decision:
   [ADR 0022](./adr/0022-mcp-installation-inspection-and-homologation.md),
   extended with ephemeral OAuth by
   [ADR 0023](./adr/0023-ephemeral-oauth-for-installed-mcp-inspection.md)
+- Portable MCP tool names —
+  [ADR 0025](./adr/0025-portable-mcp-tool-names.md)
 
 ## Guides and examples
 

--- a/docs/adr/0025-portable-mcp-tool-names.md
+++ b/docs/adr/0025-portable-mcp-tool-names.md
@@ -1,0 +1,71 @@
+# ADR 0025: Portable MCP tool names
+
+- Status: Accepted
+- Date: 2026-08-11
+
+## Context
+
+Invokta capability IDs are domain identifiers such as
+`support.classify-ticket`. The MCP adapter previously copied each capability ID
+directly into the tool `name`. Some MCP clients, including Claude.ai, exclude
+tools whose names do not match `^[a-zA-Z0-9_-]{1,64}$`, so an otherwise valid
+engine could connect successfully while exposing none of its dotted
+capabilities.
+
+Changing capability IDs would break the direct API, CLI, composition, access,
+events, and engine invocation contract. Naming compatibility therefore belongs
+at the MCP protocol boundary.
+
+## Decision
+
+`@invokta/mcp` derives one portable MCP tool name for each capability ID when it
+constructs the shared protocol server used by stdio and HTTP:
+
+1. Every Unicode code point outside ASCII letters, digits, `_`, and `-` becomes
+   `_`.
+2. An empty result becomes `_`.
+3. A result of at most 64 characters is used directly.
+4. A longer result becomes its first 51 characters, `_`, and the first 12
+   lowercase hexadecimal characters of the SHA-256 digest of the original
+   capability ID encoded as UTF-8.
+
+An ID already matching `^[a-zA-Z0-9_-]{1,64}$` remains unchanged. The adapter
+builds a reverse map from the published tool name to the original capability
+ID. `tools/list` publishes only the portable name, while `tools/call` resolves
+that name and invokes `engine.invoke` with the original ID. Capability
+descriptions, access rules, events, direct calls, CLI commands, and composition
+continue to use the domain ID.
+
+The adapter validates uniqueness while constructing the protocol server. If
+two capability IDs produce the same portable tool name, construction fails with
+a deterministic `TypeError`; the adapter neither publishes nor invokes an
+ambiguous catalog. This also guards the bounded hash suffix against a digest
+prefix collision.
+
+There is no configuration option and no second alias registry. A tool call must
+use a name returned by `tools/list`; an old dotted name is not accepted as a
+hidden alias.
+
+## Migration
+
+This changes MCP tool names for capability IDs containing unsupported
+characters or exceeding 64 characters. MCP clients must refresh `tools/list`,
+and integrations that hard-code tool calls must adopt the published name. For
+example, `support.classify-ticket` becomes `support_classify-ticket`. Direct API
+and CLI callers continue to use `support.classify-ticket`.
+
+Before upgrading, engine authors must also check for collisions such as
+`support.echo` and `support_echo`. Rename one domain capability if construction
+reports a duplicate portable name. Capability IDs that already satisfy the
+portable pattern require no migration.
+
+## Consequences
+
+- Dotted Invokta capabilities remain domain-oriented while becoming visible to
+  clients with the stricter tool-name profile.
+- Stdio and HTTP share exactly the same publication and reverse-resolution
+  behavior.
+- Long names remain deterministic and bounded, although their hash suffix is
+  less readable than the original ID.
+- A colliding catalog fails closed instead of routing a tool call to an
+  arbitrary capability.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0021](0021-engine-devtools-dev-server.md) | Engine devtools dev server | Accepted | 2026-08-05 |
 | [0022](0022-mcp-installation-inspection-and-homologation.md) | MCP installation inspection and homologation | Accepted | 2026-08-06 |
 | [0023](0023-ephemeral-oauth-for-installed-mcp-inspection.md) | Ephemeral OAuth for installed MCP inspection | Accepted | 2026-08-06 |
+| [0025](0025-portable-mcp-tool-names.md) | Portable MCP tool names | Accepted | 2026-08-11 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0022](0022-mcp-installation-inspection-and-homologation.md) | MCP installation inspection and homologation | Accepted | 2026-08-06 |
 | [0023](0023-ephemeral-oauth-for-installed-mcp-inspection.md) | Ephemeral OAuth for installed MCP inspection | Accepted | 2026-08-06 |
 | [0024](0024-production-mcp-oauth-integration-boundary.md) | Production MCP OAuth integration boundary | Accepted | 2026-08-10 |
+| [0025](0025-portable-mcp-tool-names.md) | Portable MCP tool names | Accepted | 2026-08-11 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,13 +164,16 @@ selected for the original outcome.
 
 ## MCP
 
-**AE-MCP-01 — One capability, one tool.** Key, title, description, schemas, and
-annotations map directly to the tool. Success returns `structuredContent` and a
-JSON text fallback. A nonexistent tool is a protocol error; all other capability
-errors return `isError: true`. Error serialization is atomic: if the adapter
-cannot safely read or serialize the structured `EngineError`, it MUST return the
-generic `EXECUTION_FAILED` tool error and MUST NOT let the SDK convert the failure
-into an internal protocol error.
+**AE-MCP-01 — One capability, one tool.** Title, description, schemas, and
+annotations map directly to the tool. The capability key maps deterministically
+to a portable tool name matching `^[a-zA-Z0-9_-]{1,64}$`, and `tools/call`
+resolves that name back to the original key before `engine.invoke`. The adapter
+MUST fail closed if two keys map to the same tool name. Success returns
+`structuredContent` and a JSON text fallback. A nonexistent tool is a protocol
+error; all other capability errors return `isError: true`. Error serialization
+is atomic: if the adapter cannot safely read or serialize the structured
+`EngineError`, it MUST return the generic `EXECUTION_FAILED` tool error and MUST
+NOT let the SDK convert the failure into an internal protocol error.
 
 **AE-MCP-02 — Isolated SDK.** `@invokta/mcp` encapsulates the official SDK and
 MUST NOT leak its types through the public API or copy it into the core. The

--- a/docs/capability-composition.md
+++ b/docs/capability-composition.md
@@ -7,9 +7,10 @@ it explicitly at its composition root.
 
 Every published capability carries a **default ID** chosen by its author. The
 importing engine may keep that ID or replace it with an **effective ID**. The
-effective ID is the only identity the framework exposes: `invoke`, `list`,
-`describe`, `capabilityId` in access rules, invocation events, CLI selection,
-and MCP tool names all use it. Default IDs and source metadata never reach
+effective ID is the only domain identity the framework exposes: `invoke`,
+`list`, `describe`, `capabilityId` in access rules, invocation events, and CLI
+selection all use it. MCP derives its portable tool name from that effective ID
+and resolves calls back to it. Default IDs and source metadata never reach
 `ExecutionContext`, business inputs, outputs, or events.
 
 Composition is eager and synchronous. It performs no I/O, starts no adapter,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,7 +182,7 @@ safe integer as `maxReadBufferBytes`. Crossing the boundary closes the protocol
 connection and rejects `serveMcpStdio`; input exactly at the boundary remains
 accepted.
 
-An MCP client will discover `onboarding.create-welcome-message` as one tool with
+An MCP client will discover `onboarding_create-welcome-message` as one tool with
 the capability's original input schema, output schema, description, and optional
 annotations.
 

--- a/examples/agent-session-engine/test/entrypoints.test.ts
+++ b/examples/agent-session-engine/test/entrypoints.test.ts
@@ -195,7 +195,7 @@ describe("agent session example entrypoints", () => {
         id: 2,
         method: "tools/call",
         params: {
-          name: "agent-session.get",
+          name: "agent-session_get",
           arguments: { sessionId: "entrypoint-session" },
         },
       });

--- a/examples/auth-api-key-engine/README.md
+++ b/examples/auth-api-key-engine/README.md
@@ -101,7 +101,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H 'authorization: Bearer svc_9f21c4a7.<secret>' \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 An absent, malformed, unknown, or wrong-secret key returns HTTP 401 before

--- a/examples/auth-api-key-engine/test/mcp-http.test.ts
+++ b/examples/auth-api-key-engine/test/mcp-http.test.ts
@@ -60,7 +60,7 @@ function callWhoami(
       jsonrpc: "2.0",
       id: "whoami",
       method: "tools/call",
-      params: { name: "identity.whoami", arguments: {} },
+      params: { name: "identity_whoami", arguments: {} },
     }),
   });
 }

--- a/examples/auth-auth0-engine/README.md
+++ b/examples/auth-auth0-engine/README.md
@@ -89,7 +89,7 @@ curl -i --request POST http://127.0.0.1:3000/mcp \
   --header "authorization: Bearer $ACCESS_TOKEN" \
   --header 'accept: application/json, text/event-stream' \
   --header 'content-type: application/json' \
-  --data '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  --data '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 Keep the client secret in your shell's secret mechanism. Never paste a token

--- a/examples/auth-auth0-engine/test/mcp-http.test.ts
+++ b/examples/auth-auth0-engine/test/mcp-http.test.ts
@@ -16,8 +16,6 @@ import {
 } from "./support/auth0-tokens.js";
 
 const resource = "https://engine.example.com/mcp";
-const capabilityId = "identity.whoami";
-
 let tokens: Auth0TokenFactory;
 let healthy: McpHttpServerHandle;
 let unavailable: McpHttpServerHandle;
@@ -38,7 +36,7 @@ function callToolRequest(): RequestInit {
       jsonrpc: "2.0",
       id: "whoami",
       method: "tools/call",
-      params: { name: capabilityId, arguments: {} },
+      params: { name: "identity_whoami", arguments: {} },
     }),
   };
 }
@@ -92,7 +90,7 @@ describe("auth0 MCP HTTP boundary", () => {
     try {
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: capabilityId, arguments: {} }),
+        client.callTool({ name: "identity_whoami", arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           principalId: "auth0|64f0c0ffee0000000000abcd",

--- a/examples/auth-authjs-engine/README.md
+++ b/examples/auth-authjs-engine/README.md
@@ -105,7 +105,7 @@ curl --fail-with-body http://127.0.0.1:3000/mcp \
   --header 'Accept: application/json, text/event-stream' \
   --header "Authorization: Bearer $ENGINE_ACCESS_TOKEN" \
   --header 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","id":"whoami-1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  --data '{"jsonrpc":"2.0","id":"whoami-1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 A missing, malformed, expired, foreign-issuer, foreign-audience, or

--- a/examples/auth-authjs-engine/test/mcp-http.test.ts
+++ b/examples/auth-authjs-engine/test/mcp-http.test.ts
@@ -140,7 +140,7 @@ describe("MCP HTTP authentication hook", () => {
       jsonrpc: "2.0",
       id: "whoami-1",
       method: "tools/call",
-      params: { name: "identity.whoami", arguments: {} },
+      params: { name: "identity_whoami", arguments: {} },
     });
     const headers = {
       accept: "application/json, text/event-stream",

--- a/examples/auth-better-auth-engine/README.md
+++ b/examples/auth-better-auth-engine/README.md
@@ -85,7 +85,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $BETTER_AUTH_JWT" \
   -H "accept: application/json, text/event-stream" \
   -H "content-type: application/json" \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The embedded surface needs no token and no server:

--- a/examples/auth-better-auth-engine/test/mcp-http.test.ts
+++ b/examples/auth-better-auth-engine/test/mcp-http.test.ts
@@ -24,8 +24,6 @@ import {
 const issuer = "https://app.example.com";
 const audience = "https://app.example.com";
 const keyId = "better-auth-test-key";
-const capabilityId = "identity.whoami";
-
 let signingKey: CryptoKey;
 let keys: JWTVerifyGetKey;
 let validToken: string;
@@ -181,7 +179,7 @@ describe("the served MCP HTTP boundary", () => {
       jsonrpc: "2.0",
       id: "auth-boundary",
       method: "tools/call",
-      params: { name: capabilityId, arguments: {} },
+      params: { name: "identity_whoami", arguments: {} },
     });
 
     const missing = await fetch(url, { method: "POST", headers, body });
@@ -210,7 +208,7 @@ describe("the served MCP HTTP boundary", () => {
     try {
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: capabilityId, arguments: {} }),
+        client.callTool({ name: "identity_whoami", arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           principalId: "user_01",

--- a/examples/auth-clerk-engine/README.md
+++ b/examples/auth-clerk-engine/README.md
@@ -63,7 +63,7 @@ curl -sS http://127.0.0.1:3010/mcp \
   -H "authorization: Bearer $CLERK_SESSION_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 Clerk session tokens are short-lived, so an old token returns HTTP 401. So does

--- a/examples/auth-clerk-engine/test/mcp-http.test.ts
+++ b/examples/auth-clerk-engine/test/mcp-http.test.ts
@@ -22,8 +22,6 @@ import { startClerkMcpHttp } from "../src/mcp-http.js";
 const frontendApiUrl = "https://clean-mayfly-62.clerk.accounts.dev";
 const authorizedParties = ["https://app.example.com"] as const;
 const signingKeyId = "ins_test_signing_key";
-const capabilityId = "identity.whoami";
-
 let signingKey: CryptoKey;
 let keys: JWTVerifyGetKey;
 let sessionToken: string;
@@ -41,7 +39,7 @@ function toolCallBody(): string {
     jsonrpc: "2.0",
     id: "auth-boundary",
     method: "tools/call",
-    params: { name: capabilityId, arguments: {} },
+    params: { name: "identity_whoami", arguments: {} },
   });
 }
 
@@ -113,7 +111,7 @@ describe("clerk MCP HTTP boundary", () => {
     try {
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: capabilityId, arguments: {} }),
+        client.callTool({ name: "identity_whoami", arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           principalId: "user_2abcDEF",

--- a/examples/auth-cognito-engine/README.md
+++ b/examples/auth-cognito-engine/README.md
@@ -69,7 +69,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H 'accept: application/json, text/event-stream' \
   -H "authorization: Bearer $COGNITO_ACCESS_TOKEN" \
   -d '{"jsonrpc":"2.0","id":"1","method":"tools/call",
-       "params":{"name":"identity.whoami","arguments":{}}}'
+       "params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 A valid token returns the principal. A missing, expired, foreign-issuer,

--- a/examples/auth-cognito-engine/test/mcp-http.test.ts
+++ b/examples/auth-cognito-engine/test/mcp-http.test.ts
@@ -33,7 +33,7 @@ const requestBody = JSON.stringify({
   jsonrpc: "2.0",
   id: "cognito-whoami",
   method: "tools/call",
-  params: { name: "identity.whoami", arguments: {} },
+  params: { name: "identity_whoami", arguments: {} },
 });
 
 beforeAll(async () => {

--- a/examples/auth-firebase-engine/README.md
+++ b/examples/auth-firebase-engine/README.md
@@ -76,7 +76,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $FIREBASE_ID_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 ## Run the embedded example

--- a/examples/auth-firebase-engine/test/mcp-http.test.ts
+++ b/examples/auth-firebase-engine/test/mcp-http.test.ts
@@ -61,7 +61,7 @@ async function callWhoami(
       jsonrpc: "2.0",
       id: "whoami",
       method: "tools/call",
-      params: { name: "identity.whoami", arguments: toolArguments },
+      params: { name: "identity_whoami", arguments: toolArguments },
     }),
   });
 }

--- a/examples/auth-jwt-bearer-engine/README.md
+++ b/examples/auth-jwt-bearer-engine/README.md
@@ -83,7 +83,7 @@ curl -s http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $ACCESS_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 An unauthenticated call returns HTTP 401. To make that 401 carry a discovery

--- a/examples/auth-jwt-bearer-engine/test/mcp-http.test.ts
+++ b/examples/auth-jwt-bearer-engine/test/mcp-http.test.ts
@@ -124,7 +124,7 @@ describe("protected resource metadata", () => {
         jsonrpc: "2.0",
         id: "unauthenticated",
         method: "tools/call",
-        params: { name: "identity.whoami", arguments: {} },
+        params: { name: "identity_whoami", arguments: {} },
       }),
     });
     await response.arrayBuffer();
@@ -152,7 +152,7 @@ describe("authenticated MCP HTTP requests", () => {
     try {
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: "identity.whoami", arguments: {} }),
+        client.callTool({ name: "identity_whoami", arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           principalId: "user-42",
@@ -185,7 +185,7 @@ describe("authenticated MCP HTTP requests", () => {
         jsonrpc: "2.0",
         id: "wrong-audience",
         method: "tools/call",
-        params: { name: "identity.whoami", arguments: {} },
+        params: { name: "identity_whoami", arguments: {} },
       }),
     });
     const body = await response.text();

--- a/examples/auth-supabase-engine/README.md
+++ b/examples/auth-supabase-engine/README.md
@@ -79,7 +79,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 The same request without the header returns HTTP 401 before `engine.invoke`

--- a/examples/auth-supabase-engine/test/mcp-http.test.ts
+++ b/examples/auth-supabase-engine/test/mcp-http.test.ts
@@ -21,8 +21,6 @@ import {
   subject,
 } from "./tokens.js";
 
-const capabilityId = "identity.whoami";
-
 let tokens: SupabaseTokenFactory;
 const servers: McpHttpServerHandle[] = [];
 
@@ -38,7 +36,7 @@ function callBody(): string {
     jsonrpc: "2.0",
     id: "whoami",
     method: "tools/call",
-    params: { name: capabilityId, arguments: {} },
+    params: { name: "identity_whoami", arguments: {} },
   });
 }
 
@@ -123,7 +121,7 @@ describe("Supabase MCP HTTP boundary", () => {
     try {
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: capabilityId, arguments: {} }),
+        client.callTool({ name: "identity_whoami", arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           principalId: subject,

--- a/examples/auth-workos-engine/README.md
+++ b/examples/auth-workos-engine/README.md
@@ -60,7 +60,7 @@ curl -sS http://127.0.0.1:3000/mcp \
   -H "authorization: Bearer $WORKOS_ACCESS_TOKEN" \
   -H 'accept: application/json, text/event-stream' \
   -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity.whoami","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"identity_whoami","arguments":{}}}'
 ```
 
 A missing or invalid token answers HTTP 401 before `engine.invoke` runs.

--- a/examples/auth-workos-engine/test/mcp-http.test.ts
+++ b/examples/auth-workos-engine/test/mcp-http.test.ts
@@ -26,8 +26,6 @@ const clientId = "client_01JTESTCLIENTID";
 const issuer = "https://api.workos.com/";
 const audience = "https://engine.example.com/mcp";
 const keyId = "workos-test-key";
-const capabilityId = "identity.whoami";
-
 const signing = await generateKeyPair("RS256", { extractable: true });
 const publicJwk: JWK = {
   ...(await exportJWK(signing.publicKey)),
@@ -171,7 +169,7 @@ describe("WorkOS MCP HTTP boundary", () => {
     try {
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: capabilityId, arguments: {} }),
+        client.callTool({ name: "identity_whoami", arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           principalId: "user_01JTESTUSER",
@@ -198,7 +196,7 @@ describe("WorkOS MCP HTTP boundary", () => {
       jsonrpc: "2.0",
       id: "auth-boundary",
       method: "tools/call",
-      params: { name: capabilityId, arguments: {} },
+      params: { name: "identity_whoami", arguments: {} },
     });
 
     const missing = await fetch(url, { method: "POST", headers, body });
@@ -230,7 +228,7 @@ describe("WorkOS MCP HTTP boundary", () => {
         jsonrpc: "2.0",
         id: "auth-boundary",
         method: "tools/call",
-        params: { name: capabilityId, arguments: {} },
+        params: { name: "identity_whoami", arguments: {} },
       }),
     });
     const text = await response.text();

--- a/examples/composed-engine/test/entrypoints.test.ts
+++ b/examples/composed-engine/test/entrypoints.test.ts
@@ -11,12 +11,21 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
 const atomicCapabilityId = "operations.classify-ticket";
 const libraryCapabilityId = "operations.draft-reply";
+const atomicToolName = "operations_classify-ticket";
+const libraryToolName = "operations_draft-reply";
 const effectiveIds = [
   "operations.generate-report",
   "community.score-ticket-priority",
   "operations.classify-ticket",
   "community.search-knowledge-base",
   "operations.draft-reply",
+];
+const effectiveToolNames = [
+  "operations_generate-report",
+  "community_score-ticket-priority",
+  "operations_classify-ticket",
+  "community_search-knowledge-base",
+  "operations_draft-reply",
 ];
 const draftReply = {
   subject: "Re: Duplicate invoice",
@@ -143,11 +152,11 @@ describe("composed engine entrypoints", () => {
     try {
       await client.connect(transport);
       const tools = await client.listTools();
-      expect(tools.tools.map((tool) => tool.name)).toEqual(effectiveIds);
+      expect(tools.tools.map((tool) => tool.name)).toEqual(effectiveToolNames);
 
       await expect(
         client.callTool({
-          name: atomicCapabilityId,
+          name: atomicToolName,
           arguments: { ticketId: "T-456" },
         }),
       ).resolves.toMatchObject({
@@ -155,17 +164,17 @@ describe("composed engine entrypoints", () => {
       });
       await expect(
         client.callTool({
-          name: libraryCapabilityId,
+          name: libraryToolName,
           arguments: { ticketId: "T-123" },
         }),
       ).resolves.toMatchObject({ structuredContent: draftReply });
 
       await expect(
         client.callTool({
-          name: "community.draft-reply",
+          name: "community_draft-reply",
           arguments: { ticketId: "T-123" },
         }),
-      ).rejects.toThrowError(/Tool community\.draft-reply not found/u);
+      ).rejects.toThrowError(/Tool community_draft-reply not found/u);
     } finally {
       await client.close();
     }
@@ -216,7 +225,7 @@ describe("composed engine entrypoints", () => {
           id: "auth-boundary",
           method: "tools/call",
           params: {
-            name: libraryCapabilityId,
+            name: libraryToolName,
             arguments: { ticketId: "T-123" },
           },
         }),
@@ -235,7 +244,7 @@ describe("composed engine entrypoints", () => {
 
       await expect(
         client.callTool({
-          name: "community.score-ticket-priority",
+          name: "community_score-ticket-priority",
           arguments: { ticketId: "T-789" },
         }),
       ).resolves.toMatchObject({
@@ -243,13 +252,13 @@ describe("composed engine entrypoints", () => {
       });
       await expect(
         client.callTool({
-          name: libraryCapabilityId,
+          name: libraryToolName,
           arguments: { ticketId: "T-123" },
         }),
       ).resolves.toMatchObject({ structuredContent: draftReply });
 
       const forbidden = await client.callTool({
-        name: atomicCapabilityId,
+        name: atomicToolName,
         arguments: {
           ticketId: "T-999",
           principal: {

--- a/examples/crawl-engine/test/entrypoints.test.ts
+++ b/examples/crawl-engine/test/entrypoints.test.ts
@@ -20,6 +20,7 @@ import { type FirecrawlStub, startFirecrawlStub } from "./firecrawl-stub.js";
 
 const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
 const capabilityId = "crawl.scrape-page";
+const toolName = "crawl_scrape-page";
 const apiKey = "test-firecrawl-key";
 const scrapedMarkdown =
   "# Example Domain\n\nThis domain is for use in examples.";
@@ -215,14 +216,14 @@ describe("crawl engine entrypoints", () => {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
         tools: [
-          { name: "crawl.scrape-page" },
-          { name: "crawl.map-site" },
-          { name: "crawl.crawl-site" },
+          { name: "crawl_scrape-page" },
+          { name: "crawl_map-site" },
+          { name: "crawl_crawl-site" },
         ],
       });
       await expect(
         client.callTool({
-          name: "crawl.crawl-site",
+          name: "crawl_crawl-site",
           arguments: { url: "https://example.com/", limit: 2 },
         }),
       ).resolves.toMatchObject({
@@ -281,7 +282,7 @@ describe("crawl engine entrypoints", () => {
           id: "auth-boundary",
           method: "tools/call",
           params: {
-            name: capabilityId,
+            name: toolName,
             arguments: { url: "https://example.com/" },
           },
         }),
@@ -299,7 +300,7 @@ describe("crawl engine entrypoints", () => {
       await client.connect(transport as unknown as Transport);
       await expect(
         client.callTool({
-          name: capabilityId,
+          name: toolName,
           arguments: { url: "https://example.com/" },
         }),
       ).resolves.toMatchObject({
@@ -307,7 +308,7 @@ describe("crawl engine entrypoints", () => {
       });
 
       const forbidden = await client.callTool({
-        name: capabilityId,
+        name: toolName,
         arguments: {
           url: "https://competitor.test/pricing",
           principal: {

--- a/examples/cursor-agent-routing-engine/README.md
+++ b/examples/cursor-agent-routing-engine/README.md
@@ -115,9 +115,10 @@ To use this example from the repository root:
 5. Reload Cursor and verify the tool with
    `agent mcp list-tools cursor-agent-routing`.
 
-The rule classifies work into one of the seven use cases, calls
-`developer-work.route-cursor-task`, and delegates to the custom agent named by
-`agent.invocation`. Custom subagent configuration follows Cursor's
+The rule classifies work into one of the seven use cases, calls the MCP tool
+`developer-work_route-cursor-task` for the
+`developer-work.route-cursor-task` capability, and delegates to the custom
+agent named by `agent.invocation`. Custom subagent configuration follows Cursor's
 [Subagents documentation](https://cursor.com/docs/subagents). Cursor also
 supports general model family names for subagents, but this example intentionally
 pins a dated model to make routing reproducible.

--- a/examples/cursor-agent-routing-engine/cursor-config/rules/model-routing.mdc
+++ b/examples/cursor-agent-routing-engine/cursor-config/rules/model-routing.mdc
@@ -14,7 +14,7 @@ cases:
 - `prototype-development`
 - `simple-development`
 
-Call the MCP tool `developer-work.route-cursor-task` with that `useCase`. Invoke
+Call the MCP tool `developer-work_route-cursor-task` with that `useCase`. Invoke
 the custom subagent named by `agent.invocation` and give it a self-contained
 task. Keep read-only agents read-only. Use `fallbackModel` only when the primary
 model is unavailable for the current account, region, or organization policy.

--- a/examples/cursor-agent-routing-engine/test/cursor-config.test.ts
+++ b/examples/cursor-agent-routing-engine/test/cursor-config.test.ts
@@ -36,7 +36,7 @@ describe("the Cursor project configuration", () => {
       "utf8",
     );
 
-    expect(rule).toContain("developer-work.route-cursor-task");
+    expect(rule).toContain("developer-work_route-cursor-task");
     for (const useCase of cursorUseCases) {
       expect(rule).toContain(`\`${useCase}\``);
     }

--- a/examples/cursor-agent-routing-engine/test/entrypoints.test.ts
+++ b/examples/cursor-agent-routing-engine/test/entrypoints.test.ts
@@ -93,11 +93,11 @@ describe("Cursor agent routing engine entrypoints", () => {
     try {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: [{ name: "developer-work.route-cursor-task" }],
+        tools: [{ name: "developer-work_route-cursor-task" }],
       });
 
       const result = await client.callTool({
-        name: "developer-work.route-cursor-task",
+        name: "developer-work_route-cursor-task",
         arguments: { useCase: "complex-development" },
       });
       expect(structuredContent(result)).toMatchObject({
@@ -155,7 +155,7 @@ describe("Cursor agent routing engine entrypoints", () => {
           id: "auth-boundary",
           method: "tools/call",
           params: {
-            name: "developer-work.route-cursor-task",
+            name: "developer-work_route-cursor-task",
             arguments: { useCase: "simple-development" },
           },
         }),
@@ -173,7 +173,7 @@ describe("Cursor agent routing engine entrypoints", () => {
       await client.connect(transport as unknown as Transport);
 
       const result = await client.callTool({
-        name: "developer-work.route-cursor-task",
+        name: "developer-work_route-cursor-task",
         arguments: { useCase: "simple-development" },
       });
       expect(structuredContent(result)).toMatchObject({

--- a/examples/hello-engine/README.md
+++ b/examples/hello-engine/README.md
@@ -69,7 +69,7 @@ curl --fail-with-body http://127.0.0.1:3000/mcp \
   --header 'Accept: application/json, text/event-stream' \
   --header 'Authorization: Bearer replace-with-a-local-secret' \
   --header 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","id":"hello-1","method":"tools/call","params":{"name":"onboarding.create-welcome-message","arguments":{"name":"Ada"}}}'
+  --data '{"jsonrpc":"2.0","id":"hello-1","method":"tools/call","params":{"name":"onboarding_create-welcome-message","arguments":{"name":"Ada"}}}'
 ```
 
 The response contains the validated result in `result.structuredContent`:

--- a/examples/hello-engine/test/entrypoints.test.ts
+++ b/examples/hello-engine/test/entrypoints.test.ts
@@ -122,7 +122,7 @@ describe("hello engine entrypoints", () => {
         id: 2,
         method: "tools/call",
         params: {
-          name: "onboarding.create-welcome-message",
+          name: "onboarding_create-welcome-message",
           arguments: { name: "Ada" },
         },
       });
@@ -182,7 +182,7 @@ describe("hello engine entrypoints", () => {
         id: "hello-http",
         method: "tools/call",
         params: {
-          name: "onboarding.create-welcome-message",
+          name: "onboarding_create-welcome-message",
           arguments: { name: "Ada" },
         },
       });

--- a/examples/image-engine/test/entrypoints.test.ts
+++ b/examples/image-engine/test/entrypoints.test.ts
@@ -146,7 +146,7 @@ describe("image engine entrypoints", () => {
       await client.connect(transport);
       await expect(
         client.callTool({
-          name: "image.compose-reference-asset",
+          name: "image_compose-reference-asset",
           arguments: {
             prompt: "Compose a new product scene.",
             referenceImages,
@@ -190,7 +190,7 @@ describe("image engine entrypoints", () => {
           id: "auth-boundary",
           method: "tools/call",
           params: {
-            name: "image.edit-asset",
+            name: "image_edit-asset",
             arguments: {
               prompt: "Change the background.",
               referenceImages: referenceImages.slice(0, 1),
@@ -212,7 +212,7 @@ describe("image engine entrypoints", () => {
       await client.connect(transport as unknown as Transport);
       await expect(
         client.callTool({
-          name: "image.edit-asset",
+          name: "image_edit-asset",
           arguments: {
             prompt: "Change the background.",
             referenceImages: referenceImages.slice(0, 1),

--- a/examples/observability-engine/test/entrypoints.test.ts
+++ b/examples/observability-engine/test/entrypoints.test.ts
@@ -23,6 +23,7 @@ import {
 
 const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
 const capabilityId = "observability.collect-incident-context";
+const toolName = "observability_collect-incident-context";
 const input = {
   service: "checkout-api",
   from: "2026-07-28T12:00:00.000Z",
@@ -193,10 +194,10 @@ describe("observability engine entrypoints", () => {
     try {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: [{ name: capabilityId }],
+        tools: [{ name: toolName }],
       });
       await expect(
-        client.callTool({ name: capabilityId, arguments: input }),
+        client.callTool({ name: toolName, arguments: input }),
       ).resolves.toMatchObject({ structuredContent: expectedContext() });
     } finally {
       await client.close();
@@ -246,7 +247,7 @@ describe("observability engine entrypoints", () => {
           jsonrpc: "2.0",
           id: "auth-boundary",
           method: "tools/call",
-          params: { name: capabilityId, arguments: input },
+          params: { name: toolName, arguments: input },
         }),
       });
       expect(unauthenticated.status).toBe(401);
@@ -261,7 +262,7 @@ describe("observability engine entrypoints", () => {
       );
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: capabilityId, arguments: input }),
+        client.callTool({ name: toolName, arguments: input }),
       ).resolves.toMatchObject({ structuredContent: expectedContext() });
     } finally {
       await client?.close().catch(() => undefined);

--- a/examples/obsidian-context-engine/test/entrypoints.test.ts
+++ b/examples/obsidian-context-engine/test/entrypoints.test.ts
@@ -14,6 +14,8 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
 const listRootsId = "knowledge.list-context-roots";
 const openNodeId = "knowledge.open-context-node";
+const listRootsToolName = "knowledge_list-context-roots";
+const openNodeToolName = "knowledge_open-context-node";
 let vaultPath: string;
 
 beforeAll(async () => {
@@ -181,11 +183,11 @@ describe("Obsidian context engine entrypoints", () => {
     try {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: [{ name: listRootsId }, { name: openNodeId }],
+        tools: [{ name: listRootsToolName }, { name: openNodeToolName }],
       });
       await expect(
         client.callTool({
-          name: openNodeId,
+          name: openNodeToolName,
           arguments: { id: "capability-contracts" },
         }),
       ).resolves.toMatchObject({
@@ -242,7 +244,7 @@ describe("Obsidian context engine entrypoints", () => {
           jsonrpc: "2.0",
           id: "auth-boundary",
           method: "tools/call",
-          params: { name: listRootsId, arguments: {} },
+          params: { name: listRootsToolName, arguments: {} },
         }),
       });
       expect(unauthenticated.status).toBe(401);
@@ -257,7 +259,7 @@ describe("Obsidian context engine entrypoints", () => {
       );
       await client.connect(transport as unknown as Transport);
       await expect(
-        client.callTool({ name: listRootsId, arguments: {} }),
+        client.callTool({ name: listRootsToolName, arguments: {} }),
       ).resolves.toMatchObject({
         structuredContent: {
           roots: [{ id: "architecture" }],

--- a/examples/review-engine/test/entrypoints.test.ts
+++ b/examples/review-engine/test/entrypoints.test.ts
@@ -102,10 +102,10 @@ describe("review engine entrypoints", () => {
     try {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: [{ name: "review.assess-task-readiness" }],
+        tools: [{ name: "review_assess-task-readiness" }],
       });
       const result = await client.callTool({
-        name: "review.assess-task-readiness",
+        name: "review_assess-task-readiness",
         arguments: {
           ...exampleCandidate,
           evidence: exampleCandidate.evidence.filter(
@@ -164,7 +164,7 @@ describe("review engine entrypoints", () => {
           id: "auth-boundary",
           method: "tools/call",
           params: {
-            name: "review.assess-task-readiness",
+            name: "review_assess-task-readiness",
             arguments: exampleCandidate,
           },
         }),
@@ -182,7 +182,7 @@ describe("review engine entrypoints", () => {
       await client.connect(transport as unknown as Transport);
 
       const result = await client.callTool({
-        name: "review.assess-task-readiness",
+        name: "review_assess-task-readiness",
         arguments: exampleCandidate as unknown as Record<string, unknown>,
       });
       expect(structuredContent(result)).toMatchObject({

--- a/examples/spec-engine/test/entrypoints.test.ts
+++ b/examples/spec-engine/test/entrypoints.test.ts
@@ -166,16 +166,16 @@ describe("spec engine entrypoints", () => {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
         tools: [
-          { name: "spec.create-specification" },
-          { name: "spec.plan-implementation" },
-          { name: "spec.break-down-tasks" },
-          { name: "spec.complete-task" },
-          { name: "spec.get-workflow-status" },
+          { name: "spec_create-specification" },
+          { name: "spec_plan-implementation" },
+          { name: "spec_break-down-tasks" },
+          { name: "spec_complete-task" },
+          { name: "spec_get-workflow-status" },
         ],
       });
 
       const planned = await client.callTool({
-        name: "spec.plan-implementation",
+        name: "spec_plan-implementation",
         arguments: { specId: "SPEC-1" },
       });
       expect(structuredContent(planned)).toMatchObject({
@@ -184,7 +184,7 @@ describe("spec engine entrypoints", () => {
       });
 
       const status = await client.callTool({
-        name: "spec.get-workflow-status",
+        name: "spec_get-workflow-status",
         arguments: { specId: "SPEC-1" },
       });
       expect(structuredContent(status)).toMatchObject({
@@ -237,7 +237,7 @@ describe("spec engine entrypoints", () => {
           id: "auth-boundary",
           method: "tools/call",
           params: {
-            name: "spec.get-workflow-status",
+            name: "spec_get-workflow-status",
             arguments: { specId: "SPEC-1" },
           },
         }),
@@ -255,7 +255,7 @@ describe("spec engine entrypoints", () => {
       await client.connect(transport as unknown as Transport);
 
       const created = await client.callTool({
-        name: "spec.create-specification",
+        name: "spec_create-specification",
         arguments: {
           specId: "SPEC-HTTP",
           intent: "Publish a stateless HTTP workflow example",
@@ -267,7 +267,7 @@ describe("spec engine entrypoints", () => {
       });
 
       const status = await client.callTool({
-        name: "spec.get-workflow-status",
+        name: "spec_get-workflow-status",
         arguments: { specId: "SPEC-HTTP" },
       });
       expect(structuredContent(status)).toMatchObject({

--- a/examples/support-engine/test/entrypoints.test.ts
+++ b/examples/support-engine/test/entrypoints.test.ts
@@ -10,6 +10,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
 const capabilityId = "support.classify-ticket";
+const toolName = "support_classify-ticket";
 
 beforeAll(() => {
   const build = spawnSync(
@@ -123,11 +124,11 @@ describe("support engine entrypoints", () => {
     try {
       await client.connect(transport);
       await expect(client.listTools()).resolves.toMatchObject({
-        tools: [{ name: capabilityId }],
+        tools: [{ name: toolName }],
       });
       await expect(
         client.callTool({
-          name: capabilityId,
+          name: toolName,
           arguments: { ticketId: "T-123" },
         }),
       ).resolves.toMatchObject({
@@ -179,7 +180,7 @@ describe("support engine entrypoints", () => {
         id: "auth-boundary",
         method: "tools/call",
         params: {
-          name: capabilityId,
+          name: toolName,
           arguments: { ticketId: "T-123" },
         },
       });
@@ -214,7 +215,7 @@ describe("support engine entrypoints", () => {
       await client.connect(transport as unknown as Transport);
       await expect(
         client.callTool({
-          name: capabilityId,
+          name: toolName,
           arguments: { ticketId: "T-123" },
         }),
       ).resolves.toMatchObject({
@@ -225,7 +226,7 @@ describe("support engine entrypoints", () => {
       });
 
       const forbidden = await client.callTool({
-        name: capabilityId,
+        name: toolName,
         arguments: {
           ticketId: "T-999",
           principal: {

--- a/examples/support-harness/README.md
+++ b/examples/support-harness/README.md
@@ -2,8 +2,9 @@
 
 This private example is a consumer of the support engine, not a fourth framework
 package. It starts the existing support engine MCP stdio process with the
-official MCP client, discovers `support.classify-ticket`, calls it once, and
-records its own message and tool-execution history.
+official MCP client, discovers `support_classify-ticket`, calls it once, and
+records its own message and tool-execution history. The engine keeps
+`support.classify-ticket` as its domain capability ID.
 
 The harness does not import the engine, capability, core runtime, or MCP server
 adapter. It does not contain an autonomous loop: the requested ticket maps to one

--- a/examples/support-harness/src/support-harness.ts
+++ b/examples/support-harness/src/support-harness.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
-export const supportCapabilityId = "support.classify-ticket";
+export const supportToolName = "support_classify-ticket";
 
 export interface HarnessMessage {
   readonly role: "user" | "assistant";
@@ -116,20 +116,20 @@ export class SupportHarness {
       this.#discoveredTools = tools.tools
         .map(({ name }) => name)
         .sort((left, right) => left.localeCompare(right));
-      if (!this.#discoveredTools.includes(supportCapabilityId)) {
-        throw new Error(`Required MCP tool not found: ${supportCapabilityId}`);
+      if (!this.#discoveredTools.includes(supportToolName)) {
+        throw new Error(`Required MCP tool not found: ${supportToolName}`);
       }
 
       const toolArguments = { ticketId };
       const result = await client.callTool({
-        name: supportCapabilityId,
+        name: supportToolName,
         arguments: toolArguments,
       });
       const isError = result.isError === true;
       const output = isError ? safeToolError(result) : structuredResult(result);
 
       this.#executions.push({
-        toolName: supportCapabilityId,
+        toolName: supportToolName,
         arguments: toolArguments,
         isError,
         result: output,

--- a/examples/support-harness/test/support-harness.test.ts
+++ b/examples/support-harness/test/support-harness.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { SupportHarness, supportCapabilityId } from "../src/support-harness.js";
+import { SupportHarness, supportToolName } from "../src/support-harness.js";
 
 const exampleRoot = fileURLToPath(new URL("..", import.meta.url));
 const expectedClassification = {
@@ -40,7 +40,7 @@ describe("the private support harness", () => {
     const snapshot = await harness.classifyTicket("T-123");
 
     expect(snapshot).toEqual({
-      discoveredTools: [supportCapabilityId],
+      discoveredTools: [supportToolName],
       messages: [
         {
           role: "user",
@@ -53,7 +53,7 @@ describe("the private support harness", () => {
       ],
       executions: [
         {
-          toolName: supportCapabilityId,
+          toolName: supportToolName,
           arguments: { ticketId: "T-123" },
           isError: false,
           result: expectedClassification,
@@ -72,7 +72,7 @@ describe("the private support harness", () => {
     const snapshot = await harness.classifyTicket("T-999");
 
     expect(snapshot).toEqual({
-      discoveredTools: [supportCapabilityId],
+      discoveredTools: [supportToolName],
       messages: [
         {
           role: "user",
@@ -85,7 +85,7 @@ describe("the private support harness", () => {
       ],
       executions: [
         {
-          toolName: supportCapabilityId,
+          toolName: supportToolName,
           arguments: { ticketId: "T-999" },
           isError: true,
           result: safeError,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "packages/*",
     "examples/*"
   ],
+  "resolutions": {
+    "nanoid": "3.3.17"
+  },
   "scripts": {
     "build": "tsc -b --pretty false",
     "typecheck": "tsc -b --pretty false && tsc -p tsconfig.test.json --pretty false --noEmit && tsc -p packages/devtools/tsconfig.test.json --pretty false --noEmit",

--- a/packages/devtools/src/host-entry.ts
+++ b/packages/devtools/src/host-entry.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { createInterface } from "node:readline";
 
 import type { Principal } from "@invokta/core";
+import { toMcpToolName } from "@invokta/mcp";
 
 import { readThrownValueInfo } from "./diagnostics.js";
 import { doctorReportToJson, inspectEngine } from "./doctor.js";
@@ -109,9 +110,10 @@ async function main(): Promise<number> {
 
   let describedCapabilities: unknown = [];
   try {
-    describedCapabilities = loaded.engine
-      .list()
-      .map(({ id }) => loaded.engine.describe(id));
+    describedCapabilities = loaded.engine.list().map(({ id }) => ({
+      ...loaded.engine.describe(id),
+      mcpToolName: toMcpToolName(id),
+    }));
   } catch {
     describedCapabilities = [];
   }

--- a/packages/devtools/src/serve.ts
+++ b/packages/devtools/src/serve.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { toMcpToolName } from "@invokta/mcp";
+
 import type { ThrownValueInfo } from "./diagnostics.js";
 import type { DoctorReport } from "./doctor.js";
 import { doctorReportToJson, inspectEngine } from "./doctor.js";
@@ -105,9 +107,10 @@ async function startWithEngine(
     if (cachedView !== undefined) return cachedView;
     let capabilities: EngineView["capabilities"] = [];
     try {
-      capabilities = options.engine
-        .list()
-        .map(({ id }) => options.engine.describe(id));
+      capabilities = options.engine.list().map(({ id }) => ({
+        ...options.engine.describe(id),
+        mcpToolName: toMcpToolName(id),
+      }));
     } catch {
       capabilities = [];
     }

--- a/packages/devtools/src/ui/api.ts
+++ b/packages/devtools/src/ui/api.ts
@@ -7,6 +7,7 @@ export interface EngineInfo {
 
 export interface CapabilityInfo {
   readonly id: string;
+  readonly mcpToolName: string;
   readonly title?: string;
   readonly description: string;
   readonly annotations?: Readonly<Record<string, boolean>>;
@@ -158,7 +159,7 @@ export interface ToolCallRequest {
  * "Copy as curl" action) replay the same exchange byte for byte.
  */
 export function toolCallRequest(
-  capabilityId: string,
+  toolName: string,
   args: unknown,
   token: string | null,
 ): ToolCallRequest {
@@ -175,7 +176,7 @@ export function toolCallRequest(
         jsonrpc: "2.0",
         id: 1,
         method: "tools/call",
-        params: { name: capabilityId, arguments: args },
+        params: { name: toolName, arguments: args },
       },
       null,
       2,
@@ -185,12 +186,12 @@ export function toolCallRequest(
 
 /** Sends one raw MCP `tools/call` through the same-origin proxy. */
 export async function callTool(
-  capabilityId: string,
+  toolName: string,
   args: unknown,
   token: string | null,
   signal?: AbortSignal,
 ): Promise<McpExchange> {
-  const request = toolCallRequest(capabilityId, args, token);
+  const request = toolCallRequest(toolName, args, token);
   const response = await fetch(request.path, {
     method: request.method,
     headers: request.headers,

--- a/packages/devtools/src/ui/invoke-panel.ts
+++ b/packages/devtools/src/ui/invoke-panel.ts
@@ -432,7 +432,12 @@ export function renderInvokePanel(capability: CapabilityInfo): HTMLElement {
       timedOut = true;
       controller.abort();
     }, clientTimeoutMs);
-    void callTool(capability.id, args, getActiveToken(), controller.signal)
+    void callTool(
+      capability.mcpToolName,
+      args,
+      getActiveToken(),
+      controller.signal,
+    )
       .then((exchange) => {
         const elapsedMs = performance.now() - startedAt;
         rawSection.hidden = false;
@@ -585,7 +590,7 @@ export function renderInvokePanel(capability: CapabilityInfo): HTMLElement {
     }
     // The session token is never copied: the command references an
     // environment variable so the clipboard never carries a live credential.
-    const request = toolCallRequest(capability.id, args, null);
+    const request = toolCallRequest(capability.mcpToolName, args, null);
     const origin = (globalThis as { location?: { origin?: unknown } }).location
       ?.origin;
     const target = `${typeof origin === "string" ? origin : ""}${request.path}`;

--- a/packages/devtools/test/capability-invoke-ui.test.mjs
+++ b/packages/devtools/test/capability-invoke-ui.test.mjs
@@ -198,6 +198,7 @@ async function waitFor(assertion) {
 
 const classify = {
   id: "support.classify-ticket",
+  mcpToolName: "support_classify-ticket",
   title: "Classify ticket",
   description: "Classifies a support ticket by urgency.",
   annotations: { readOnlyHint: true, destructiveHint: false },
@@ -258,6 +259,7 @@ describe("capability discovery", () => {
           {
             ...classify,
             id: "support.summarize-ticket",
+            mcpToolName: "support_summarize-ticket",
             title: undefined,
             description: "Summarizes a support ticket.",
           },
@@ -424,6 +426,7 @@ describe("capability discovery", () => {
           {
             ...classify,
             id: "support.create-brief",
+            mcpToolName: "support_create-brief",
             title: "Create brief",
             description: "Produces a concise overview for an account.",
           },
@@ -580,6 +583,7 @@ describe("capability discovery", () => {
           {
             ...classify,
             id: "support.summarize-ticket",
+            mcpToolName: "support_summarize-ticket",
             title: "Summarize ticket",
             description: "Summarizes a support ticket.",
           },
@@ -640,6 +644,7 @@ describe("capability discovery", () => {
           {
             ...classify,
             id: "support.summarize",
+            mcpToolName: "support_summarize",
             title: "Summarize ticket",
             description: "Summarizes a support ticket.",
           },
@@ -803,7 +808,7 @@ describe("capability invocation", () => {
     expect(JSON.parse(options.body)).toMatchObject({
       method: "tools/call",
       params: {
-        name: "support.classify-ticket",
+        name: "support_classify-ticket",
         arguments: { ticketId: "T-123" },
       },
     });
@@ -964,7 +969,7 @@ describe("capability invocation", () => {
     );
     expect(command).not.toContain("authorization");
     expect(command).toContain('"method": "tools/call"');
-    expect(command).toContain('"name": "support.classify-ticket"');
+    expect(command).toContain('"name": "support_classify-ticket"');
     expect(command).toContain('"ticketId": "T-9"');
   });
 

--- a/packages/devtools/test/engine-host.test.ts
+++ b/packages/devtools/test/engine-host.test.ts
@@ -133,7 +133,7 @@ describe("startEngineHost", () => {
         jsonrpc: "2.0",
         id: 1,
         method: "tools/call",
-        params: { name: "fixture.echo", arguments: args },
+        params: { name: "fixture_echo", arguments: args },
       },
       headers,
     );

--- a/packages/devtools/test/self-hosted-oauth.integration.test.ts
+++ b/packages/devtools/test/self-hosted-oauth.integration.test.ts
@@ -356,9 +356,9 @@ describe("official self-hosted OAuth devtools homologation", () => {
       toolCount: 1,
     });
     expect(controller.tools(owner).map((tool) => tool.name)).toEqual([
-      "identity.whoami",
+      "identity_whoami",
     ]);
-    const result = await controller.call(owner, "identity.whoami", {});
+    const result = await controller.call(owner, "identity_whoami", {});
     expect(result.response.structuredContent).toMatchObject({
       principalId: account.id,
       scopes: expect.arrayContaining(["mcp:tools"]),

--- a/packages/devtools/test/server.test.ts
+++ b/packages/devtools/test/server.test.ts
@@ -138,7 +138,7 @@ describe("startServe", () => {
         jsonrpc: "2.0",
         id: 1,
         method: "tools/call",
-        params: { name: "fixture.echo", arguments: { message: "hi" } },
+        params: { name: "fixture_echo", arguments: { message: "hi" } },
       }),
     });
   }
@@ -161,11 +161,13 @@ describe("startServe", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as ReadonlyArray<{
       readonly id: string;
+      readonly mcpToolName: string;
       readonly inputSchema: unknown;
       readonly outputSchema: unknown;
     }>;
     expect(body).toHaveLength(1);
     expect(body[0]?.id).toBe("fixture.echo");
+    expect(body[0]?.mcpToolName).toBe("fixture_echo");
     expect(body[0]?.inputSchema).toEqual({ type: "object" });
     expect(body[0]?.outputSchema).toEqual({ type: "object" });
   });
@@ -430,7 +432,7 @@ describe("startServe trace capacity", () => {
             jsonrpc: "2.0",
             id: index + 1,
             method: "tools/call",
-            params: { name: "fixture.echo", arguments: { message: "hi" } },
+            params: { name: "fixture_echo", arguments: { message: "hi" } },
           }),
         });
         await response.arrayBuffer();

--- a/packages/devtools/test/trace-panel.test.mjs
+++ b/packages/devtools/test/trace-panel.test.mjs
@@ -772,7 +772,7 @@ describe("trace panel", () => {
         mcpMethod: "tools/call",
         capabilityId: "support.classify",
         requestBody:
-          '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"support.classify","arguments":{"ticketId":"T-1"}}}',
+          '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"support_classify","arguments":{"ticketId":"T-1"}}}',
         responseBody: "{}",
       },
     });

--- a/packages/devtools/test/ui-behavior.test.mjs
+++ b/packages/devtools/test/ui-behavior.test.mjs
@@ -559,6 +559,7 @@ describe("application tabs", () => {
           return jsonResponse([
             {
               id: "support.classify",
+              mcpToolName: "support_classify",
               title: "Classify ticket",
               description: "Classifies a support ticket.",
               inputSchema: { type: "object" },

--- a/packages/devtools/test/watch.test.ts
+++ b/packages/devtools/test/watch.test.ts
@@ -149,7 +149,7 @@ describe("serve --watch", () => {
           jsonrpc: "2.0",
           id: 1,
           method: "tools/call",
-          params: { name: "fixture.greet", arguments: {} },
+          params: { name: "fixture_greet", arguments: {} },
         }),
       });
     } catch {

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -7,7 +7,7 @@ import type { WebStandardStreamableHTTPServerTransportOptions } from "@modelcont
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 
-import { createMcpServer } from "./protocol-server.js";
+import { createMcpServer, createMcpToolCatalog } from "./protocol-server.js";
 import { preserveFalsyRequestIds } from "./request-id-transport.js";
 
 const DEFAULT_HOST = "127.0.0.1";
@@ -674,6 +674,7 @@ export async function serveMcpHttp<Capabilities extends CapabilityMap>(
       : getOAuthProtectedResourceMetadataUrl(new URL(metadata.resource));
   const metadataPath =
     metadataUrl === undefined ? undefined : new URL(metadataUrl).pathname;
+  const toolCatalog = createMcpToolCatalog(engine);
   const activeRequests = new Set<AbortController>();
 
   const httpServer = createServer((request, response) => {
@@ -860,11 +861,15 @@ export async function serveMcpHttp<Capabilities extends CapabilityMap>(
         return;
       }
 
-      const protocolServer = createMcpServer(engine, {
-        principal,
-        source: "mcp-http",
-        requestSignal: abortController.signal,
-      });
+      const protocolServer = createMcpServer(
+        engine,
+        {
+          principal,
+          source: "mcp-http",
+          requestSignal: abortController.signal,
+        },
+        toolCatalog,
+      );
       const statelessTransportOptions: WebStandardStreamableHTTPServerTransportOptions =
         {
           enableJsonResponse: true,

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -7,7 +7,7 @@ import type { WebStandardStreamableHTTPServerTransportOptions } from "@modelcont
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { OAuthProtectedResourceMetadataSchema } from "@modelcontextprotocol/sdk/shared/auth.js";
 
-import { createMcpServer } from "./protocol-server.js";
+import { createMcpServer, createMcpToolCatalog } from "./protocol-server.js";
 import { preserveFalsyRequestIds } from "./request-id-transport.js";
 
 const DEFAULT_HOST = "127.0.0.1";
@@ -609,6 +609,7 @@ export async function serveMcpHttp<Capabilities extends CapabilityMap>(
       : getOAuthProtectedResourceMetadataUrl(new URL(metadata.resource));
   const metadataPath =
     metadataUrl === undefined ? undefined : new URL(metadataUrl).pathname;
+  const toolCatalog = createMcpToolCatalog(engine);
   const activeRequests = new Set<AbortController>();
 
   const httpServer = createServer((request, response) => {
@@ -795,11 +796,15 @@ export async function serveMcpHttp<Capabilities extends CapabilityMap>(
         return;
       }
 
-      const protocolServer = createMcpServer(engine, {
-        principal,
-        source: "mcp-http",
-        requestSignal: abortController.signal,
-      });
+      const protocolServer = createMcpServer(
+        engine,
+        {
+          principal,
+          source: "mcp-http",
+          requestSignal: abortController.signal,
+        },
+        toolCatalog,
+      );
       const statelessTransportOptions: WebStandardStreamableHTTPServerTransportOptions =
         {
           enableJsonResponse: true,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -34,6 +34,7 @@ export {
   type ServeMcpHttpOptions,
   serveMcpHttp,
 } from "./http.js";
+export { toMcpToolName } from "./tool-name.js";
 
 import { createMcpServer } from "./protocol-server.js";
 import { preserveFalsyRequestIds } from "./request-id-transport.js";

--- a/packages/mcp/src/protocol-server.ts
+++ b/packages/mcp/src/protocol-server.ts
@@ -16,6 +16,8 @@ import {
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 
+import { toMcpToolName } from "./tool-name.js";
+
 interface McpServerOptions {
   readonly principal: Principal | null;
   readonly source: Extract<ExecutionSource, "mcp-stdio" | "mcp-http">;
@@ -107,45 +109,84 @@ function errorResult(error: unknown) {
   };
 }
 
+interface McpToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: McpObjectSchema;
+  readonly outputSchema: McpObjectSchema;
+  readonly title?: string;
+  readonly annotations?: ReturnType<typeof mapAnnotations>;
+}
+
+export interface McpToolCatalog<Capabilities extends CapabilityMap> {
+  readonly tools: ReadonlyArray<McpToolDefinition>;
+  capabilityIdForToolName(
+    toolName: string,
+  ): Extract<keyof Capabilities, string> | undefined;
+}
+
+export function createMcpToolCatalog<Capabilities extends CapabilityMap>(
+  engine: Engine<Capabilities>,
+): McpToolCatalog<Capabilities> {
+  type CapabilityId = Extract<keyof Capabilities, string>;
+  const capabilityIdByToolName = new Map<string, CapabilityId>();
+  const tools = engine.list().map((summary) => {
+    const capabilityId = summary.id as CapabilityId;
+    const toolName = toMcpToolName(capabilityId);
+    const existingCapabilityId = capabilityIdByToolName.get(toolName);
+    if (existingCapabilityId !== undefined) {
+      const [firstCapabilityId, secondCapabilityId] = [
+        existingCapabilityId,
+        capabilityId,
+      ].sort();
+      throw new TypeError(
+        `Capabilities ${JSON.stringify(firstCapabilityId)} and ${JSON.stringify(secondCapabilityId)} resolve to duplicate MCP tool name ${JSON.stringify(toolName)}.`,
+      );
+    }
+    capabilityIdByToolName.set(toolName, capabilityId);
+
+    const description = engine.describe(capabilityId);
+    const annotations = mapAnnotations(description.annotations);
+    return Object.freeze({
+      name: toolName,
+      description: description.description,
+      inputSchema: asObjectSchema(description.inputSchema),
+      outputSchema: asObjectSchema(description.outputSchema),
+      ...(description.title === undefined ? {} : { title: description.title }),
+      ...(annotations === undefined ? {} : { annotations }),
+    });
+  });
+  const frozenTools = Object.freeze(tools);
+
+  return Object.freeze({
+    tools: frozenTools,
+    capabilityIdForToolName: (toolName: string) =>
+      capabilityIdByToolName.get(toolName),
+  });
+}
+
 export function createMcpServer<Capabilities extends CapabilityMap>(
   engine: Engine<Capabilities>,
   options: McpServerOptions,
+  catalog: McpToolCatalog<Capabilities> = createMcpToolCatalog(engine),
 ): Server {
-  const capabilityIds = new Set(engine.list().map(({ id }) => id));
   const server = new Server(
     { name: engine.name, version: engine.version },
     { capabilities: { tools: {} } },
   );
 
   server.setRequestHandler(ListToolsRequestSchema, () => ({
-    tools: engine.list().map((summary) => {
-      const capabilityId = summary.id as Extract<keyof Capabilities, string>;
-      const description = engine.describe(capabilityId);
-      const annotations = mapAnnotations(description.annotations);
-      return {
-        name: description.id,
-        description: description.description,
-        inputSchema: asObjectSchema(description.inputSchema),
-        outputSchema: asObjectSchema(description.outputSchema),
-        ...(description.title === undefined
-          ? {}
-          : { title: description.title }),
-        ...(annotations === undefined ? {} : { annotations }),
-      };
-    }),
+    tools: Array.from(catalog.tools),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-    if (!capabilityIds.has(request.params.name)) {
+    const capabilityId = catalog.capabilityIdForToolName(request.params.name);
+    if (capabilityId === undefined) {
       throw new McpError(
         ErrorCode.InvalidParams,
         `Tool ${request.params.name} not found`,
       );
     }
-    const capabilityId = request.params.name as Extract<
-      keyof Capabilities,
-      string
-    >;
     try {
       const result = await engine.invoke(
         capabilityId,

--- a/packages/mcp/src/tool-name.ts
+++ b/packages/mcp/src/tool-name.ts
@@ -1,0 +1,21 @@
+import { createHash } from "node:crypto";
+
+const MAX_MCP_TOOL_NAME_LENGTH = 64;
+const MCP_TOOL_NAME_HASH_LENGTH = 12;
+const MCP_TOOL_NAME_PREFIX_LENGTH =
+  MAX_MCP_TOOL_NAME_LENGTH - MCP_TOOL_NAME_HASH_LENGTH - 1;
+
+/** Derives the portable MCP tool name published for one domain capability ID. */
+export function toMcpToolName(capabilityId: string): string {
+  if (typeof capabilityId !== "string") {
+    throw new TypeError("capabilityId must be a string.");
+  }
+  const portable = capabilityId.replace(/[^a-zA-Z0-9_-]/gu, "_") || "_";
+  if (portable.length <= MAX_MCP_TOOL_NAME_LENGTH) return portable;
+
+  const hash = createHash("sha256")
+    .update(capabilityId, "utf8")
+    .digest("hex")
+    .slice(0, MCP_TOOL_NAME_HASH_LENGTH);
+  return `${portable.slice(0, MCP_TOOL_NAME_PREFIX_LENGTH)}_${hash}`;
+}

--- a/packages/mcp/test/client-http.test.ts
+++ b/packages/mcp/test/client-http.test.ts
@@ -154,20 +154,20 @@ describe("plain MCP client facade over Streamable HTTP", () => {
     });
     await expect(connection.listTools()).resolves.toMatchObject({
       tools: [
-        { name: "fixture.echo", title: "Echo fixture" },
-        { name: "fixture.error" },
-        { name: "fixture.wait" },
+        { name: "fixture_echo", title: "Echo fixture" },
+        { name: "fixture_error" },
+        { name: "fixture_wait" },
       ],
     });
     await expect(
-      connection.callTool("fixture.echo", { value: "hello" }),
+      connection.callTool("fixture_echo", { value: "hello" }),
     ).resolves.toMatchObject({
       response: {
         structuredContent: { value: "hello", principalId: "bearer-user" },
       },
     });
     await expect(
-      connection.callTool("fixture.error", {}),
+      connection.callTool("fixture_error", {}),
     ).resolves.toMatchObject({
       response: { isError: true },
     });
@@ -185,7 +185,7 @@ describe("plain MCP client facade over Streamable HTTP", () => {
     });
 
     await expect(
-      connection.callTool("fixture.echo", { value: "custom" }),
+      connection.callTool("fixture_echo", { value: "custom" }),
     ).resolves.toMatchObject({
       response: {
         structuredContent: { value: "custom", principalId: "header-user" },
@@ -218,7 +218,7 @@ describe("plain MCP client facade over Streamable HTTP", () => {
       url: fixture.url,
       authentication: { type: "bearer", token: "correct" },
     });
-    const call = connection.callTool("fixture.wait", {});
+    const call = connection.callTool("fixture_wait", {});
     const closing = connection.close();
 
     await expect(call).rejects.toMatchObject({ code: "CANCELLED" });

--- a/packages/mcp/test/composition-remap.test.ts
+++ b/packages/mcp/test/composition-remap.test.ts
@@ -33,6 +33,8 @@ const effectiveIds = [
   "reports.archive",
 ] as const;
 
+const effectiveToolNames = effectiveIds.map((id) => id.replaceAll(".", "_"));
+
 const remappedDefaultIds = [
   "support.classify-ticket",
   "reports.summarize",
@@ -295,13 +297,13 @@ function expectNoCompositionLeak(serialized: string): void {
 }
 
 describe("MCP adapter over remapped imported capabilities", () => {
-  it("advertises exactly the effective IDs as tool names", async () => {
+  it("advertises portable MCP names for exactly the effective IDs", async () => {
     const probe = createProbe();
     const { client } = await connect(createComposedEngine(probe));
 
     const listed = await client.listTools();
 
-    expect(listed.tools.map((tool) => tool.name)).toEqual([...effectiveIds]);
+    expect(listed.tools.map((tool) => tool.name)).toEqual(effectiveToolNames);
     expectNoCompositionLeak(JSON.stringify(listed.tools));
   });
 
@@ -367,10 +369,11 @@ describe("MCP adapter over remapped imported capabilities", () => {
       const expected = baseline.describe(effectiveId);
 
       const listed = await client.listTools();
-      const tool = listed.tools.find(({ name }) => name === effectiveId);
+      const toolName = effectiveId.replaceAll(".", "_");
+      const tool = listed.tools.find(({ name }) => name === toolName);
 
       expect(tool).toEqual({
-        name: effectiveId,
+        name: toolName,
         description: expected.description,
         inputSchema: expected.inputSchema,
         outputSchema: expected.outputSchema,
@@ -416,7 +419,7 @@ describe("MCP adapter over remapped imported capabilities", () => {
       const { client } = await connect(createComposedEngine(probe));
 
       const result = await client.callTool({
-        name: effectiveId,
+        name: effectiveId.replaceAll(".", "_"),
         arguments: toolArguments,
       });
 
@@ -470,11 +473,11 @@ describe("MCP adapter over remapped imported capabilities", () => {
     const engine = spyOnInvoke(createComposedEngine(probe), probe);
     const { client } = await connect(engine);
     const calls = [
-      { name: "operations.ping", arguments: {} },
-      { name: "operations.classify-ticket", arguments: { ticketId: "T-2" } },
-      { name: "health.check", arguments: {} },
-      { name: "operations.summarize-report", arguments: { reportId: "R-1" } },
-      { name: "reports.archive", arguments: { reportId: "R-1" } },
+      { name: "operations_ping", arguments: {} },
+      { name: "operations_classify-ticket", arguments: { ticketId: "T-2" } },
+      { name: "health_check", arguments: {} },
+      { name: "operations_summarize-report", arguments: { reportId: "R-1" } },
+      { name: "reports_archive", arguments: { reportId: "R-1" } },
     ];
 
     for (const call of calls) {
@@ -542,16 +545,16 @@ describe("MCP adapter over remapped imported capabilities", () => {
     ];
 
     await client.callTool({
-      name: "operations.classify-ticket",
+      name: "operations_classify-ticket",
       arguments: { ticketId: "T-3" },
     });
     await client.callTool({
-      name: "operations.summarize-report",
+      name: "operations_summarize-report",
       arguments: { reportId: "R-2" },
     });
-    await client.callTool({ name: "health.check", arguments: {} });
+    await client.callTool({ name: "health_check", arguments: {} });
     await client.callTool({
-      name: "reports.archive",
+      name: "reports_archive",
       arguments: { reportId: "R-2" },
     });
 

--- a/packages/mcp/test/http.test.ts
+++ b/packages/mcp/test/http.test.ts
@@ -99,7 +99,7 @@ async function callTool(
       id: options.id ?? crypto.randomUUID(),
       method: "tools/call",
       params: {
-        name: "support.inspect",
+        name: "support_inspect",
         arguments: options.arguments ?? { value: "ok" },
       },
     }),
@@ -141,7 +141,7 @@ async function callToolWithRawHost(
         jsonrpc: "2.0",
         id: "host-test",
         method: "tools/call",
-        params: { name: "support.inspect", arguments: { value: "ok" } },
+        params: { name: "support_inspect", arguments: { value: "ok" } },
       }),
     );
   });
@@ -243,7 +243,7 @@ function toolCallBodyWithValueBytes(
 ): ReadonlyArray<Uint8Array> {
   return [
     Buffer.from(
-      `{"jsonrpc":"2.0","id":"${id}","method":"tools/call","params":{"name":"support.inspect","arguments":{"value":"`,
+      `{"jsonrpc":"2.0","id":"${id}","method":"tools/call","params":{"name":"support_inspect","arguments":{"value":"`,
     ),
     value,
     Buffer.from('"}}}'),
@@ -311,6 +311,37 @@ describe("MCP stateless Streamable HTTP", () => {
         auth: { mode: "required", authenticate: undefined } as never,
       }),
     ).rejects.toThrow("authenticate");
+  });
+
+  it("rejects colliding portable tool names before listening", async () => {
+    const capability = defineCapability({
+      description: "Creates a tool-name collision fixture.",
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      access: "public",
+      async run() {
+        return { ok: true };
+      },
+    });
+    const engine = createEngine({
+      name: "colliding-http-tool-name-engine",
+      version: "0.1.0",
+      capabilities: {
+        "support.inspect": capability,
+        support_inspect: capability,
+      },
+    });
+    const authenticate = vi.fn(() => ({ id: "must-not-run" }));
+
+    await expect(
+      serveMcpHttp(engine, {
+        port: 0,
+        auth: { mode: "required", authenticate },
+      }),
+    ).rejects.toThrow(
+      'Capabilities "support.inspect" and "support_inspect" resolve to duplicate MCP tool name "support_inspect".',
+    );
+    expect(authenticate).not.toHaveBeenCalled();
   });
 
   it("snapshots the required authentication hook before listening", async () => {
@@ -486,7 +517,9 @@ describe("MCP stateless Streamable HTTP", () => {
   });
 
   it("interoperates with the official Streamable HTTP client", async () => {
-    const server = await start();
+    const engine = createContextEngine();
+    const invoke = vi.spyOn(engine, "invoke");
+    const server = await start(engine);
     const transport = new StreamableHTTPClientTransport(
       new URL(endpoint(server)),
       { requestInit: { headers: { authorization: "Bearer official" } } },
@@ -498,9 +531,12 @@ describe("MCP stateless Streamable HTTP", () => {
 
     try {
       await client.connect(transport as unknown as Transport);
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: "support_inspect" }],
+      });
       await expect(
         client.callTool({
-          name: "support.inspect",
+          name: "support_inspect",
           arguments: { value: "official-client" },
         }),
       ).resolves.toMatchObject({
@@ -509,6 +545,7 @@ describe("MCP stateless Streamable HTTP", () => {
           principalId: "user:official",
         },
       });
+      expect(invoke.mock.calls[0]?.[0]).toBe("support.inspect");
     } finally {
       await client.close();
     }
@@ -931,7 +968,7 @@ describe("MCP stateless Streamable HTTP", () => {
     try {
       const response = await rawHttpResponseFromBodyChunks(server, [
         Buffer.from(
-          '{"jsonrpc":"2.0","id":"pending-eof","method":"tools/call","params":{"name":"support.inspect","arguments":{"value":"',
+          '{"jsonrpc":"2.0","id":"pending-eof","method":"tools/call","params":{"name":"support_inspect","arguments":{"value":"',
         ),
         Uint8Array.from([0xc3]),
       ]);
@@ -1125,7 +1162,7 @@ describe("MCP stateless Streamable HTTP", () => {
         id: "batch-call",
         method: "tools/call",
         params: {
-          name: "support.inspect",
+          name: "support_inspect",
           arguments: { value: "must-not-run" },
         },
       },
@@ -1671,7 +1708,7 @@ describe("MCP stateless Streamable HTTP", () => {
         jsonrpc: "2.0",
         id: "cancel-http",
         method: "tools/call",
-        params: { name: "support.inspect", arguments: { value: "wait" } },
+        params: { name: "support_inspect", arguments: { value: "wait" } },
       }),
       signal: controller.signal,
     });

--- a/packages/mcp/test/http.test.ts
+++ b/packages/mcp/test/http.test.ts
@@ -99,7 +99,7 @@ async function callTool(
       id: options.id ?? crypto.randomUUID(),
       method: "tools/call",
       params: {
-        name: "support.inspect",
+        name: "support_inspect",
         arguments: options.arguments ?? { value: "ok" },
       },
     }),
@@ -141,7 +141,7 @@ async function callToolWithRawHost(
         jsonrpc: "2.0",
         id: "host-test",
         method: "tools/call",
-        params: { name: "support.inspect", arguments: { value: "ok" } },
+        params: { name: "support_inspect", arguments: { value: "ok" } },
       }),
     );
   });
@@ -243,7 +243,7 @@ function toolCallBodyWithValueBytes(
 ): ReadonlyArray<Uint8Array> {
   return [
     Buffer.from(
-      `{"jsonrpc":"2.0","id":"${id}","method":"tools/call","params":{"name":"support.inspect","arguments":{"value":"`,
+      `{"jsonrpc":"2.0","id":"${id}","method":"tools/call","params":{"name":"support_inspect","arguments":{"value":"`,
     ),
     value,
     Buffer.from('"}}}'),
@@ -311,6 +311,37 @@ describe("MCP stateless Streamable HTTP", () => {
         auth: { mode: "required", authenticate: undefined } as never,
       }),
     ).rejects.toThrow("authenticate");
+  });
+
+  it("rejects colliding portable tool names before listening", async () => {
+    const capability = defineCapability({
+      description: "Creates a tool-name collision fixture.",
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      access: "public",
+      async run() {
+        return { ok: true };
+      },
+    });
+    const engine = createEngine({
+      name: "colliding-http-tool-name-engine",
+      version: "0.1.0",
+      capabilities: {
+        "support.inspect": capability,
+        support_inspect: capability,
+      },
+    });
+    const authenticate = vi.fn(() => ({ id: "must-not-run" }));
+
+    await expect(
+      serveMcpHttp(engine, {
+        port: 0,
+        auth: { mode: "required", authenticate },
+      }),
+    ).rejects.toThrow(
+      'Capabilities "support.inspect" and "support_inspect" resolve to duplicate MCP tool name "support_inspect".',
+    );
+    expect(authenticate).not.toHaveBeenCalled();
   });
 
   it("snapshots the required authentication hook before listening", async () => {
@@ -486,7 +517,9 @@ describe("MCP stateless Streamable HTTP", () => {
   });
 
   it("interoperates with the official Streamable HTTP client", async () => {
-    const server = await start();
+    const engine = createContextEngine();
+    const invoke = vi.spyOn(engine, "invoke");
+    const server = await start(engine);
     const transport = new StreamableHTTPClientTransport(
       new URL(endpoint(server)),
       { requestInit: { headers: { authorization: "Bearer official" } } },
@@ -498,9 +531,12 @@ describe("MCP stateless Streamable HTTP", () => {
 
     try {
       await client.connect(transport as unknown as Transport);
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: "support_inspect" }],
+      });
       await expect(
         client.callTool({
-          name: "support.inspect",
+          name: "support_inspect",
           arguments: { value: "official-client" },
         }),
       ).resolves.toMatchObject({
@@ -509,6 +545,7 @@ describe("MCP stateless Streamable HTTP", () => {
           principalId: "user:official",
         },
       });
+      expect(invoke.mock.calls[0]?.[0]).toBe("support.inspect");
     } finally {
       await client.close();
     }
@@ -931,7 +968,7 @@ describe("MCP stateless Streamable HTTP", () => {
     try {
       const response = await rawHttpResponseFromBodyChunks(server, [
         Buffer.from(
-          '{"jsonrpc":"2.0","id":"pending-eof","method":"tools/call","params":{"name":"support.inspect","arguments":{"value":"',
+          '{"jsonrpc":"2.0","id":"pending-eof","method":"tools/call","params":{"name":"support_inspect","arguments":{"value":"',
         ),
         Uint8Array.from([0xc3]),
       ]);
@@ -1125,7 +1162,7 @@ describe("MCP stateless Streamable HTTP", () => {
         id: "batch-call",
         method: "tools/call",
         params: {
-          name: "support.inspect",
+          name: "support_inspect",
           arguments: { value: "must-not-run" },
         },
       },
@@ -1762,7 +1799,7 @@ describe("MCP stateless Streamable HTTP", () => {
         jsonrpc: "2.0",
         id: "cancel-http",
         method: "tools/call",
-        params: { name: "support.inspect", arguments: { value: "wait" } },
+        params: { name: "support_inspect", arguments: { value: "wait" } },
       }),
       signal: controller.signal,
     });

--- a/packages/mcp/test/public-api.types.ts
+++ b/packages/mcp/test/public-api.types.ts
@@ -22,7 +22,10 @@ import {
   type ServeMcpStdioOptions,
   serveMcpHttp,
   serveMcpStdio,
+  toMcpToolName,
 } from "../src/index.js";
+
+expectTypeOf(toMcpToolName("support.classify-ticket")).toEqualTypeOf<string>();
 
 const stdioTarget = {
   transport: "stdio",

--- a/packages/mcp/test/stdio-child-process.test.ts
+++ b/packages/mcp/test/stdio-child-process.test.ts
@@ -150,14 +150,14 @@ it("serves handshake, tools/list, and tools/call over protocol-only stdio", asyn
     await expect(client.listTools()).resolves.toMatchObject({
       tools: [
         {
-          name: "example.inspect-context",
+          name: "example_inspect-context",
           description: "Returns the stdio execution boundary context.",
         },
       ],
     });
     await expect(
       client.callTool({
-        name: "example.inspect-context",
+        name: "example_inspect-context",
         arguments: { value: "wire-ok" },
       }),
     ).resolves.toEqual({
@@ -209,7 +209,7 @@ it("closes on stdin EOF, cancels active work, and exits cleanly", async () => {
     jsonrpc: "2.0",
     id: 2,
     method: "tools/call",
-    params: { name: "example.wait", arguments: {} },
+    params: { name: "example_wait", arguments: {} },
   });
   await stderr.waitFor("started\n");
 
@@ -288,7 +288,7 @@ it("drops a backpressured response when stdin closes and exits cleanly", async (
     jsonrpc: "2.0",
     id: 2,
     method: "tools/call",
-    params: { name: "example.large", arguments: {} },
+    params: { name: "example_large", arguments: {} },
   });
   await stderr.waitFor("large-write-started\n");
   child.stdin.end();
@@ -360,7 +360,7 @@ it("closes cleanly when a stdio frame exceeds the configured read-buffer limit",
     jsonrpc: "2.0",
     id: 2,
     method: "tools/call",
-    params: { name: "example.wait", arguments: {} },
+    params: { name: "example_wait", arguments: {} },
   });
   await stderr.waitFor("started\n");
   child.stdin.write("x".repeat(maxReadBufferBytes + 1));
@@ -418,7 +418,7 @@ it("round trips and cancels concurrent request IDs including falsy IDs", async (
         id,
         method: "tools/call",
         params: {
-          name: "example.concurrent-wait",
+          name: "example_concurrent-wait",
           arguments: { label },
         },
       });

--- a/packages/mcp/test/stdio.test.ts
+++ b/packages/mcp/test/stdio.test.ts
@@ -103,7 +103,7 @@ describe("MCP stdio protocol adapter", () => {
     },
   );
 
-  it("negotiates the baseline protocol and maps each capability to one tool", async () => {
+  it("negotiates the baseline protocol and maps each capability to one portable tool", async () => {
     expect(LATEST_PROTOCOL_VERSION).toBe("2025-11-25");
     const engine = createEchoEngine();
     const { client } = await connect(engine);
@@ -116,7 +116,7 @@ describe("MCP stdio protocol adapter", () => {
 
     expect(listed.tools).toEqual([
       {
-        name: "support.echo",
+        name: "support_echo",
         title: "Echo support text",
         description: "Returns normalized support text.",
         inputSchema: engine.describe("support.echo").inputSchema,
@@ -136,7 +136,7 @@ describe("MCP stdio protocol adapter", () => {
     const { client } = await connect(createEchoEngine(observeContext));
 
     const result = await client.callTool({
-      name: "support.echo",
+      name: "support_echo",
       arguments: { text: "  hello  " },
     });
 
@@ -156,11 +156,105 @@ describe("MCP stdio protocol adapter", () => {
     );
   });
 
-  it("returns a protocol error for an unknown tool", async () => {
+  it("normalizes unsupported characters and bounds long MCP tool names", async () => {
+    const longCapabilityId = "a".repeat(65);
+    const engine = createEngine({
+      name: "portable-tool-name-engine",
+      version: "0.1.0",
+      capabilities: {
+        "": defineCapability({
+          description: "Uses an empty capability ID.",
+          input: z.object({}),
+          output: z.object({ id: z.string() }),
+          access: "public",
+          async run() {
+            return { id: "" };
+          },
+        }),
+        "already-compatible_1": defineCapability({
+          description: "Uses an already portable capability ID.",
+          input: z.object({}),
+          output: z.object({ id: z.string() }),
+          access: "public",
+          async run() {
+            return { id: "already-compatible_1" };
+          },
+        }),
+        "knowledge/ação": defineCapability({
+          description: "Uses non-ASCII and separator characters.",
+          input: z.object({}),
+          output: z.object({ id: z.string() }),
+          access: "public",
+          async run() {
+            return { id: "knowledge/ação" };
+          },
+        }),
+        [longCapabilityId]: defineCapability({
+          description: "Uses a capability ID longer than the MCP limit.",
+          input: z.object({}),
+          output: z.object({ id: z.string() }),
+          access: "public",
+          async run() {
+            return { id: longCapabilityId };
+          },
+        }),
+      },
+    });
+    const { client } = await connect(engine);
+
+    const listed = await client.listTools();
+
+    expect(listed.tools.map(({ name }) => name)).toEqual([
+      "_",
+      "already-compatible_1",
+      "knowledge_a__o",
+      `${"a".repeat(51)}_635361c48bb9`,
+    ]);
+    for (const { name } of listed.tools) {
+      expect(name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/u);
+    }
+    await expect(
+      client.callTool({ name: "knowledge_a__o", arguments: {} }),
+    ).resolves.toMatchObject({ structuredContent: { id: "knowledge/ação" } });
+  });
+
+  it("rejects capability IDs that resolve to the same MCP tool name", () => {
+    const capability = defineCapability({
+      description: "Creates a tool-name collision fixture.",
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      access: "public",
+      async run() {
+        return { ok: true };
+      },
+    });
+    const engine = createEngine({
+      name: "colliding-tool-name-engine",
+      version: "0.1.0",
+      capabilities: {
+        "support.echo": capability,
+        support_echo: capability,
+      },
+    });
+
+    expect(() =>
+      createMcpServer(engine, {
+        principal: null,
+        source: "mcp-stdio",
+      }),
+    ).toThrow(
+      'Capabilities "support.echo" and "support_echo" resolve to duplicate MCP tool name "support_echo".',
+    );
+  });
+
+  it("rejects domain IDs and unknown names not published by tools/list", async () => {
     const { client } = await connect(createEchoEngine());
 
     await expect(
-      client.callTool({ name: "support.missing", arguments: {} }),
+      client.callTool({ name: "support.echo", arguments: {} }),
+    ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+    await expect(
+      client.callTool({ name: "support_missing", arguments: {} }),
     ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
   });
 
@@ -188,7 +282,7 @@ describe("MCP stdio protocol adapter", () => {
     const { client } = await connect(engine);
 
     const result = await client.callTool({
-      name: "support.fail",
+      name: "support_fail",
       arguments: { ticketId: "T-1" },
     });
 
@@ -327,7 +421,7 @@ describe("MCP stdio protocol adapter", () => {
       const { client } = await connect(engine);
 
       const result = await client.callTool({
-        name: "support.echo",
+        name: "support_echo",
         arguments: { text: "hello" },
       });
 
@@ -351,7 +445,7 @@ describe("MCP stdio protocol adapter", () => {
     const invalidInputClient = (await connect(createEchoEngine())).client;
 
     const inputResult = await invalidInputClient.callTool({
-      name: "support.echo",
+      name: "support_echo",
       arguments: { text: "   " },
     });
     expect(inputResult.isError).toBe(true);
@@ -378,7 +472,7 @@ describe("MCP stdio protocol adapter", () => {
     const invalidOutputClient = (await connect(invalidOutputEngine)).client;
 
     const outputResult = await invalidOutputClient.callTool({
-      name: "support.invalid-output",
+      name: "support_invalid-output",
       arguments: {},
     });
     expect(outputResult.isError).toBe(true);
@@ -406,7 +500,7 @@ describe("MCP stdio protocol adapter", () => {
     const { client } = await connect(engine, null);
 
     const result = await client.callTool({
-      name: "support.authenticated",
+      name: "support_authenticated",
       arguments: {},
     });
     expect(result.isError).toBe(true);
@@ -436,7 +530,7 @@ describe("MCP stdio protocol adapter", () => {
     const { client } = await connect(engine);
 
     const result = await client.callTool({
-      name: "support.unsafe",
+      name: "support_unsafe",
       arguments: {},
     });
 
@@ -473,7 +567,7 @@ describe("MCP stdio protocol adapter", () => {
     const { client } = await connect(engine);
 
     const result = await client.callTool({
-      name: "support.protected",
+      name: "support_protected",
       arguments: {},
     });
 
@@ -526,7 +620,7 @@ describe("MCP stdio protocol adapter", () => {
     const controller = new AbortController();
 
     const invocation = client.callTool(
-      { name: "support.wait", arguments: {} },
+      { name: "support_wait", arguments: {} },
       undefined,
       { signal: controller.signal },
     );

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -417,7 +417,7 @@ function writeGeneratedMcpSmoke(projectDirectory, projectName) {
         id: 2,
         method: "tools/call",
         params: {
-          name: "onboarding.create-welcome-message",
+          name: "onboarding_create-welcome-message",
           arguments: { name: "Ada" },
         },
       });
@@ -559,7 +559,7 @@ function writeGeneratedHttpSmoke(projectDirectory, projectName) {
       try {
         await client.connect(transport);
         const result = await client.callTool({
-          name: "onboarding.create-welcome-message",
+          name: "onboarding_create-welcome-message",
           arguments: { name: "Ada" },
         });
         assert.deepEqual(result.structuredContent, {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    testTimeout: 10_000,
     coverage: {
       thresholds: {
         "packages/devtools/**": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,10 +1372,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.17, nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 negotiator@0.6.3:
   version "0.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,10 +1112,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@3.3.17, nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 negotiator@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

This PR introduces a production-oriented self-hosted OAuth 2.1 authorization server example and adds OAuth inspection capabilities to the deploy toolkit. The changes enable MCP deployments to run their own OAuth infrastructure with PKCE, Dynamic Client Registration, JWT access tokens, and rotating refresh tokens, while providing diagnostic tools to verify OAuth configuration.

## Key Changes

### New Self-Hosted OAuth Engine Example
- **`examples/auth-self-hosted-oauth-engine/`**: Complete PostgreSQL-backed OAuth 2.1 authorization server
  - OIDC Provider integration with ES256 ID tokens and `client_secret_basic` defaults
  - Authorization Code flow with mandatory PKCE
  - Dynamic Client Registration (DCR) support
  - JWT ES256 access tokens scoped to MCP resource and `mcp:tools`
  - Rotating refresh tokens with 30-day lifetime
  - Explicit owner login and consent (no public sign-up)
  - Sanitized OAuth diagnostics that never log sensitive data
  - Docker Compose deployment with bundled Caddy or Traefik integration
  - PostgreSQL schema migrations and user/secret management
  - Comprehensive documentation (architecture, troubleshooting, deployment runbook, production checklist)

### OAuth Inspection Tooling
- **`packages/deploy/src/oauth-inspection/`**: New inspection module for OAuth configuration validation
  - `inspect.ts`: Core inspection logic validating resource metadata, authorization server discovery, JWKS, and registration readiness
  - `request.ts`: HTTP request handling with deadline enforcement and response size limits
  - `options.ts`: CLI argument parsing for inspection commands
  - Detailed failure reasons and stages for diagnostic clarity
- **`packages/deploy/src/inspect-oauth.ts`**: CLI entry point for `invokta-deploy inspect-oauth` command
- **Test coverage**: Integration tests with OAuth stub servers and devtools OAuth client testing

### MCP HTTP Enhancements
- Added `challengeScopes` optional field to `McpHttpAuthOptions` in `@invokta/mcp`
- Allows ordered OAuth challenge scopes independent from supported scopes
- Validates challenge scope size (4096 byte limit)

### Documentation & Examples
- **`apps/docs/src/content/docs/recipes/auth/self-hosted-oauth.mdx`**: Production deployment guide
- **`docs/adr/0024-production-mcp-oauth-integration-boundary.md`**: Architecture decision record
- **`docs/oauth-client-interoperability-checklist.md`**: Manual testing checklist for OAuth clients
- **`docs/http-authentication.md`**: Updated with challenge scopes documentation
- Updated examples index and recipe navigation

### Supporting Infrastructure
- Agent skills for deploying, maintaining, and developing the OAuth engine
- Environment configuration with safe defaults and validation
- HTTP authentication modes (Bearer token and OAuth)
- Database configuration and migration tooling
- Health check endpoint for container orchestration

## Notable Implementation Details

- **Security-first design**: Fail-closed validation, timing-safe comparisons, CSRF protection, CSP headers
- **Boundary preservation**: OAuth authorization server remains separate from MCP resource server; both can be deployed independently
- **Production-ready**: Includes logging sanitization, error handling, PostgreSQL persistence, and deployment automation
- **Extensible**: Example is meant to be imported and customized; includes clear customization guide
- **Comprehensive testing**: Unit tests for password hashing, OAuth provider configuration, HTTP authentication, and database setup

The implementation follows the architecture decision in ADR 0024, establishing the MCP HTTP adapter as a Resource Server while providing a reference Authorization Server implementation that projects can own and customize.

https://claude.ai/code/session_01HUXcqZVpwNWjfbtLVAZWxq