### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/.agents/skills/prepare-invokta-release/SKILL.md
+++ b/.agents/skills/prepare-invokta-release/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: prepare-invokta-release
+description: "Prepare Invokta versioned releases on dedicated release branches with synchronized package metadata, changelog and validation evidence, complete repository gates, and one cohesive commit. Use when asked to prepare, cut, stage, or validate an Invokta release or release candidate."
+---
+
+# Prepare an Invokta Release
+
+## Establish the release branch
+
+1. Read `.agents/skills/invokta-delivery/SKILL.md`, `docs/README.md`, the
+   release gates in `docs/implementation-plan-and-acceptance-criteria.md`, and
+   the ADRs represented by the unreleased changes.
+2. Inspect the working tree, current branch, local and remote mainline refs,
+   recent tags, `CHANGELOG.md`, and commits since the latest release. Preserve
+   unrelated changes and stop if they make the release slice ambiguous.
+3. Select the next semantic version from the compatibility of the Unreleased
+   changes and the repository's prior release policy. Request a decision when
+   the correct increment is ambiguous.
+4. Confirm the intended mainline base. If local `main` and `origin/main`
+   diverge, resolve the base explicitly before continuing.
+5. Create or switch to `chore/release-X.Y.Z` from the confirmed mainline before
+   editing any release file. Never prepare or commit a release on `main`.
+
+## Synchronize release metadata
+
+1. Bump the root version and every public package version to `X.Y.Z`.
+2. Bump every exact internal `@invokta/*` dependency pin in public packages and
+   examples. Update version assertions and protocol client self-identification
+   constants that intentionally track the release.
+3. Search the repository for the previous version. Classify every match as
+   current release metadata, historical release documentation, or an unrelated
+   dependency before changing it.
+4. Synchronize committed example lockfiles. For unpublished Invokta packages,
+   derive integrity values from the exact locally packed `X.Y.Z` artifacts;
+   never retain old integrity hashes or invent new ones. Recheck the hashes if
+   package contents change afterward.
+5. Move the Unreleased notes under `## [X.Y.Z] - YYYY-MM-DD`, update the
+   Unreleased comparison base, and add the release link. Preserve historical
+   entries and write all release content in English.
+6. Refresh `docs/validation-record.md` only with evidence produced during this
+   release run, including the review date, accepted ADRs, test totals,
+   coverage, and audit count.
+
+Do not change a public contract merely to prepare the release. If preparation
+reveals a missing or conflicting contract, stop and apply
+`$invokta-contract-review` before continuing.
+
+## Run the release gates
+
+Run the canonical commands from a clean dependency state:
+
+```sh
+yarn install --frozen-lockfile --non-interactive
+yarn run check
+yarn audit
+cd apps/docs
+yarn install --frozen-lockfile --non-interactive
+yarn validate
+```
+
+Return to the repository root and then:
+
+1. Update the validation record with the exact results and stage only the
+   cohesive release slice.
+2. Inspect `git diff --cached`, run `git diff --cached --check`, and confirm all
+   package versions and internal pins equal `X.Y.Z`.
+3. Run `yarn release:verify`. This verifier archives the Git index, so release
+   files must be staged first; unstaged changes are intentionally excluded.
+4. If a packed consumer tries to resolve `@invokta/*@X.Y.Z` from the registry,
+   treat that as a pre-publish verifier defect. Record the failing command as
+   RED, install the complete matching local tarball dependency closure in the
+   fixture, and rerun the verifier for GREEN.
+5. Rerun `yarn run check` after any executable verifier change. Reinspect the
+   staged diff and confirm the working tree has no unstaged release changes.
+
+Do not claim readiness while any typecheck, lint, formatting, test, coverage,
+build, audit, documentation, package, or diff gate fails.
+
+## Commit and hand off
+
+1. Create one commit named `chore(release): prepare X.Y.Z` on the release
+   branch.
+2. Confirm `main` still points to the confirmed mainline, the release branch
+   contains the commit, and the working tree is clean.
+3. Report the version, branch, commit hash, RED/GREEN evidence or metadata-only
+   exception, validation results, risks, and pending work.
+4. Do not tag, push, publish packages, or create a pull request unless the user
+   explicitly requests that separate action.

--- a/.agents/skills/prepare-invokta-release/agents/openai.yaml
+++ b/.agents/skills/prepare-invokta-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare Invokta Release"
+  short_description: "Prepare validated Invokta release branches"
+  default_prompt: "Use $prepare-invokta-release to prepare the next Invokta release on a dedicated release branch."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-15
+
 ### Added
 
 - `invokta-devtools serve` now emulates a capability call through the execution
