### PR TITLE
ci(release): publish packages directly to latest

### DIFF
--- a/.github/workflows/security-and-release.yml
+++ b/.github/workflows/security-and-release.yml
@@ -42,10 +42,66 @@ jobs:
         run: yarn audit
 
       - name: Dry-run public packages
-        run: |
-          for package_directory in ./packages/core ./packages/cli ./packages/mcp ./packages/tooling ./packages/installer ./packages/deploy ./packages/devtools ./packages/create-invokta-engine ./packages/create-invokta-capability ./packages/create-invokta-capability-library; do
-            npm pack --dry-run "$package_directory"
-          done
+        run: yarn release:pack
 
       - name: Verify clean release package contents
         run: yarn release:verify
+
+  publish:
+    name: Publish directly to npm latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm
+    concurrency:
+      group: npm-release
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js and npm registry
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install trusted-publishing npm
+        run: npm install --global npm@11
+
+      - name: Publish packages directly to latest
+        run: yarn release:publish "$GITHUB_REF_NAME"
+
+  release:
+    name: Create GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub Release after npm publication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "GitHub Release $GITHUB_REF_NAME already exists."
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,73 @@
+# Releasing Invokta
+
+Invokta publishes its ten public packages from one protected GitHub Actions
+workflow. Stable versions publish directly to the `latest` dist-tag. The
+versioned scripts under `scripts/release` contain the release rules; the
+workflow supplies the trusted environment and orchestration.
+
+## One-time repository setup
+
+Create a protected GitHub environment named `npm` and configure:
+
+- required reviewer approval before the publish job starts;
+- deployment tag access restricted to `v*`; and
+- no npm token secret.
+
+For every package listed in `scripts/release/package-set.sh`, configure an npm
+trusted publisher with these exact values:
+
+- repository: `vinilana/invokta`;
+- workflow filename: `security-and-release.yml`;
+- environment: `npm`; and
+- allowed action: `npm publish`.
+
+Trusted publishing requires npm 11.5.1 or newer. The workflow installs npm 11
+before publication and grants only `contents: read` and `id-token: write` to the
+publish job. npm uses the short-lived GitHub OIDC identity and generates package
+provenance without an npm token.
+
+## Release flow
+
+1. Prepare and merge the cohesive `chore/release-X.Y.Z` change through the
+   documented release preparation workflow.
+2. On a clean checkout whose `HEAD` matches `origin/main`, run:
+
+   ```bash
+   yarn release:create-tag X.Y.Z
+   ```
+
+3. Confirm the annotated tag. Its push starts `security-and-release.yml`.
+4. Wait for the `Verify` job, then approve the protected `npm` environment.
+5. Confirm that all packages publish and that the final job creates the GitHub
+   Release.
+
+The GitHub Release is created only after every package reports the release
+version as `latest` with a matching `gitHead`.
+
+## Read-only preflight
+
+After checking out an existing release tag, run the complete read-only
+publication preflight with:
+
+```bash
+yarn release:publish --check X.Y.Z
+```
+
+The command validates the annotated local and remote tag, the commit on
+`origin/main`, all package names and versions, registry state, build, and package
+dry-runs. It does not require npm authentication and makes no registry change.
+
+## Recovering a partial release
+
+npm package publication is irreversible and a ten-package release is not an
+atomic registry operation. If a publish job stops after creating a partial
+release, rerun the failed GitHub Actions workflow. The publication script skips
+only a package version whose npm `gitHead` matches the release tag and whose
+`latest` dist-tag already points to that version, then continues in dependency
+order.
+
+The preflight refuses to overwrite an existing version from another commit,
+move `latest` backward, or recover a version that was previously published under
+a different dist-tag. Do not publish or repair a stable release from a local
+workstation; use the protected workflow so the OIDC identity and audit trail are
+preserved.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,8 @@ Create a protected GitHub environment named `npm` and configure:
 - deployment tag access restricted to `v*`; and
 - no npm token secret.
 
-For every package listed in `scripts/release/package-set.sh`, configure an npm
-trusted publisher with these exact values:
+For every package listed in `scripts/release/release-packages.json`, configure
+an npm trusted publisher with these exact values:
 
 - repository: `vinilana/invokta`;
 - workflow filename: `security-and-release.yml`;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "test:coverage": "vitest run --coverage",
     "lint": "biome lint .",
     "format:check": "biome format .",
+    "release:create-tag": "bash scripts/release/create-tag.sh",
+    "release:pack": "bash scripts/release/check-packages.sh",
+    "release:publish": "bash scripts/release/publish-release.sh",
     "release:verify": "node scripts/verify-release-packages.mjs",
     "check": "yarn typecheck && yarn lint && yarn format:check && yarn test:coverage && yarn build"
   },

--- a/scripts/release/check-packages.sh
+++ b/scripts/release/check-packages.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+for command_name in git node npm; do
+  require_command "$command_name"
+done
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(git -C "$script_directory" rev-parse --show-toplevel 2>/dev/null) ||
+  die "The script must remain inside the Invokta repository"
+cd "$repository_root"
+
+# shellcheck source=./package-set.sh
+source "$script_directory/package-set.sh"
+
+root_version=$(node -p "require('./package.json').version")
+
+for entry in "${release_package_entries[@]}"; do
+  IFS='|' read -r package_directory expected_name <<<"$entry"
+  manifest_name=$(node -p "require('./$package_directory/package.json').name")
+  manifest_version=$(node -p "require('./$package_directory/package.json').version")
+  [[ "$manifest_name" == "$expected_name" ]] ||
+    die "$package_directory is named $manifest_name, expected $expected_name"
+  [[ "$manifest_version" == "$root_version" ]] ||
+    die "$manifest_name is version $manifest_version, expected $root_version"
+
+  printf 'Dry run: %s@%s\n' "$manifest_name" "$manifest_version"
+  npm pack --dry-run "./$package_directory" >/dev/null
+done
+
+printf 'Package dry-runs passed for Invokta %s.\n' "$root_version"

