### PR TITLE
chore(release): prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-22
+
 ### Added
 
 - `create-invokta-engine --openapi` imports supported operations from a bounded
@@ -443,7 +445,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/vinilana/invokta/releases/tag/v0.7.0
 [0.6.1]: https://github.com/vinilana/invokta/releases/tag/v0.6.1
 [0.6.0]: https://github.com/vinilana/invokta/releases/tag/v0.6.0
 [0.5.0]: https://github.com/vinilana/invokta/releases/tag/v0.5.0

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -18,8 +18,11 @@
   0030; advertised authorization servers and OAuth discovery inspection
   accepted in ADR 0031; CLI installation inspection and homologation
   accepted in ADR 0032; and the workbench launcher with workbench selection
-  accepted in ADR 0033; typed connector definitions accepted in ADR 0037; and
-  guided OpenAPI capability import accepted in ADR 0038.
+  accepted in ADR 0033; harness configuration variants and VS Code remote user
+  scope accepted in ADR 0034; example archive path and subtree validation
+  accepted in ADR 0035; engine-owned outbound connectors accepted in ADR 0036;
+  typed connector definitions accepted in ADR 0037; and guided OpenAPI
+  capability import accepted in ADR 0038.
 - Architectural conventions: ADR 0036 defines engine-owned outbound connectors;
   ADR 0037 adds their optional typed core authoring definition without changing
   capability contracts, the error-code taxonomy, or the execution path.
@@ -46,14 +49,15 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 3,112 tests with one
+- `yarn run check` passes typecheck, lint, formatting, 3,120 tests with one
   intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  78.90% statements, 74.29% branches, 83.40% functions, and 80.61% lines.
-- `yarn release:verify` passes clean tarball inspection, isolated ESM imports,
-  dependency boundaries, all four packed engine profiles, the authenticated MCP
-  HTTP exchange, and the remaining creator and installer smoke tests.
-- `yarn validate` in `apps/docs` passes route and link tests, Astro diagnostics,
-  and the production site build.
+  78.90% statements, 74.28% branches, 83.41% functions, and 80.63% lines.
+- `yarn release:verify` passes metadata alignment and clean tarball inspection
+  for all 10 public packages, isolated ESM imports, all four packed engine
+  profiles, authenticated MCP HTTP exchange, DevTools doctor checks, and the
+  atomic and capability-library creator smoke tests.
+- `yarn validate` in `apps/docs` passes 15 route and link contract tests, zero
+  Astro diagnostics, and the 49-page production site build.
 - `yarn audit` reports zero vulnerabilities across 307 audited packages.
 
 ## Boundaries exercised

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -20,14 +20,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -14,12 +14,12 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1"
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.6.1",
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/deploy": "0.7.0",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -14,13 +14,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1"
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0"
   }
 }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -14,14 +14,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -14,14 +14,14 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.6.1",
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1"
+    "@invokta/deploy": "0.7.0",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0"
   }
 }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -13,12 +13,12 @@
     "devtools:doctor": "tsc -b --pretty false && invokta-devtools doctor dist/engine.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1"
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.6.1",
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/deploy": "0.7.0",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.6.1",
-        "@invokta/core": "0.6.1",
-        "@invokta/installer": "0.6.1",
-        "@invokta/mcp": "0.6.1",
+        "@invokta/cli": "0.7.0",
+        "@invokta/core": "0.7.0",
+        "@invokta/installer": "0.7.0",
+        "@invokta/mcp": "0.7.0",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,8 +21,8 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.6.1",
-        "@invokta/devtools": "0.6.1",
+        "@invokta/deploy": "0.7.0",
+        "@invokta/devtools": "0.7.0",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -83,21 +83,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.6.1.tgz",
-      "integrity": "sha512-jrqoBK1ovxRWaA62gF4ZA4Vx8lcEnhgj7zvGkahFMCoHZx9O83cs24M7MUzvayvuWl8nL/gm+T5GYHWWRi9zAg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.7.0.tgz",
+      "integrity": "sha512-AXA1NPhExsfKGAvBpYw72L7kicsRrnFppyHZYwx7tiK8KZ5Tcen3wHKL+aEIb070E878l8m7ngIusMd2wIpMvQ==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.6.1"
+        "@invokta/core": "0.7.0"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.6.1.tgz",
-      "integrity": "sha512-6V/B47kAqEv8yCYpJsOH1EshuxNyFeM4UyLQkeSwHcOakVs3h957r9qDOut+OifynIE5CwV6xd74KXTth5oH1Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-Rk9xKiEEmsMPokGvL7mziFWzgJu2Uwaf+EgpC6gH9segwWYHUzDheIjZfJqNF9GjCv0IbpjScU/sCx0ypL1DVw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.6.1.tgz",
-      "integrity": "sha512-SuPCwuSd1Hr0D8RU4sxcBpeMDtzYqic/lAHed3K3VqVr3sPR3iOndd/9URpKLpaq2+iGnuqpv7EYFb6wkXPedQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.7.0.tgz",
+      "integrity": "sha512-pvpdZkzJ/ShYDWxhfJu3v/PrlCYs8NcvB8HT4n3oQDO+a30aoa0/DF5lfrNNtjqDKua93SVRMBQepC/D5CxrUA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -120,15 +120,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.6.1.tgz",
-      "integrity": "sha512-WJDVUstOUjjgjnt8TY2Dw4gideoi4ub4OL654D2A1grSzQBwN4D28HTvfH6debTfR3I7FtwGqdD1ND8QfSNsqw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.7.0.tgz",
+      "integrity": "sha512-rSuggPLNW7mBPrhcZ0vKEjJIGRN2fPKtxpr3nLawLejDOSOt5jv6q8ojL3Pn3SStVhs/dfXpqfDcHzZuelfQMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/cli": "0.6.1",
-        "@invokta/core": "0.6.1",
-        "@invokta/mcp": "0.6.1"
+        "@invokta/cli": "0.7.0",
+        "@invokta/core": "0.7.0",
+        "@invokta/mcp": "0.7.0"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.6.1.tgz",
-      "integrity": "sha512-sURJx2QtMJccCHekbVK3KhUSvcHvGaL2XMUCy7oayJY/1LG5NsaTeqosJXVS/DjKULSq8evp//VKuZ6xyUnT9Q==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.7.0.tgz",
+      "integrity": "sha512-t3EIp3ttRs8AQsjC/NL/Llgiv2P+dRdPQTGakFL6iMLiCSADMslO/UFW8pEVvAfYx1nsXysjPRdFEPDifSFpOA==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -156,12 +156,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.6.1.tgz",
-      "integrity": "sha512-g8VcV7OOmI305tkQLFydIcTUYV4umHaVAczxs0RQT6ox37ijdfddeXRnwiZ3AMX4BVequqwAtZhRYBdDrV/9Rw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.7.0.tgz",
+      "integrity": "sha512-gxbn3E75Eo2COGxtzCxlRHOYGm5w6HPc2OjH5jTfMFl3qS4Tw5CCVClbDGgO9tUIV/rkuQZKF8RHv9ZBF21+bg==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.6.1",
+        "@invokta/core": "0.7.0",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -37,19 +37,19 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/installer": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/installer": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.6.1",
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/deploy": "0.7.0",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.6.1",
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/deploy": "0.7.0",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
+    "@invokta/core": "0.7.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -17,15 +17,15 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
+    "@invokta/devtools": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -18,13 +18,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1"
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
+    "@invokta/devtools": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
+    "@invokta/devtools": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -17,14 +17,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
+    "@invokta/devtools": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -16,14 +16,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1",
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1",
-    "@invokta/tooling": "0.6.1",
+    "@invokta/devtools": "0.7.0",
+    "@invokta/tooling": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-harness/package.json
+++ b/examples/support-harness/package.json
@@ -13,6 +13,6 @@
     "@modelcontextprotocol/sdk": "1.30.0"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.6.1"