@@ -300,7 +302,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/vinilana/invokta/releases/tag/v0.5.0
 [0.4.0]: https://github.com/vinilana/invokta/releases/tag/v0.4.0
 [0.3.0]: https://github.com/vinilana/invokta/releases/tag/v0.3.0
 [0.2.0]: https://github.com/vinilana/invokta/releases/tag/v0.2.0

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,6 +1,6 @@
 # Validation record
 
-- Last reviewed: 2026-08-06
+- Last reviewed: 2026-08-15
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
@@ -9,7 +9,14 @@
   accepted in ADR 0018; GitHub example import for `create-invokta-engine`
   accepted in ADR 0020; the `@invokta/devtools` dev server and doctor accepted
   in ADR 0021; MCP installation inspection and homologation accepted in
-  ADR 0022; ephemeral OAuth for installed MCP inspection accepted in ADR 0023
+  ADR 0022; ephemeral OAuth for installed MCP inspection accepted in ADR 0023;
+  the production MCP OAuth integration boundary accepted in ADR 0024; portable
+  MCP tool names accepted in ADR 0025; generated engine MCP conformance accepted
+  in ADR 0026; Windows installer ownership identity accepted in ADR 0027;
+  devtools adapter emulation accepted in ADR 0028; selectable HTTP
+  authentication accepted in ADR 0029; project entry points accepted in ADR
+  0030; and advertised authorization servers and OAuth discovery inspection
+  accepted in ADR 0031
 
 ## Reuse evidence
 