--- a/scripts/release/create-tag.sh
+++ b/scripts/release/create-tag.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: yarn release:create-tag VERSION
+
+Create and push the annotated tag that starts the protected release workflow.
+The workflow publishes the packages before it creates the GitHub Release.
+
+Examples:
+  yarn release:create-tag 0.7.0
+  yarn release:create-tag v0.7.0
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+[[ $# -eq 1 ]] || {
+  usage >&2
+  exit 2
+}
+
+case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --*)
+    die "Unknown option: $1"
+    ;;
+esac
+
+version="${1#v}"
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "Version must use stable semantic versioning, for example 0.7.0"
+
+for command_name in git node awk; do
+  require_command "$command_name"
+done
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(git -C "$script_directory" rev-parse --show-toplevel 2>/dev/null) ||
+  die "The script must remain inside the Invokta repository"
+cd "$repository_root"
+
+tag="v$version"
+
+log "Checking release state"
+git fetch --quiet origin --prune --tags
+
+[[ -z "$(git status --porcelain --untracked-files=normal)" ]] ||
+  die "The working tree must be clean"
+
+head_commit=$(git rev-parse HEAD)
+main_commit=$(git rev-parse refs/remotes/origin/main 2>/dev/null) ||
+  die "origin/main is not available"
+[[ "$head_commit" == "$main_commit" ]] ||
+  die "HEAD must match origin/main ($main_commit)"
+
+root_version=$(node -p "require('./package.json').version")
+[[ "$root_version" == "$version" ]] ||
+  die "Root package version is $root_version, expected $version"
+
+local_tag_type=$(git cat-file -t "$tag" 2>/dev/null || true)
+if [[ -n "$local_tag_type" && "$local_tag_type" != "tag" ]]; then
+  die "$tag exists but is not an annotated tag"
+fi
+
+if [[ "$local_tag_type" == "tag" ]]; then
+  local_tag_commit=$(git rev-parse "$tag^{commit}")
+  [[ "$local_tag_commit" == "$head_commit" ]] ||
+    die "$tag points to $local_tag_commit, expected $head_commit"
+fi
+
+remote_tag_object=$(
+  git ls-remote --tags origin "refs/tags/$tag" |
+    awk -F '\t' 'NR == 1 { print $1 }'
+)
+remote_tag_commit=$(
+  git ls-remote --tags origin "refs/tags/$tag^{}" |
+    awk -F '\t' 'NR == 1 { print $1 }'
+)
+
+if [[ -n "$remote_tag_object" ]]; then
+  [[ -n "$remote_tag_commit" ]] ||
+    die "origin/$tag exists but is not an annotated tag"
+  [[ "$remote_tag_commit" == "$head_commit" ]] ||
+    die "origin/$tag points to $remote_tag_commit, expected $head_commit"
+
+  local_tag_object=$(git rev-parse "$tag")
+  [[ "$local_tag_object" == "$remote_tag_object" ]] ||
+    die "Local and remote $tag tag objects do not match"
+
+  printf '%s already exists on origin at %s.\n' "$tag" "$head_commit"
+  printf 'Rerun its GitHub Actions workflow if publication needs to resume.\n'
+  exit 0
+fi
+
+printf '\nThis will push annotated tag %s from commit %s.\n' "$tag" "$head_commit"
+read -r -p "Type $tag to continue: " confirmation
+[[ "$confirmation" == "$tag" ]] || die "Tag creation cancelled"
+
+if [[ -z "$local_tag_type" ]]; then
+  log "Creating annotated tag $tag"
+  git tag -a "$tag" "$head_commit" -m "Invokta $version"
+fi
+
+log "Pushing annotated tag $tag"
+git push --quiet origin "refs/tags/$tag:refs/tags/$tag"
+
+remote_tag_commit=$(
+  git ls-remote --tags origin "refs/tags/$tag^{}" |
+    awk -F '\t' 'NR == 1 { print $1 }'
+)
+[[ "$remote_tag_commit" == "$head_commit" ]] ||
+  die "The pushed $tag does not resolve to $head_commit on origin"
+
+printf '\nPushed %s. The protected release workflow will publish it.\n' "$tag"

--- a/scripts/release/package-set.sh
+++ b/scripts/release/package-set.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
 
