### PR TITLE
fix(devtools): exit the watch engine host on SIGTERM instead of waiting out SIGKILL

### DIFF
--- a/packages/devtools/src/host-entry.ts
+++ b/packages/devtools/src/host-entry.ts
@@ -133,6 +133,12 @@ async function main(): Promise<number> {
     process.once("SIGTERM", stop);
     process.stdin.once("end", stop);
   });
+  // The readline interface holds a referenced stdin handle that the parent
+  // never closes. Releasing it lets the event loop drain once the host is
+  // closed; otherwise the process outlives SIGTERM and the watcher waits out
+  // its whole SIGKILL timeout before starting the rebuilt engine.
+  stdinLines.close();
+  process.stdin.pause();
   await host.close();
   return 0;
 }

--- a/packages/devtools/test/watch.test.ts
+++ b/packages/devtools/test/watch.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -246,4 +246,54 @@ describe("serve --watch", () => {
     expect(failed.detail).toContain("error TS1005");
     expect(await greet()).toBe("two");
   }, 20_000);
+
+  // Every rebuild kills the previous host before starting the next one, so a
+  // host that outlives SIGTERM makes the watcher wait out its whole SIGKILL
+  // timeout on each change.
+  it("exits the engine host on SIGTERM without waiting for SIGKILL", async () => {
+    const hostEntry = join(
+      repositoryRoot,
+      "packages/devtools/dist/host-entry.js",
+    );
+    const child = spawn(
+      process.execPath,
+      [hostEntry, "out/engine.js", "engine", "http://127.0.0.1:0", "0"],
+      { cwd: projectRoot, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const exited = new Promise<void>((resolvePromise) => {
+      child.once("exit", () => {
+        resolvePromise();
+      });
+    });
+
+    try {
+      child.stderr.setEncoding("utf8");
+      await waitFor(
+        () =>
+          new Promise<true | undefined>((resolvePromise) => {
+            const onData = (chunk: string): void => {
+              if (!chunk.includes('"type":"ready"')) return;
+              child.stderr.off("data", onData);
+              resolvePromise(true);
+            };
+            child.stderr.on("data", onData);
+            setTimeout(() => {
+              child.stderr.off("data", onData);
+              resolvePromise(undefined);
+            }, 500);
+          }),
+        15_000,
+        "the engine host ready message",
+      );
+
+      const sentAt = Date.now();
+      child.kill("SIGTERM");
+      await exited;
+      // The watcher escalates to SIGKILL after 3s; a clean exit is immediate.
+      expect(Date.now() - sentAt).toBeLessThan(2_000);
+    } finally {
+      child.kill("SIGKILL");
+      await exited;
+    }
+  }, 25_000);
 });


### PR DESCRIPTION
## Summary

`invokta-devtools serve --watch` took **3.8s** to reflect a one-line source change on `examples/hello-engine`, while the incremental `tsc -b` that produced the change took **~40 ms**. Practically all of the remaining time was the watcher waiting out its own `SIGKILL` timeout, because the engine host child never exited on `SIGTERM`.

This fixes the shutdown so the host exits on its own. The rebuild cycle drops from **3.5s to 0.5s**, and `packages/devtools/test/watch.test.ts` from **32.5s to 2.3s**.

![Rebuild cycle before and after the fix](https://raw.githubusercontent.com/willianbvsanches13/invokta/5bae25b9117b3966a9b815d9b505bd51664d690c/watch-cycle.svg)

## Root cause

`packages/devtools/src/host-entry.ts` opens a readline interface over `process.stdin` — that is the control channel the devtools parent uses to mirror the principal token table into the child:

```ts
const stdinLines = createInterface({ input: process.stdin });
stdinLines.on("line", (line) => { /* principals */ });
```

`createInterface` resumes stdin and keeps its handle **referenced**, and the parent never closes the child's stdin. So on `SIGTERM` the shutdown gets as far as it can and then stalls:

1. the `stop` promise resolves,
2. `await host.close()` completes — the MCP HTTP listener really does go away,
3. `main()` returns and `process.exitCode` is set,
4. …and the process stays alive anyway, because the referenced stdin handle keeps the event loop from ever draining.

![Handle-by-handle shutdown of the engine host](https://raw.githubusercontent.com/willianbvsanches13/invokta/5bae25b9117b3966a9b815d9b505bd51664d690c/sigterm-shutdown.svg)

Verified directly against a running host: after `kill -TERM`, the process was still alive **more than 100 seconds later**, and its `/proc/<pid>/fd` listing showed no listening socket and no established connections left — only the stdio pipes. Nothing was left to do; the loop just could not drain.

## Why that costs 3 seconds on every rebuild

`packages/devtools/src/watch.ts` replaces the host by killing the previous child *before* spawning the next one, and `killChild` escalates to `SIGKILL` after `killTimeoutMs = 3000`:

```
runCycle: debounce 300ms → build → await killChild(previous) → await startChild()
```

Since the child never honoured `SIGTERM`, every single rebuild paid the full 3000 ms before the replacement engine could even start.

## The fix

Release the control channel before closing the host, so the event loop drains:

```ts
// packages/devtools/src/host-entry.ts
stdinLines.close();
process.stdin.pause();
await host.close();
```

Nothing else changes: the child still never reloads a module, the parent still replaces the whole process, and a failed build still keeps the previous engine serving.

## Measurements

Taken on `examples/hello-engine` with `--watch --build "tsc -b --pretty false"`, changing one capability description and polling `/api/capabilities` until the new value is served.

| | before | after |
|---|---|---|
| rebuild cycle (`rebuild ok (…)` notice) | 3.5s | **0.5s** |
| change → served, 3 consecutive runs | 3.8s | **0.86s / 0.92s / 0.94s** |
| `packages/devtools/test/watch.test.ts` | 32.5s | **2.3s** |

For context, these were never the bottleneck — the whole rest of the local loop is already fast:

| step | time |
|---|---|
| cold build of the monorepo (10 packages + 24 examples) | 1.4s |
| incremental `tsc -b` after a one-line change | ~40 ms |
| `invokta-devtools --version` (CLI startup) | 0.26s |
| index HTML + each of the 17 UI modules | <1 ms |
| `GET /api/capabilities` | 1 ms |

## Tests

Added `exits the engine host on SIGTERM without waiting for SIGKILL` to `packages/devtools/test/watch.test.ts`. It spawns `host-entry.js` against the existing watch fixture, waits for the `ready` protocol message, sends `SIGTERM`, and asserts the process exits in under 2s — comfortably inside the watcher's 3s escalation.

Followed RED → GREEN: the test times out at 25s against the unfixed host, and passes in ~40 ms with the fix.

## Verification

- `yarn typecheck` ✅
- `yarn lint` ✅
- `yarn format:check` ✅
- `yarn test:run` — 2728 passed, 1 failed
- `yarn build` ✅

The single failure is `packages/deploy/test/container-e2e.test.ts` (`connect ECONNREFUSED`), which fails identically on `main` in this environment and is unrelated to this change.

## About the diagrams

The two animated SVGs above are **not part of this pull request** — it is a
single commit touching only `packages/devtools`. They are hosted on a
standalone branch of my own fork purely to carry this description, so nothing
image-related ever enters this repository.