@@ -31,15 +38,15 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 2,621 tests with one
+- `yarn run check` passes typecheck, lint, formatting, 2,822 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  80.90% statements, 76.22% branches, 83.91% functions, and 82.33% lines.
+  80.78% statements, 75.78% branches, 85.23% functions, and 82.30% lines.
 - `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
   dependency boundaries, all four packed engine profiles, the authenticated MCP
   HTTP exchange, and the remaining creator and installer smoke tests.
 - `yarn validate` in `apps/docs` passes route and link tests, Astro diagnostics,
   and the production site build.
-- `yarn audit` reports zero vulnerabilities across 271 audited packages.
+- `yarn audit` reports zero vulnerabilities across 307 audited packages.
 
 ## Boundaries exercised
 

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -17,9 +17,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -11,8 +11,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -11,8 +11,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -11,8 +11,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -10,8 +10,8 @@
     "direct": "node dist/direct.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.4.0",
-        "@invokta/core": "0.4.0",
-        "@invokta/installer": "0.4.0",
-        "@invokta/mcp": "0.4.0",
+        "@invokta/cli": "0.5.0",
+        "@invokta/core": "0.5.0",
+        "@invokta/installer": "0.5.0",
+        "@invokta/mcp": "0.5.0",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,8 +21,8 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.4.0",
-        "@invokta/devtools": "0.4.0",
+        "@invokta/deploy": "0.5.0",
+        "@invokta/devtools": "0.5.0",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -83,21 +83,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.4.0.tgz",
-      "integrity": "sha512-3sOt+Ly+aODgDpwYVXjm3M0951eh1MzzzfsR/C+O8vUuUdhOab68B6gTNH2HTrPvV1syPa+fBtgbgJ5lVcL6EQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.5.0.tgz",
+      "integrity": "sha512-ZSCYfg1uxbI1k/iZ/8qPS0t1ZA5Lx69TlJaNMxGJNw4DhzxFx2UWaErUnl3lJvAlHQ5jbfl5WO6Sdvq46xpgaw==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.4.0"
+        "@invokta/core": "0.5.0"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-91sEPZKCMBp3x0znxiAyDrh6T8Hrc93TrzWID3nDQVpkx1VxGVona0HhnMy2sTdD2ywKiehiy73tkHhy+9aTsg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-HjaEx6bX5dO3khxwEhdh4TjVQpxmERtAdHqKBZO8HL68e+Iw204YQ3MHkqenl1umKZhzm7TDdHSS9QlsoZOw4Q==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.4.0.tgz",
-      "integrity": "sha512-8jRCunZXEgRQmEjzfZhU3D0bDTfyz7Lp0gkktEmXxAMshC5OrKSXdlitH2C84q55L/0xhjG0/M0zl5/NRkeySQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.5.0.tgz",
+      "integrity": "sha512-RKt//v+Zil5r3yqQ3UHtkYCED5ckBcey1uuC2W80a5JUWOUuu4pvKum4Moxhz7glsMHbT1yh/FM1o2qWQ1S/4Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -120,14 +120,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.4.0.tgz",
-      "integrity": "sha512-zv7qM3As3sA0XQCf005uC7cq7mW3ZYi4m+pynFMTxj53fHipBmSAitL6JCmEHvF9Lz8YFWd8OTEaubWTU6ZFXg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.5.0.tgz",
+      "integrity": "sha512-0Whglgc7v18f5VfEPGRAzOqXJmWznQB8vDVcvv9KGosT9iuAd3QyAPyub9VrZcR2zD2LF6hhYSIw8RQZ4mOVuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.4.0",
-        "@invokta/mcp": "0.4.0"
+        "@invokta/cli": "0.5.0",
+        "@invokta/core": "0.5.0",
+        "@invokta/mcp": "0.5.0"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -137,9 +138,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.4.0.tgz",
-      "integrity": "sha512-9TFv2jmZ/zRpuo+htPgJRXNrHIsONxDsiAor9oTy4LzDGOJ0JmW26N8rhkTJ8P+VVEO9JcGhYxnordv1DOdWBw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.5.0.tgz",
+      "integrity": "sha512-SrYxDRqdzuC/NHIkG3NNxUq3sVxHkxWaAjj+Ajf+Vi74A/UV43HDSy6/2x97o+xrk3jbrnfRjM8/Z9sE9/tS0w==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -155,12 +156,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.4.0.tgz",
-      "integrity": "sha512-EREc6y09qWS6dUMzwAa5omcsZWpsDUaS15csk+BO1/NcskgRKvBus2nUbxv9MLB1zk/It7NaWufN+FaOoVp9/g==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.5.0.tgz",
+      "integrity": "sha512-35aYti0pl1FX/m+p+RRrKSWTtHxZOPCoqp+1cD3ruAHRXmVrfR0JxuXHmQLtoPFfEVHYtf3FCGhm1eUmF+3aDw==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.4.0",
+        "@invokta/core": "0.5.0",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -36,18 +36,18 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/installer": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/installer": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.4.0",
-    "@invokta/devtools": "0.4.0",
+    "@invokta/deploy": "0.5.0",
+    "@invokta/devtools": "0.5.0",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
+    "@invokta/core": "0.5.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -14,14 +14,14 @@
     "check:capabilities": "node ../../packages/tooling/dist/cli.js check-capabilities ./dist/capabilities.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/tooling": "0.4.0",
+    "@invokta/tooling": "0.5.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -16,12 +16,12 @@
     "devtools": "invokta-devtools serve dist/engine.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.4.0"
+    "@invokta/devtools": "0.5.0"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -13,9 +13,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0",
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0"
+    "@invokta/core": "0.5.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Typed capability contracts and execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.4.0",
+    "@invokta/deploy": "0.5.0",
     "tar": "7.5.22"
   }
 }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.4.0",
+      "@invokta/deploy": "0.5.0",
       tar: "7.5.22",
     });
   });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Local MCP workbench, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.4.0",
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0"
+    "@invokta/cli": "0.5.0",
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0"
   }
 }

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.4.0",
+      version: "0.5.0",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
+    "@invokta/core": "0.5.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.4.0";
+const CLIENT_VERSION = "0.5.0";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.4.0",
-    "@invokta/mcp": "0.4.0"
+    "@invokta/core": "0.5.0",
+    "@invokta/mcp": "0.5.0"
   }
 }

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -1079,9 +1079,11 @@ try {
       ...profileCase.dependencies,
       ...profileCase.devDependencies,
     ]);
-    // Devtools loads its public MCP dependency at runtime. Install the matching
-    // local artifact so this pre-release smoke validates one coherent release
-    // set instead of resolving an older published package for focused profiles.
+    // Devtools loads its public adapter dependencies at runtime. Install the
+    // matching local artifacts so this pre-release smoke validates one coherent
+    // release set instead of resolving older published packages for focused
+    // profiles.
+    generatedPackageNames.add("@invokta/cli");
     generatedPackageNames.add("@invokta/mcp");
     const generatedDependencyTarballs = [...generatedPackageNames].map((name) =>
       tarballsByName.get(name),


### PR DESCRIPTION
## Summary

- prepare all Invokta packages and examples for version 0.5.0
- cut the 0.5.0 changelog and refresh the validation record
- keep release verification fully local by including `@invokta/cli` in the devtools dependency closure
- add a repository skill that standardizes future releases on dedicated release branches

## Why

Invokta is ready to stage the 0.5.0 release. The package metadata, changelog, validation evidence, and prerelease smoke tests need to move together so the release can be reviewed as one cohesive change.

The release verifier previously omitted the local CLI tarball from the generated-profile dependency closure, which could make validation attempt to resolve an unpublished 0.5.0 package from npm. This change keeps that verification path local and reproducible.

## Impact

This PR changes release metadata and release tooling only. It does not introduce a new runtime contract. Future releases can follow the checked-in workflow in `.agents/skills/prepare-invokta-release`.

## Validation

- `yarn run check` — 2,822 tests passed, 1 skipped; typecheck, lint, format, build, and coverage gates passed
- `yarn release:verify` — 10 packages and 4 generated profiles passed
- `yarn audit` — 0 vulnerabilities across 307 packages
- `yarn validate` in `apps/docs` — 15 tests passed, 0 Astro diagnostics, 49 pages built
- release skill quick validation passed