-# The order preserves exact internal dependency availability during publication.
-release_package_entries=(
-  "packages/core|@invokta/core"
-  "packages/cli|@invokta/cli"
-  "packages/mcp|@invokta/mcp"
-  "packages/tooling|@invokta/tooling"
-  "packages/installer|@invokta/installer"
-  "packages/deploy|@invokta/deploy"
-  "packages/devtools|@invokta/devtools"
-  "packages/create-invokta-engine|create-invokta-engine"
-  "packages/create-invokta-capability|create-invokta-capability"
-  "packages/create-invokta-capability-library|create-invokta-capability-library"
+# The manifest order preserves internal dependency availability during publish.
+release_manifest_directory=$(
+  CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
 )
+if ! release_package_output=$(
+  node "$release_manifest_directory/release-packages.mjs" shell-entries
+); then
+  printf 'Error: Could not load the release package manifest\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+release_package_entries=()
+while IFS= read -r release_package_entry; do
+  [[ -n "$release_package_entry" ]] &&
+    release_package_entries+=("$release_package_entry")
+done <<<"$release_package_output"
+
+if ((${#release_package_entries[@]} == 0)); then
+  printf 'Error: The release package manifest is empty\n' >&2
+  return 1 2>/dev/null || exit 1
+fi
 
 readonly -a release_package_entries
+unset release_manifest_directory release_package_entry release_package_output

--- a/scripts/release/package-set.sh
+++ b/scripts/release/package-set.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# The order preserves exact internal dependency availability during publication.
+release_package_entries=(
+  "packages/core|@invokta/core"
+  "packages/cli|@invokta/cli"
+  "packages/mcp|@invokta/mcp"
+  "packages/tooling|@invokta/tooling"
+  "packages/installer|@invokta/installer"
+  "packages/deploy|@invokta/deploy"
+  "packages/devtools|@invokta/devtools"
+  "packages/create-invokta-engine|create-invokta-engine"
+  "packages/create-invokta-capability|create-invokta-capability"
+  "packages/create-invokta-capability-library|create-invokta-capability-library"
+)
+
+readonly -a release_package_entries

--- a/scripts/release/publish-release.sh
+++ b/scripts/release/publish-release.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: yarn release:publish [--check] VERSION
+
+Publish every Invokta package from an existing stable release tag directly to
+the npm latest dist-tag. Publication requires GitHub Actions OIDC. The command
+is state-aware and safely skips package versions already published from the
+same release commit.
+
+Options:
+  --check   Run all read-only checks, build, and package dry-runs.
+  -h, --help
+            Show this help.
+
+Examples:
+  yarn release:publish --check 0.7.0
+  yarn release:publish 0.7.0
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+require_trusted_publishing_npm() {
+  local npm_version major minor patch
+  npm_version=$(npm --version)
+  IFS='.' read -r major minor patch <<<"$npm_version"
+  patch="${patch%%-*}"
+
+  [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]] ||
+    die "Could not parse npm version $npm_version"
+  if ((major < 11 || (major == 11 && minor < 5) || (major == 11 && minor == 5 && patch < 1))); then
+    die "npm $npm_version does not support trusted publishing; npm 11.5.1 or newer is required"
+  fi
+}
+
+is_newer_stable_version() {
+  node - "$1" "$2" <<'NODE'
+const [candidate, target] = process.argv.slice(2);
+const parse = (value) => {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  if (match === null) process.exit(2);
+  return match.slice(1).map(Number);
+};
+const left = parse(candidate);
+const right = parse(target);
+for (let index = 0; index < left.length; index += 1) {
+  if (left[index] > right[index]) process.exit(0);
+  if (left[index] < right[index]) process.exit(1);
+}
+process.exit(1);
+NODE
+}
+
+wait_for_registry_field() {
+  local package_spec="$1"
+  local field="$2"
+  local expected="$3"
+  local actual=""
+
+  for attempt in {1..12}; do
+    if actual=$(npm view "$package_spec" "$field" 2>/dev/null) && [[ "$actual" == "$expected" ]]; then
+      return 0
+    fi
+    if ((attempt < 12)); then
+      sleep 5
+    fi
+  done
+
+  die "$package_spec $field is ${actual:-unavailable}, expected $expected"
+}
+
+check_only=false
+version=""
+
+while (($# > 0)); do
+  case "$1" in
+    --check)
+      check_only=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --*)
+      die "Unknown option: $1"
+      ;;
+    *)
+      [[ -z "$version" ]] || die "Only one version may be supplied"
+      version="${1#v}"
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$version" ]] || {
+  usage >&2
+  exit 2
+}
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "Version must use stable semantic versioning, for example 0.7.0"
+
+for command_name in git npm yarn node awk; do
+  require_command "$command_name"
+done
+
+script_directory=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(git -C "$script_directory" rev-parse --show-toplevel 2>/dev/null) ||
+  die "The script must remain inside the Invokta repository"
+cd "$repository_root"
+
+# shellcheck source=./package-set.sh
+source "$script_directory/package-set.sh"
+
+tag="v$version"
+
+log "Checking Git release state"
+git fetch --quiet origin --prune --tags
+
+[[ -z "$(git status --porcelain --untracked-files=normal)" ]] ||
+  die "The working tree must be clean"
+[[ "$(git cat-file -t "$tag" 2>/dev/null || true)" == "tag" ]] ||
+  die "$tag must exist as an annotated tag"
+
+tag_commit=$(git rev-list -n 1 "$tag")
+head_commit=$(git rev-parse HEAD)
+[[ "$head_commit" == "$tag_commit" ]] ||
+  die "HEAD must point to $tag ($tag_commit)"
+git merge-base --is-ancestor "$tag_commit" origin/main ||
+  die "$tag is not contained in origin/main"
+
+remote_tag_object=$(
+  git ls-remote --tags origin "refs/tags/$tag" |
+    awk -F '\t' 'NR == 1 { print $1 }'
+)
+remote_tag_commit=$(
+  git ls-remote --tags origin "refs/tags/$tag^{}" |
+    awk -F '\t' 'NR == 1 { print $1 }'
+)
+[[ -n "$remote_tag_object" && -n "$remote_tag_commit" ]] ||
+  die "The remote $tag must be an annotated tag"
+[[ "$remote_tag_commit" == "$tag_commit" ]] ||
+  die "The remote $tag resolves to $remote_tag_commit, expected $tag_commit"
+
+root_version=$(node -p "require('./package.json').version")
+[[ "$root_version" == "$version" ]] ||
+  die "Root package version is $root_version, expected $version"
+
+for entry in "${release_package_entries[@]}"; do
+  IFS='|' read -r package_directory expected_name <<<"$entry"
+  manifest_name=$(node -p "require('./$package_directory/package.json').name")
+  manifest_version=$(node -p "require('./$package_directory/package.json').version")
+  [[ "$manifest_name" == "$expected_name" ]] ||
+    die "$package_directory is named $manifest_name, expected $expected_name"
+  [[ "$manifest_version" == "$version" ]] ||
+    die "$manifest_name is version $manifest_version, expected $version"
+done
+
+log "Checking npm registry"
+registry=$(npm config get registry)
+[[ "$registry" == "https://registry.npmjs.org/" ]] ||
+  die "npm registry is $registry, expected https://registry.npmjs.org/"
+npm ping >/dev/null
+
+pending_entries=()
+published_entries=()
+
+for entry in "${release_package_entries[@]}"; do
+  IFS='|' read -r package_directory package_name <<<"$entry"
+  latest_version=$(npm view "$package_name" dist-tags.latest 2>/dev/null) ||
+    die "$package_name has no readable latest dist-tag"
+  [[ "$latest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    die "$package_name latest is not a stable semantic version: $latest_version"
+  if is_newer_stable_version "$latest_version" "$version"; then
+    die "$package_name latest is $latest_version, which is newer than $version"
+  fi
+
+  if registry_output=$(npm view "$package_name@$version" version 2>&1); then
+    registry_git_head=$(npm view "$package_name@$version" gitHead)
+    [[ "$registry_git_head" == "$tag_commit" ]] ||
+      die "$package_name@$version already exists with gitHead $registry_git_head"
+    [[ "$latest_version" == "$version" ]] ||
+      die "$package_name@$version exists but latest is $latest_version; trusted publishing cannot change dist-tags"
+    printf 'Present: %s@%s (matching gitHead)\n' "$package_name" "$version"
+    published_entries+=("$entry")
+  elif [[ "$registry_output" == *"E404"* ]]; then
+    printf 'Pending: %s@%s; current latest=%s\n' "$package_name" "$version" "$latest_version"
+    pending_entries+=("$entry")
+  else
+    printf '%s\n' "$registry_output" >&2
+    die "Could not determine whether $package_name@$version exists"
+  fi
+done
+
+log "Building the tagged source"
+yarn install --frozen-lockfile --non-interactive
+yarn build
+
+log "Checking package contents"
+bash "$script_directory/check-packages.sh"
+
+if [[ "$check_only" == true ]]; then
+  printf '\nPreflight passed for %s. No registry changes were made.\n' "$tag"
+  printf 'Pending packages: %d; already published from this tag: %d.\n' \
+    "${#pending_entries[@]}" "${#published_entries[@]}"
+  exit 0
+fi
+
+[[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]] ||
+  die "GitHub Actions OIDC is unavailable: ACTIONS_ID_TOKEN_REQUEST_URL is missing"
+[[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] ||
+  die "GitHub Actions OIDC is unavailable: ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing"
+require_trusted_publishing_npm
+
+for entry in "${pending_entries[@]}"; do
+  IFS='|' read -r package_directory package_name <<<"$entry"
+  log "Publishing $package_name@$version directly to latest"
+  npm publish "./$package_directory" --access public --tag latest
+  wait_for_registry_field "$package_name@$version" version "$version"
+  wait_for_registry_field "$package_name@$version" gitHead "$tag_commit"
+done
+
+log "Verifying latest dist-tags"
+for entry in "${release_package_entries[@]}"; do
+  IFS='|' read -r _ package_name <<<"$entry"
+  wait_for_registry_field "$package_name" dist-tags.latest "$version"
+  printf '%s latest -> %s\n' "$package_name" "$version"
+done
+
+printf '\nPublished %s directly to latest successfully.\n' "$tag"

--- a/scripts/release/release-automation.test.ts
+++ b/scripts/release/release-automation.test.ts
@@ -24,7 +24,14 @@ function read(relativePath: string): string {
 }
 
 describe("release automation", () => {
-  it("keeps the ordered public package set in one versioned source", () => {
+  it("keeps publisher and verifier metadata in one machine-readable source", () => {
+    const manifest = JSON.parse(
+      read("scripts/release/release-packages.json"),
+    ) as Array<{
+      directory: string;
+      name: string;
+      requiredFiles: string[];
+    }>;
     const output = execFileSync(
       "bash",
       [
@@ -34,6 +41,12 @@ describe("release automation", () => {
       { cwd: repositoryRoot, encoding: "utf8" },
     );
 
+    expect(
+      manifest.map(({ directory, name }) => `packages/${directory}|${name}`),
+    ).toEqual(expectedPackages);
+    expect(
+      manifest.every(({ requiredFiles }) => requiredFiles.length > 0),
+    ).toBe(true);
     expect(output.trim().split("\n")).toEqual(expectedPackages);
 
     for (const entry of expectedPackages) {
@@ -43,6 +56,12 @@ describe("release automation", () => {
       };
       expect(manifest.name).toBe(expectedName);
     }
+
+    const verifier = read("scripts/verify-release-packages.mjs");
+    expect(verifier).toContain(
+      'import { releasePackages as publicPackages } from "./release/release-packages.mjs";',
+    );
+    expect(verifier).not.toContain("const publicPackages = [");
   });
 
   it("publishes stable packages directly to latest through OIDC and supports reruns", () => {

--- a/scripts/release/release-automation.test.ts
+++ b/scripts/release/release-automation.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+const expectedPackages = [
+  "packages/core|@invokta/core",
+  "packages/cli|@invokta/cli",
+  "packages/mcp|@invokta/mcp",
+  "packages/tooling|@invokta/tooling",
+  "packages/installer|@invokta/installer",
+  "packages/deploy|@invokta/deploy",
+  "packages/devtools|@invokta/devtools",
+  "packages/create-invokta-engine|create-invokta-engine",
+  "packages/create-invokta-capability|create-invokta-capability",
+  "packages/create-invokta-capability-library|create-invokta-capability-library",
+] as const;
+
+function read(relativePath: string): string {
+  return readFileSync(`${repositoryRoot}/${relativePath}`, "utf8");
+}
+
+describe("release automation", () => {
+  it("keeps the ordered public package set in one versioned source", () => {
+    const output = execFileSync(
+      "bash",
+      [
+        "-c",
+        `source scripts/release/package-set.sh; printf "%s\\n" "\${release_package_entries[@]}"`,
+      ],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    );
+
+    expect(output.trim().split("\n")).toEqual(expectedPackages);
+
+    for (const entry of expectedPackages) {
+      const [directory, expectedName] = entry.split("|");
+      const manifest = JSON.parse(read(`${directory}/package.json`)) as {
+        name: string;
+      };
+      expect(manifest.name).toBe(expectedName);
+    }
+  });
+
+  it("publishes stable packages directly to latest through OIDC and supports reruns", () => {
+    const script = read("scripts/release/publish-release.sh");
+
+    expect(script).toContain('source "$script_directory/package-set.sh"');
+    expect(script).toContain("ACTIONS_ID_TOKEN_REQUEST_URL");
+    expect(script).toContain("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+    expect(script).toContain(
+      'npm publish "./$package_directory" --access public --tag latest',
+    );
+    expect(script).toContain("Present: %s@%s (matching gitHead)");
+    expect(script).not.toContain("npm dist-tag");
+    expect(script).not.toContain("--otp");
+    expect(script).not.toContain("npm whoami");
+    expect(script).not.toContain("read -r -p");
+  });
+
+  it("runs direct publication behind the protected npm environment after verification", () => {
+    const workflow = read(".github/workflows/security-and-release.yml");
+
+    expect(workflow).toContain("publish:\n");
+    expect(workflow).toContain("if: startsWith(github.ref, 'refs/tags/v')");
+    expect(workflow).toContain("needs: verify");
+    expect(workflow).toContain("environment: npm");
+    expect(workflow).toContain("id-token: write");
+    expect(workflow).toContain("registry-url: https://registry.npmjs.org");
+    expect(workflow).toContain("npm install --global npm@11");
+    expect(workflow).toContain('yarn release:publish "$GITHUB_REF_NAME"');
+    expect(workflow).toContain("release:\n");
+    expect(workflow).toContain('gh release create "$GITHUB_REF_NAME"');
+    expect(workflow.indexOf("release:\n")).toBeGreaterThan(
+      workflow.indexOf("publish:\n"),
+    );
+  });
+
+  it("keeps tag creation operator-driven and defers the GitHub Release", () => {
+    const script = read("scripts/release/create-tag.sh");
+    const manifest = JSON.parse(read("package.json")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(script).toContain('git tag -a "$tag"');
+    expect(script).toContain(
+      'git push --quiet origin "refs/tags/$tag:refs/tags/$tag"',
+    );
+    expect(script).not.toContain("gh release");
+    expect(manifest.scripts["release:create-tag"]).toBe(
+      "bash scripts/release/create-tag.sh",
+    );
+    expect(manifest.scripts["release:pack"]).toBe(
+      "bash scripts/release/check-packages.sh",
+    );
+    expect(manifest.scripts["release:publish"]).toBe(
+      "bash scripts/release/publish-release.sh",
+    );
+  });
+
+  it("documents trusted publishing setup and partial-release recovery", () => {
+    const runbook = read("RELEASING.md");
+
+    expect(runbook).toContain("security-and-release.yml");
+    expect(runbook).toContain("GitHub environment named `npm`");
+    expect(runbook).toContain("trusted publisher");
+    expect(runbook).toContain("directly to the `latest` dist-tag");
+    expect(runbook).toContain("partial release");
+  });
+});

--- a/scripts/release/release-packages.json
+++ b/scripts/release/release-packages.json
@@ -1,0 +1,69 @@
+[
+  {
+    "directory": "core",
+    "name": "@invokta/core",
+    "requiredFiles": ["dist/index.js", "dist/index.d.ts"]
+  },
+  {
+    "directory": "cli",
+    "name": "@invokta/cli",
+    "requiredFiles": ["dist/index.js", "dist/index.d.ts"]
+  },
+  {
+    "directory": "mcp",
+    "name": "@invokta/mcp",
+    "requiredFiles": ["dist/index.js", "dist/index.d.ts"]
+  },
+  {
+    "directory": "tooling",
+    "name": "@invokta/tooling",
+    "requiredFiles": ["dist/index.js", "dist/index.d.ts", "dist/cli.js"]
+  },
+  {
+    "directory": "installer",
+    "name": "@invokta/installer",
+    "requiredFiles": [
+      "dist/cli.js",
+      "dist/engine-cli.js",
+      "dist/engine-cli.d.ts",
+      "registry/capabilities.json",
+      "registry/README.md"
+    ]
+  },
+  {
+    "directory": "deploy",
+    "name": "@invokta/deploy",
+    "requiredFiles": [
+      "dist/index.js",
+      "dist/index.d.ts",
+      "dist/bin.js",
+      "dist/scaffold-public.js",
+      "dist/scaffold-public.d.ts"
+    ]
+  },
+  {
+    "directory": "devtools",
+    "name": "@invokta/devtools",
+    "requiredFiles": [
+      "dist/index.js",
+      "dist/index.d.ts",
+      "dist/cli.js",
+      "dist/ui/app.js"
+    ]
+  },
+  {
+    "directory": "create-invokta-engine",
+    "name": "create-invokta-engine",
+    "requiredFiles": ["dist/bin.js"]
+  },
+  {
+    "directory": "create-invokta-capability",
+    "name": "create-invokta-capability",
+    "requiredFiles": ["dist/bin.js"]
+  },
+  {
+    "directory": "create-invokta-capability-library",
+    "name": "create-invokta-capability-library",
+    "requiredFiles": ["dist/bin.js"]
+  }
+]

--- a/scripts/release/release-packages.mjs
+++ b/scripts/release/release-packages.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const modulePath = fileURLToPath(import.meta.url);
+const manifestPath = fileURLToPath(
+  new URL("./release-packages.json", import.meta.url),
+);
+
+function fail(message) {
+  throw new Error(`Invalid release package manifest: ${message}`);
+}
+
+function validateRelativePath(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.startsWith("/") ||
+    value.split("/").includes("..")
+  ) {
+    fail(`${label} must be a non-empty repository-relative path`);
+  }
+  return value;
+}
+
+const parsedManifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+if (!Array.isArray(parsedManifest) || parsedManifest.length === 0) {
+  fail("the root must be a non-empty array");
+}
+
+const seenDirectories = new Set();
+const seenNames = new Set();
+export const releasePackages = Object.freeze(
+  parsedManifest.map((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      fail(`entry ${index} must be an object`);
+    }
+    const directory = validateRelativePath(
+      entry.directory,
+      `entry ${index} directory`,
+    );
+    if (directory.includes("/")) {
+      fail(`entry ${index} directory must be relative to packages`);
+    }
+    if (typeof entry.name !== "string" || entry.name.length === 0) {
+      fail(`entry ${index} name must be a non-empty string`);
+    }
+    if (seenDirectories.has(directory)) {
+      fail(`duplicate directory ${directory}`);
+    }
+    if (seenNames.has(entry.name)) {
+      fail(`duplicate package name ${entry.name}`);
+    }
+    if (
+      !Array.isArray(entry.requiredFiles) ||
+      entry.requiredFiles.length === 0
+    ) {
+      fail(`${entry.name} must declare requiredFiles`);
+    }
+    const requiredFiles = entry.requiredFiles.map((file, fileIndex) =>
+      validateRelativePath(file, `${entry.name} requiredFiles[${fileIndex}]`),
+    );
+    if (new Set(requiredFiles).size !== requiredFiles.length) {
+      fail(`${entry.name} contains duplicate requiredFiles`);
+    }
+    seenDirectories.add(directory);
+    seenNames.add(entry.name);
+    return Object.freeze({
+      directory,
+      name: entry.name,
+      requiredFiles: Object.freeze(requiredFiles),
+    });
+  }),
+);
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === modulePath) {
+  if (process.argv.length !== 3 || process.argv[2] !== "shell-entries") {
+    process.stderr.write(
+      "Usage: node scripts/release/release-packages.mjs shell-entries\n",
+    );
+    process.exitCode = 2;
+  } else {
+    for (const entry of releasePackages) {
+      process.stdout.write(`packages/${entry.directory}|${entry.name}\n`);
+    }
+  }
+}

--- a/scripts/release/release-scripts.integration.test.ts
+++ b/scripts/release/release-scripts.integration.test.ts
@@ -1,0 +1,390 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+const temporaryRoots: string[] = [];
+const releaseVersion = "1.2.3";
+const releaseTag = `v${releaseVersion}`;
+const releaseCommit = "1111111111111111111111111111111111111111";
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryRoots.push(directory);
+  return directory;
+}
+
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+function copyReleaseScript(repository: string, name: string): void {
+  copyFileSync(
+    join(repositoryRoot, "scripts", "release", name),
+    join(repository, "scripts", "release", name),
+  );
+}
+
+type PublishFixtureOptions = {
+  gitHead?: string;
+  latest: string;
+  oidc?: boolean;
+  targetState: "pending" | "present";
+};
+
+function runPublishFixture(options: PublishFixtureOptions) {
+  const root = temporaryDirectory("invokta-publish-script-");
+  const binDirectory = join(root, "bin");
+  const releaseDirectory = join(root, "scripts", "release");
+  const packageDirectory = join(root, "packages", "fixture");
+  mkdirSync(binDirectory, { recursive: true });
+  mkdirSync(releaseDirectory, { recursive: true });
+  mkdirSync(packageDirectory, { recursive: true });
+
+  for (const script of [
+    "check-packages.sh",
+    "package-set.sh",
+    "publish-release.sh",
+    "release-packages.json",
+    "release-packages.mjs",
+  ]) {
+    copyReleaseScript(root, script);
+  }
+
+  writeFileSync(
+    join(root, "package.json"),
+    `${JSON.stringify({ version: releaseVersion })}\n`,
+  );
+  writeFileSync(
+    join(packageDirectory, "package.json"),
+    `${JSON.stringify({ name: "@invokta/fixture", version: releaseVersion })}\n`,
+  );
+  writeFileSync(
+    join(releaseDirectory, "release-packages.json"),
+    `${JSON.stringify([
+      {
+        directory: "fixture",
+        name: "@invokta/fixture",
+        requiredFiles: ["dist/index.js"],
+      },
+    ])}\n`,
+  );
+
+  writeExecutable(
+    join(binDirectory, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "-C" ]]; then
+  printf '%s\n' "$STUB_REPOSITORY_ROOT"
+  exit 0
+fi
+case "\${1:-}" in
+  fetch)
+    ;;
+  status)
+    printf '%s' "\${STUB_GIT_STATUS:-}"
+    ;;
+  cat-file)
+    printf 'tag\n'
+    ;;
+  rev-list)
+    printf '%s\n' "$STUB_COMMIT"
+    ;;
+  rev-parse)
+    printf '%s\n' "$STUB_COMMIT"
+    ;;
+  merge-base)
+    ;;
+  ls-remote)
+    if [[ "$4" == *'^{}' ]]; then
+      printf '%s\\t%s\n' "$STUB_COMMIT" "$4"
+    else
+      printf '%s\\t%s\n' "$STUB_TAG_OBJECT" "$4"
+    fi
+    ;;
+  *)
+    printf 'Unexpected git invocation: %s\n' "$*" >&2
+    exit 70
+    ;;
+esac
+`,
+  );
+  writeExecutable(
+    join(binDirectory, "npm"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-}" in
+  --version)
+    printf '11.5.1\n'
+    ;;
+  config)
+    printf 'https://registry.npmjs.org/\n'
+    ;;
+  ping|pack)
+    ;;
+  publish)
+    printf '%s\n' "$*" >> "$STUB_PUBLISH_LOG"
+    : > "$STUB_PUBLISHED_MARKER"
+    ;;
+  view)
+    package_spec="$2"
+    field="$3"
+    if [[ "$package_spec" == "$STUB_PACKAGE_NAME" && "$field" == "dist-tags.latest" ]]; then
+      if [[ -f "$STUB_PUBLISHED_MARKER" ]]; then
+        printf '%s\n' "$STUB_VERSION"
+      else
+        printf '%s\n' "$STUB_LATEST"
+      fi
+    elif [[ "$package_spec" == "$STUB_PACKAGE_NAME@$STUB_VERSION" ]]; then
+      if [[ "$STUB_TARGET_STATE" == "pending" && ! -f "$STUB_PUBLISHED_MARKER" ]]; then
+        printf 'npm error code E404\n' >&2
+        exit 1
+      fi
+      if [[ "$field" == "version" ]]; then
+        printf '%s\n' "$STUB_VERSION"
+      elif [[ -f "$STUB_PUBLISHED_MARKER" ]]; then
+        printf '%s\n' "$STUB_COMMIT"
+      else
+        printf '%s\n' "$STUB_GIT_HEAD"
+      fi
+    else
+      printf 'Unexpected npm view: %s %s\n' "$package_spec" "$field" >&2
+      exit 71
+    fi
+    ;;
+  *)
+    printf 'Unexpected npm invocation: %s\n' "$*" >&2
+    exit 72
+    ;;
+esac
+`,
+  );
+  writeExecutable(
+    join(binDirectory, "yarn"),
+    "#!/usr/bin/env bash\nset -euo pipefail\n",
+  );
+
+  const publishLog = join(root, "publish.log");
+  const publishedMarker = join(root, "published");
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+    STUB_COMMIT: releaseCommit,
+    STUB_GIT_HEAD: options.gitHead ?? releaseCommit,
+    STUB_LATEST: options.latest,
+    STUB_PACKAGE_NAME: "@invokta/fixture",
+    STUB_PUBLISHED_MARKER: publishedMarker,
+    STUB_PUBLISH_LOG: publishLog,
+    STUB_REPOSITORY_ROOT: root,
+    STUB_TAG_OBJECT: "2222222222222222222222222222222222222222",
+    STUB_TARGET_STATE: options.targetState,
+    STUB_VERSION: releaseVersion,
+  };
+  if (options.oidc !== false) {
+    environment.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "test-token";
+    environment.ACTIONS_ID_TOKEN_REQUEST_URL = "https://oidc.invalid/token";
+  } else {
+    delete environment.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+    delete environment.ACTIONS_ID_TOKEN_REQUEST_URL;
+  }
+
+  const result = spawnSync(
+    "bash",
+    [join(releaseDirectory, "publish-release.sh"), releaseVersion],
+    { cwd: root, encoding: "utf8", env: environment },
+  );
+
+  return {
+    publishLog: existsSync(publishLog) ? readFileSync(publishLog, "utf8") : "",
+    result,
+  };
+}
+
+function createTagFixture() {
+  const root = temporaryDirectory("invokta-create-tag-");
+  const remote = join(root, "remote.git");
+  const repository = join(root, "repository");
+  execFileSync("git", ["init", "--bare", "--initial-branch=main", remote]);
+  execFileSync("git", ["init", "--initial-branch=main", repository]);
+  execFileSync("git", ["config", "user.name", "Release Test"], {
+    cwd: repository,
+  });
+  execFileSync("git", ["config", "user.email", "release@example.invalid"], {
+    cwd: repository,
+  });
+  mkdirSync(join(repository, "scripts", "release"), { recursive: true });
+  copyReleaseScript(repository, "create-tag.sh");
+  writeFileSync(
+    join(repository, "package.json"),
+    `${JSON.stringify({ version: releaseVersion })}\n`,
+  );
+  execFileSync("git", ["add", "."], { cwd: repository });
+  execFileSync("git", ["commit", "-m", "release fixture"], {
+    cwd: repository,
+  });
+  execFileSync("git", ["remote", "add", "origin", remote], {
+    cwd: repository,
+  });
+  execFileSync("git", ["push", "-u", "origin", "main"], {
+    cwd: repository,
+  });
+
+  return {
+    remote,
+    repository,
+    run: (input?: string) =>
+      spawnSync(
+        "bash",
+        [
+          join(repository, "scripts", "release", "create-tag.sh"),
+          releaseVersion,
+        ],
+        { cwd: repository, encoding: "utf8", input },
+      ),
+  };
+}
+
+describe("publish-release.sh", () => {
+  it("publishes a pending package directly to latest", () => {
+    const { publishLog, result } = runPublishFixture({
+      latest: "1.2.2",
+      targetState: "pending",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Pending: @invokta/fixture@1.2.3");
+    expect(publishLog).toContain(
+      "publish ./packages/fixture --access public --tag latest",
+    );
+  });
+
+  it("skips an already published package from the release commit", () => {
+    const { publishLog, result } = runPublishFixture({
+      latest: releaseVersion,
+      targetState: "present",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "Present: @invokta/fixture@1.2.3 (matching gitHead)",
+    );
+    expect(publishLog).toBe("");
+  });
+
+  it("refuses an existing package version from another commit", () => {
+    const { publishLog, result } = runPublishFixture({
+      gitHead: "3333333333333333333333333333333333333333",
+      latest: releaseVersion,
+      targetState: "present",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("already exists with gitHead");
+    expect(publishLog).toBe("");
+  });
+
+  it("refuses to move latest backward", () => {
+    const { publishLog, result } = runPublishFixture({
+      latest: "2.0.0",
+      targetState: "pending",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("newer than 1.2.3");
+    expect(publishLog).toBe("");
+  });
+
+  it("refuses publication when GitHub Actions OIDC is missing", () => {
+    const { publishLog, result } = runPublishFixture({
+      latest: "1.2.2",
+      oidc: false,
+      targetState: "pending",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("GitHub Actions OIDC is unavailable");
+    expect(publishLog).toBe("");
+  });
+});
+
+describe("create-tag.sh", () => {
+  it("refuses a dirty checkout", () => {
+    const fixture = createTagFixture();
+    writeFileSync(join(fixture.repository, "untracked.txt"), "dirty\n");
+
+    const result = fixture.run();
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("working tree must be clean");
+  });
+
+  it("refuses a commit other than origin/main", () => {
+    const fixture = createTagFixture();
+    writeFileSync(join(fixture.repository, "change.txt"), "change\n");
+    execFileSync("git", ["add", "change.txt"], { cwd: fixture.repository });
+    execFileSync("git", ["commit", "-m", "diverge from main"], {
+      cwd: fixture.repository,
+    });
+
+    const result = fixture.run();
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("HEAD must match origin/main");
+  });
+
+  it("accepts an existing matching annotated local and remote tag", () => {
+    const fixture = createTagFixture();
+    execFileSync("git", ["tag", "-a", releaseTag, "-m", "release fixture"], {
+      cwd: fixture.repository,
+    });
+    execFileSync("git", ["push", "origin", releaseTag], {
+      cwd: fixture.repository,
+    });
+
+    const result = fixture.run();
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`${releaseTag} already exists on origin`);
+  });
+
+  it("does not create or push a tag after rejected confirmation", () => {
+    const fixture = createTagFixture();
+
+    const result = fixture.run("cancel\n");
+    const remoteTags = execFileSync(
+      "git",
+      ["ls-remote", "--tags", fixture.remote, `refs/tags/${releaseTag}`],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Tag creation cancelled");
+    expect(remoteTags).toBe("");
+    expect(() =>
+      execFileSync("git", ["rev-parse", "--verify", releaseTag], {
+        cwd: fixture.repository,
+        stdio: "ignore",
+      }),
+    ).toThrow();
+  });
+});

--- a/scripts/verify-release-packages.mjs
+++ b/scripts/verify-release-packages.mjs
@@ -16,6 +16,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { releasePackages as publicPackages } from "./release/release-packages.mjs";
+
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const temporaryRoot = mkdtempSync(join(tmpdir(), "invokta-release-verify-"));
 const checkoutDirectory = join(temporaryRoot, "checkout");
@@ -25,70 +27,10 @@ const generatedDirectory = join(temporaryRoot, "generated");
 const scriptExecutable = execFileSync("which", ["script"], {
   encoding: "utf8",
 }).trim();
-const distEntryFiles = ["dist/index.js", "dist/index.d.ts"];
 const repositoryUrl = "git+https://github.com/vinilana/invokta.git";
 const issuesUrl = "https://github.com/vinilana/invokta/issues";
 const documentationUrl = "https://docs.invokta.dev";
 const packageAuthor = "Vini Lana <vini@aicoders.academy>";
-const publicPackages = [
-  { directory: "core", name: "@invokta/core", requiredFiles: distEntryFiles },
-  { directory: "cli", name: "@invokta/cli", requiredFiles: distEntryFiles },
-  { directory: "mcp", name: "@invokta/mcp", requiredFiles: distEntryFiles },
-  {
-    directory: "tooling",
-    name: "@invokta/tooling",
-    // The dev-only package also ships the `invokta` executable.
-    requiredFiles: [...distEntryFiles, "dist/cli.js"],
-  },
-  {
-    directory: "devtools",
-    name: "@invokta/devtools",
-    // The dev-only package ships the executable and the interface bundle.
-    requiredFiles: [...distEntryFiles, "dist/cli.js", "dist/ui/app.js"],
-  },
-  {
-    directory: "installer",
-    name: "@invokta/installer",
-    // The installer is binary-first; its only import API is the engine subpath.
-    requiredFiles: [
-      "dist/cli.js",
-      "dist/engine-cli.js",
-      "dist/engine-cli.d.ts",
-      "registry/capabilities.json",
-      "registry/README.md",
-    ],
-  },
-  {
-    directory: "deploy",
-    name: "@invokta/deploy",
-    // The toolkit ships both an import API and the `invokta-deploy` executable.
-    requiredFiles: [
-      ...distEntryFiles,
-      "dist/bin.js",
-      "dist/scaffold-public.js",
-      "dist/scaffold-public.d.ts",
-    ],
-  },
-  {
-    directory: "create-invokta-engine",
-    name: "create-invokta-engine",
-    // The creator is binary-only and ships no import API.
-    requiredFiles: ["dist/bin.js"],
-  },
-  {
-    directory: "create-invokta-capability",
-    name: "create-invokta-capability",
-    // The creator is binary-only and ships no import API.
-    requiredFiles: ["dist/bin.js"],
-  },
-  {
-    directory: "create-invokta-capability-library",
-    name: "create-invokta-capability-library",
-    // The creator is binary-only and ships no import API.
-    requiredFiles: ["dist/bin.js"],
-  },
-];
-
 function run(command, args, options = {}) {
   const standardInput = options.input === undefined ? "inherit" : "pipe";
   const result = spawnSync(command, args, {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,6 +5,7 @@
   },
   "include": [
     "vitest.config.ts",
+    "scripts/**/*.test.ts",
     "packages/*/src/**/*.ts",
     "packages/*/test/**/*.ts",
     "examples/*/src/**/*.ts",


### PR DESCRIPTION
## Summary

- move release automation from ignored local scripts into versioned repository scripts
- publish all ten public packages directly to the `latest` dist-tag through npm trusted publishing and GitHub Actions OIDC
- make partial publications safely resumable and create the GitHub Release only after npm publication succeeds
- document the protected release setup and operator workflow

## Why

Release behavior should be versioned, reviewable, and executed by the protected CI/CD pipeline. Publishing directly with the target dist-tag avoids a second privileged dist-tag mutation while preserving an auditable OIDC identity.

## Impact

Release operators create and push an annotated stable tag, wait for verification, and approve the protected `npm` environment. The workflow then publishes packages in dependency order and creates the GitHub Release after all `latest` tags are verified.

Before the first release, maintainers must create the protected GitHub environment named `npm` and configure the npm trusted publisher for each public package as documented in `RELEASING.md`.

## Validation

- `yarn vitest run scripts/release/release-automation.test.ts` — 5 tests passed
- `yarn run check` — typecheck, lint, formatting, 2,922 tests passed, 1 skipped, coverage, and build passed
- `yarn audit` — 0 vulnerabilities
- `yarn release:pack` — dry-run passed for all ten public packages
- `yarn release:verify` — clean tarballs, isolated imports, generated projects, and executable smoke tests passed
