### PR TITLE
fix(create-invokta-engine): fall back to file copy when symlink fails on Windows

### DIFF
--- a/packages/create-invokta-engine/src/scaffold.ts
+++ b/packages/create-invokta-engine/src/scaffold.ts
@@ -390,7 +390,28 @@ export async function writeStarterProject(
           flag: "wx",
         });
       } else {
-        await fileSystem.symlink(entry.target, path);
+        try {
+          await fileSystem.symlink(entry.target, path);
+        } catch (symlinkError) {
+          if (readErrorCode(symlinkError) !== "EPERM") throw symlinkError;
+          // Symlink creation requires elevated privileges on some platforms.
+          // Fall back to a regular file with the target's contents.
+          const linkDir = entry.path.lastIndexOf("/");
+          const resolvedTarget =
+            linkDir === -1
+              ? entry.target
+              : `${entry.path.slice(0, linkDir)}/${entry.target}`;
+          const targetEntry = plan.entries.find(
+            (e) => e.kind === "file" && e.path === resolvedTarget,
+          );
+          if (targetEntry === undefined || targetEntry.kind !== "file") {
+            throw symlinkError;
+          }
+          await fileSystem.writeFile(path, targetEntry.contents, {
+            encoding: "utf8",
+            flag: "wx",
+          });
+        }
       }
       createdEntries.push(path);
     }

--- a/packages/create-invokta-engine/test/scaffold.test.ts
+++ b/packages/create-invokta-engine/test/scaffold.test.ts
@@ -313,6 +313,37 @@ describe("createStarterProject", () => {
     expect(readlinkSync(join(target, "CLAUDE.md"))).toBe("external-agents.md");
   });
 
+  it("falls back to a regular file when symlink creation fails with EPERM", async () => {
+    const cwd = createWorkingDirectory();
+    const target = join(cwd, "my-engine");
+    const fileSystem: ScaffoldFileSystem = {
+      ...defaultScaffoldFileSystem,
+      async symlink() {
+        const error = new Error(
+          "fixture link failure",
+        ) as NodeJS.ErrnoException;
+        error.code = "EPERM";
+        throw error;
+      },
+    };
+
+    const result = await createStarterProject({
+      cwd,
+      target: "my-engine",
+      invoktaVersion: "1.2.3",
+      packageManager: "npm",
+      profile: "complete",
+      fileSystem,
+    });
+
+    expect(result.files).toContain("CLAUDE.md");
+    expect(lstatSync(join(target, "CLAUDE.md")).isFile()).toBe(true);
+    expect(lstatSync(join(target, "CLAUDE.md")).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(target, "CLAUDE.md"), "utf8")).toBe(
+      readFileSync(join(target, "AGENTS.md"), "utf8"),
+    );
+  });
+
   it("normalizes a symbolic-link creation failure and rolls back", async () => {
     const cwd = createWorkingDirectory();
     const target = join(cwd, "my-engine");


### PR DESCRIPTION
**Symlink creation fallback:**

* Updated `writeStarterProject` in `scaffold.ts` to catch symlink creation failures with the `EPERM` error code and instead write a regular file containing the target's contents. This ensures project setup works even on platforms where symlink creation requires elevated privileges.

**Testing enhancements:**

* Added a test to `scaffold.test.ts` that simulates a symlink failure with `EPERM` and verifies that the fallback to a regular file occurs correctly, ensuring the new behavior is covered.py instead.