### PR TITLE
chore(release): prepare 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-20
+
 ### Fixed
 
+- `create-invokta-engine` falls back to a regular file copy when a symbolic
+  link cannot be created. Creating `CLAUDE.md` as a link to `AGENTS.md` fails
+  with `EPERM` on Windows without Developer Mode, which failed the whole
+  scaffold with `WRITE_FAILED`.
 - The scaffolded projects now request `vitest` as `^4.1.10` instead of the exact
   `4.1.10`. The exact pin left two `vitest` versions in the dependency graph —
   the pinned one and the `vitest@*` peer that `@vitejs/devtools-vitest` resolves
@@ -346,7 +352,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/vinilana/invokta/releases/tag/v0.6.1
 [0.6.0]: https://github.com/vinilana/invokta/releases/tag/v0.6.0
 [0.5.0]: https://github.com/vinilana/invokta/releases/tag/v0.5.0
 [0.4.0]: https://github.com/vinilana/invokta/releases/tag/v0.4.0

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,6 +1,6 @@
 # Validation record
 
-- Last reviewed: 2026-08-15
+- Last reviewed: 2026-08-20
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
@@ -40,9 +40,9 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 2,917 tests with one
+- `yarn run check` passes typecheck, lint, formatting, 2,933 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  78.47% statements, 73.98% branches, 82.85% functions, and 79.97% lines.
+  78.48% statements, 73.99% branches, 82.86% functions, and 79.97% lines.
 - `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
   dependency boundaries, all four packed engine profiles, the authenticated MCP
   HTTP exchange, and the remaining creator and installer smoke tests.

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -17,9 +17,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -11,8 +11,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -11,8 +11,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -11,8 +11,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -10,8 +10,8 @@
     "direct": "node dist/direct.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.6.0",
-        "@invokta/core": "0.6.0",
-        "@invokta/installer": "0.6.0",
-        "@invokta/mcp": "0.6.0",
+        "@invokta/cli": "0.6.1",
+        "@invokta/core": "0.6.1",
+        "@invokta/installer": "0.6.1",
+        "@invokta/mcp": "0.6.1",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,8 +21,8 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.6.0",
-        "@invokta/devtools": "0.6.0",
+        "@invokta/deploy": "0.6.1",
+        "@invokta/devtools": "0.6.1",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -83,21 +83,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.6.0.tgz",
-      "integrity": "sha512-+BOuDzq77TIiWEBJtv95xB//dqaUyieED0ZufIqQC0/ROn52SDygv3YqBtgeQ2c/ioyFgmRevj6EzBgj9t6MrQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.6.1.tgz",
+      "integrity": "sha512-jrqoBK1ovxRWaA62gF4ZA4Vx8lcEnhgj7zvGkahFMCoHZx9O83cs24M7MUzvayvuWl8nL/gm+T5GYHWWRi9zAg==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.6.0"
+        "@invokta/core": "0.6.1"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.6.0.tgz",
-      "integrity": "sha512-hXTddk/5Bp1oTJ426OxjMAVguordJo96ZM9qv6qQxVMWe+fjzDMbmGTmyg4Xs+3+a9Qb+6aybjz1ctQ9IREWGw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-6V/B47kAqEv8yCYpJsOH1EshuxNyFeM4UyLQkeSwHcOakVs3h957r9qDOut+OifynIE5CwV6xd74KXTth5oH1Q==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.6.0.tgz",
-      "integrity": "sha512-P+b1ax+de7CJEjbHc4g+CJUyT9dw6D0FAz+Wh116nQs7bXh4aAYiTwCWmjq2ao09+0c1ARIUKEPRIRXmm39PlA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.6.1.tgz",
+      "integrity": "sha512-SuPCwuSd1Hr0D8RU4sxcBpeMDtzYqic/lAHed3K3VqVr3sPR3iOndd/9URpKLpaq2+iGnuqpv7EYFb6wkXPedQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -120,15 +120,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.6.0.tgz",
-      "integrity": "sha512-OE7KHL7mwNg+9rHzc17cdMe6nBszQh0s7zoOgr7z997eEC/h7dBEFb69MG5Ig/5m6D7Xcnbf7lUieilnkJIedA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.6.1.tgz",
+      "integrity": "sha512-WJDVUstOUjjgjnt8TY2Dw4gideoi4ub4OL654D2A1grSzQBwN4D28HTvfH6debTfR3I7FtwGqdD1ND8QfSNsqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/cli": "0.6.0",
-        "@invokta/core": "0.6.0",
-        "@invokta/mcp": "0.6.0"
+        "@invokta/cli": "0.6.1",
+        "@invokta/core": "0.6.1",
+        "@invokta/mcp": "0.6.1"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.6.0.tgz",
-      "integrity": "sha512-CHTztZwGDW2zPpG1WEEBDghM3JexYdZDoO9SXntjG7JxbM1eIEXSN/x3wzoZTwluQyVEK4726TCtLrFiwZivTA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.6.1.tgz",
+      "integrity": "sha512-sURJx2QtMJccCHekbVK3KhUSvcHvGaL2XMUCy7oayJY/1LG5NsaTeqosJXVS/DjKULSq8evp//VKuZ6xyUnT9Q==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -156,12 +156,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.6.0.tgz",
-      "integrity": "sha512-xGgNAOaXBtFrGg6Zclj74k3zf6vamm1FeCEo+qTdi1n0w4fyEL6nOoHWvkCizhoH4LeDNyNFbc3VOm4fGKrGfg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.6.1.tgz",
+      "integrity": "sha512-g8VcV7OOmI305tkQLFydIcTUYV4umHaVAczxs0RQT6ox37ijdfddeXRnwiZ3AMX4BVequqwAtZhRYBdDrV/9Rw==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.6.0",
+        "@invokta/core": "0.6.1",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -36,18 +36,18 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/installer": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/installer": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.6.0",
-    "@invokta/devtools": "0.6.0",
+    "@invokta/deploy": "0.6.1",
+    "@invokta/devtools": "0.6.1",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -10,8 +10,8 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
+    "@invokta/core": "0.6.1",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -14,14 +14,14 @@
     "check:capabilities": "node ../../packages/tooling/dist/cli.js check-capabilities ./dist/capabilities.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/tooling": "0.6.0",
+    "@invokta/tooling": "0.6.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -16,12 +16,12 @@
     "devtools": "invokta-devtools serve dist/engine.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.0"
+    "@invokta/devtools": "0.6.1"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -16,9 +16,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -13,9 +13,9 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0",
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0"
+    "@invokta/core": "0.6.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Typed capability contracts and execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.6.0",
+    "@invokta/deploy": "0.6.1",
     "tar": "7.5.22"
   }
 }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.6.0",
+      "@invokta/deploy": "0.6.1",
       tar: "7.5.22",
     });
   });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Local MCP and CLI workbenches, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.0",
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0"
+    "@invokta/cli": "0.6.1",
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1"
   }
 }

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.6.0",
+      version: "0.6.1",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
+    "@invokta/core": "0.6.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.6.0";
+const CLIENT_VERSION = "0.6.1";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.6.0",
-    "@invokta/mcp": "0.6.0"
+    "@invokta/core": "0.6.1",
+    "@invokta/mcp": "0.6.1"
   }
 }


### PR DESCRIPTION
Prepares the `0.6.1` patch release. Two user-facing scaffolding fixes ship in it: #48 (symlink fallback on Windows) and #50 (npm 10 can install the generated projects).

## Metadata synchronized

- Root and all ten public package versions bumped to `0.6.1` — 81 replacements across 34 manifests, covering every exact internal `@invokta/*` pin in `packages/` and `examples/`.
- `packages/mcp/src/client.ts` → `CLIENT_VERSION = "0.6.1"`.
- Version assertions in `packages/installer/test/package-boundary.test.ts` and `packages/create-invokta-engine/test/starter.test.ts`.
- `examples/auth-self-hosted-oauth-engine/package-lock.json` — 29 lines, with integrity re-derived from the six locally packed `0.6.1` tarballs (`npm pack` → sha512), never carried over from `0.6.0`. The derivation was validated first by hashing the published `@invokta/core@0.6.0` tarball and matching the registry's `dist.integrity` exactly, and the six hashes were re-packed and re-compared after the rebase onto #48.
- `CHANGELOG.md` — both fixes recorded under `## [0.6.1] - 2026-08-20`, comparison base and release link updated. #48 shipped without a changelog entry, so this adds one.
- `docs/validation-record.md` — reviewed date `2026-08-20`, test total `2,917` → `2,933`, coverage refreshed.

The touched-file list is identical to the `0.6.0` preparation commit, so the release slice keeps the established shape.

## Gates

Run on the rebased tree, at `c717b57`:

| gate | result |
| --- | --- |
| `yarn install --frozen-lockfile --non-interactive` | ok |
| `yarn run check` | exit 0 — 197 files, 2932 passed, 1 intentional skip; coverage 78.48% statements, 73.99% branches, 82.86% functions, 79.97% lines |
| `yarn audit` | 0 vulnerabilities, 307 packages audited |
| `apps/docs` → `yarn validate` | exit 0, 49 pages built |
| `yarn release:pack` | dry-runs passed for 0.6.1 |
| `yarn release:verify` | exit 0 — clean tarballs, isolated ESM imports, dependency boundaries, all four packed engine profiles, the authenticated MCP HTTP exchange, creator and installer smoke |
| `git diff --cached --check` | clean |

RED/GREEN: metadata-only exception. No executable behavior changes here; each fix carries its own evidence in #48 and #50.

## Risks

- `packages/devtools/test/watch.test.ts:271` ("exits the engine host on SIGTERM") timed out on one earlier `yarn run check` run and passed on the re-run; the run recorded above passed first time. It passes in isolation and CI's Verify job has been green. Its 15s ready-message deadline looks tight under full-suite load — worth a separate fix, not a release blocker.
- The CI-only commits since `v0.6.0` (`ci(release): publish packages directly to latest`, `ci(release): harden release automation contracts`, and the Biome dev-dependency bump) carry no changelog entries. Left as their authors did, since they do not affect published packages.

## After merge

`yarn release:create-tag 0.6.1` from a clean checkout whose `HEAD` matches `origin/main`, then approve the protected `npm` environment when the workflow reaches the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
