### PR TITLE
fix(scaffold): request vitest by range so npm 10 can install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- The scaffolded projects now request `vitest` as `^4.1.10` instead of the exact
+  `4.1.10`. The exact pin left two `vitest` versions in the dependency graph —
+  the pinned one and the `vitest@*` peer that `@vitejs/devtools-vitest` resolves
+  to the latest release — and npm 10's dependency resolver crashed on that peer
+  set with `Cannot read properties of null (reading 'edgesOut')`, so
+  `create-invokta-engine`, `create-invokta-capability`, and
+  `create-invokta-capability-library` failed to install dependencies on the npm
+  that ships with Node 22.
+
 ## [0.6.0] - 2026-08-15
 
 ### Added

--- a/packages/create-invokta-capability-library/src/starter.ts
+++ b/packages/create-invokta-capability-library/src/starter.ts
@@ -145,7 +145,7 @@ function renderPackageManifest(
     devDependencies: {
       "@types/node": "26.1.2",
       typescript: "7.0.2",
-      vitest: "4.1.10",
+      vitest: "^4.1.10",
     },
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;

--- a/packages/create-invokta-capability/src/starter.ts
+++ b/packages/create-invokta-capability/src/starter.ts
@@ -112,7 +112,7 @@ function renderPackageManifest(
     devDependencies: {
       "@types/node": "26.1.2",
       typescript: "7.0.2",
-      vitest: "4.1.10",
+      vitest: "^4.1.10",
     },
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;

--- a/packages/create-invokta-engine/src/starter.ts
+++ b/packages/create-invokta-engine/src/starter.ts
@@ -358,7 +358,7 @@ function renderPackageManifest(
     ...(hasMcp ? { "@invokta/tooling": invoktaVersion } : {}),
     "@types/node": "26.1.2",
     typescript: "7.0.2",
-    vitest: "4.1.10",
+    vitest: "^4.1.10",
   };
   const manifest = {
     name: projectName,

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -513,7 +513,7 @@ describe("createStarterFiles", () => {
       devDependencies: {
         "@types/node": "26.1.2",
         typescript: "7.0.2",
-        vitest: "4.1.10",
+        vitest: "^4.1.10",
       },
     });
   });


### PR DESCRIPTION
## Problem

`npx create-invokta-engine@latest` failed at the install step with:

```
npm error Cannot read properties of null (reading 'edgesOut')
INSTALL_FAILED: The project dependencies could not be installed.
```

The stack in the npm log points at arborist loading a peer set:

```
verbose stack TypeError: Cannot read properties of null (reading 'edgesOut')
    at #loadPeerSet (.../arborist/lib/arborist/build-ideal-tree.js:1289:38)
```

## Cause

The generated manifests pinned `vitest` to the exact version `4.1.10`. vitest 4.x carries twelve optional peers, and the `vite → @vitejs/devtools-vite → @vitejs/devtools-vitest` chain declares a `vitest@*` peer, which npm resolves to the latest release (4.1.11). With the exact pin, the graph then needs two vitest versions, the nested peer set reaches a `null` node, and npm 10's resolver crashes.

Matrix reproduced with a minimal `package.json` (vitest only), using `--package-lock-only`:

| npm | vitest | result |
| --- | --- | --- |
| 10.9.3 (the one from Node 22.20.0) | `4.1.10` | crash |
| 10.9.9 (latest 10.x) | `4.1.10` | crash |
| 10.9.3 | `4.1.9` | crash |
| 10.9.3 | `4.1.11` (= latest) | ok |
| 10.9.3 | `^4.1.10` | ok |
| 11.19 / 12.0.2 | `4.1.10` | ok |

The repo never hit this because the root uses yarn 1 (`packageManager: yarn@1.22.22`), which resolves the graph without trouble.

## Change

`vitest: "4.1.10"` → `"^4.1.10"` in the three scaffolders, which collapses the peer set onto a single node. Bumping to `4.1.11` alone would only be a band-aid: it would break again the day 4.1.12 ships.

- `packages/create-invokta-engine/src/starter.ts`
- `packages/create-invokta-capability/src/starter.ts`
- `packages/create-invokta-capability-library/src/starter.ts`
- `packages/create-invokta-engine/test/starter.test.ts` (manifest assertion)
- `CHANGELOG.md` under `[Unreleased] → Fixed`

The remaining exact pins (`typescript`, `@types/node`, `zod`) were left as they were — none of them has a self-referential peer, so they don't trigger the bug.

## Verification

Under npm 10.9.3, the same version that was crashing, generating each starter from the built binaries and running the exact command that failed:

| scaffold | `npm install --no-audit --no-fund` | `npm run check` |
| --- | --- | --- |
| engine (complete profile) | 159 packages in 14s | exit 0 |
| capability | 50 packages in 3s | exit 0 |
| capability-library | 50 packages in 5s | exit 0 |

The generated project's `check` runs with vitest 4.1.11 (what the caret resolves to) and passes typecheck, tests, build, and `invokta check-mcp`.

In the repo: `yarn typecheck`, `yarn lint`, and `yarn format:check` are clean; scaffolder tests 198/198.

Note: on a full `yarn test:run`, `packages/devtools/test/watch.test.ts:271` failed once and passed on its own rerun — a timing flake under load, in a package this diff does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
