### PR TITLE
fix(release): keep OIDC publishing tokenless

### DIFF
--- a/.github/workflows/security-and-release.yml
+++ b/.github/workflows/security-and-release.yml
@@ -72,11 +72,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Node.js and npm registry
+      - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
       - name: Enable Corepack

--- a/scripts/release/release-automation.test.ts
+++ b/scripts/release/release-automation.test.ts
@@ -88,7 +88,8 @@ describe("release automation", () => {
     expect(workflow).toContain("needs: verify");
     expect(workflow).toContain("environment: npm");
     expect(workflow).toContain("id-token: write");
-    expect(workflow).toContain("registry-url: https://registry.npmjs.org");
+    expect(workflow).not.toContain("registry-url:");
+    expect(workflow).not.toContain("NODE_AUTH_TOKEN");
     expect(workflow).toContain("npm install --global npm@11");
     expect(workflow).toContain('yarn release:publish "$GITHUB_REF_NAME"');
     expect(workflow).toContain("release:\n");


### PR DESCRIPTION
## Summary

- stop `actions/setup-node` from generating token-based npm authentication in the OIDC publish job
- prevent Yarn from failing on an unset `${NODE_AUTH_TOKEN}` before the release script starts
- add a regression assertion that the publish workflow remains tokenless

## Failure evidence

- Release run: https://github.com/vinilana/invokta/actions/runs/32647049892
- Failure occurred before any `0.7.0` package was published.

## Validation

- `yarn vitest run scripts/release/release-automation.test.ts` (RED, then GREEN: 5 tests)
- `yarn install --frozen-lockfile --non-interactive`
- `yarn run check` (206 files, 3,120 passed, 1 skipped; 19 example gates)
- `yarn audit` (0 vulnerabilities)
- `cd apps/docs && yarn install --frozen-lockfile --non-interactive && yarn validate`
- `yarn release:verify`