+    "@invokta/devtools": "0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1"
+    "@invokta/core": "0.7.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Typed capability and connector contracts with the execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.6.1",
+    "@invokta/deploy": "0.7.0",
     "tar": "7.5.22",
     "yaml": "2.9.0"
   }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.6.1",
+      "@invokta/deploy": "0.7.0",
       tar: "7.5.22",
       yaml: "2.9.0",
     });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Local MCP and CLI workbenches, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.6.1",
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1"
+    "@invokta/cli": "0.7.0",
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0"
   }
 }

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.6.1",
+      version: "0.7.0",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
+    "@invokta/core": "0.7.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.6.1";
+const CLIENT_VERSION = "0.7.0";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.6.1",
-    "@invokta/mcp": "0.6.1"
+    "@invokta/core": "0.7.0",
+    "@invokta/mcp": "0.7.0"
   }
 }


### PR DESCRIPTION
## Summary

- bump the root and all public packages to `0.7.0`
- align exact internal `@invokta/*` pins, release assertions, and MCP client identification
- regenerate the committed example lockfile integrity values from local `0.7.0` tarballs
- move Unreleased notes into the `0.7.0` changelog entry
- refresh the validation record with ADRs 0034–0038 and current release evidence

## Validation

- `yarn install --frozen-lockfile --non-interactive`
- `yarn run check` — 3,120 passed, 1 intentional skip; 19 example gates passed
- `yarn audit` — 0 vulnerabilities across 307 packages
- `cd apps/docs && yarn install --frozen-lockfile --non-interactive && yarn validate` — 15 tests, 0 Astro diagnostics, 49 pages built
- `yarn release:verify` — all 10 public packages and packed consumer smoke tests passed

## Notes

This is metadata-only release preparation, so RED does not apply. Tagging and publishing remain separate release actions.