### PR TITLE
chore(release): prepare 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-09-03
+
 ### Added
 
 - `serveMcpHttp` accepts an optional `path` that mounts the stateless MCP HTTP
@@ -456,7 +458,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/vinilana/invokta/releases/tag/v0.8.0
 [0.7.0]: https://github.com/vinilana/invokta/releases/tag/v0.7.0
 [0.6.1]: https://github.com/vinilana/invokta/releases/tag/v0.6.1
 [0.6.0]: https://github.com/vinilana/invokta/releases/tag/v0.6.0

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,6 +1,6 @@
 # Validation record
 
-- Last reviewed: 2026-08-22
+- Last reviewed: 2026-09-03
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
@@ -21,8 +21,9 @@
   accepted in ADR 0033; harness configuration variants and VS Code remote user
   scope accepted in ADR 0034; example archive path and subtree validation
   accepted in ADR 0035; engine-owned outbound connectors accepted in ADR 0036;
-  typed connector definitions accepted in ADR 0037; and guided OpenAPI
-  capability import accepted in ADR 0038.
+  typed connector definitions accepted in ADR 0037; guided OpenAPI
+  capability import accepted in ADR 0038; and the configurable MCP HTTP
+  mount path accepted in ADR 0039.
 - Architectural conventions: ADR 0036 defines engine-owned outbound connectors;
   ADR 0037 adds their optional typed core authoring definition without changing
   capability contracts, the error-code taxonomy, or the execution path.
@@ -49,9 +50,9 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 3,120 tests with one
-  intentional skip, V8 coverage, and the full TypeScript build. Coverage is
-  78.90% statements, 74.28% branches, 83.41% functions, and 80.63% lines.
+- `yarn run check` passes typecheck, lint, formatting, 3,144 tests with two
+  intentional skips, V8 coverage, and the full TypeScript build. Coverage is
+  78.92% statements, 74.32% branches, 83.41% functions, and 80.64% lines.
 - `yarn release:verify` passes metadata alignment and clean tarball inspection
   for all 10 public packages, isolated ESM imports, all four packed engine
   profiles, authenticated MCP HTTP exchange, DevTools doctor checks, and the

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -20,14 +20,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -14,12 +14,12 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0"
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.7.0",
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/deploy": "0.8.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -14,13 +14,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0"
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0"
   }
 }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -14,14 +14,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -14,14 +14,14 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.7.0",
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0"
+    "@invokta/deploy": "0.8.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0"
   }
 }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -13,12 +13,12 @@
     "devtools:doctor": "tsc -b --pretty false && invokta-devtools doctor dist/engine.js"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0"
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.7.0",
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/deploy": "0.8.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.7.0",
-        "@invokta/core": "0.7.0",
-        "@invokta/installer": "0.7.0",
-        "@invokta/mcp": "0.7.0",
+        "@invokta/cli": "0.8.0",
+        "@invokta/core": "0.8.0",
+        "@invokta/installer": "0.8.0",
+        "@invokta/mcp": "0.8.0",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,8 +21,8 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.7.0",
-        "@invokta/devtools": "0.7.0",
+        "@invokta/deploy": "0.8.0",
+        "@invokta/devtools": "0.8.0",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -83,21 +83,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.7.0.tgz",
-      "integrity": "sha512-AXA1NPhExsfKGAvBpYw72L7kicsRrnFppyHZYwx7tiK8KZ5Tcen3wHKL+aEIb070E878l8m7ngIusMd2wIpMvQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.8.0.tgz",
+      "integrity": "sha512-DgRhVto4pqv5TzniGEloCmgoRtIgT+MuGGTcTI8cXxVl6mVSRVnDcDKGLmAV3Cb0Gg16QPfitTmOG+qGwdR9Wg==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.7.0"
+        "@invokta/core": "0.8.0"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-Rk9xKiEEmsMPokGvL7mziFWzgJu2Uwaf+EgpC6gH9segwWYHUzDheIjZfJqNF9GjCv0IbpjScU/sCx0ypL1DVw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.8.0.tgz",
+      "integrity": "sha512-I3S9+8x8t72BRSSfGvf7EAp139nVJcKxF/kL5/QEM9fsLzS0L/t2DCFbVIlCNhkCLarlOq8tpVQEzY+D1Ynowg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.7.0.tgz",
-      "integrity": "sha512-pvpdZkzJ/ShYDWxhfJu3v/PrlCYs8NcvB8HT4n3oQDO+a30aoa0/DF5lfrNNtjqDKua93SVRMBQepC/D5CxrUA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.0.tgz",
+      "integrity": "sha512-sxlPenfeQiqi6Zh0TUm9HEq4+g989qCOV7/SmzEA7Dn4FIfas1lTFOTTw8YkGMkz7AXFJHxJIi2wEZ8NyjRpSg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -120,15 +120,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.7.0.tgz",
-      "integrity": "sha512-rSuggPLNW7mBPrhcZ0vKEjJIGRN2fPKtxpr3nLawLejDOSOt5jv6q8ojL3Pn3SStVhs/dfXpqfDcHzZuelfQMA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.0.tgz",
+      "integrity": "sha512-n0gci9YWCl0qqcU3gvUzfOTJh35qBM5MVNdrDMeUVEjh/qNdNMLaMYobnNMlbJCFWLQjfFRMsD55W5Dvf6UJuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/cli": "0.7.0",
-        "@invokta/core": "0.7.0",
-        "@invokta/mcp": "0.7.0"
+        "@invokta/cli": "0.8.0",
+        "@invokta/core": "0.8.0",
+        "@invokta/mcp": "0.8.0"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.7.0.tgz",
-      "integrity": "sha512-t3EIp3ttRs8AQsjC/NL/Llgiv2P+dRdPQTGakFL6iMLiCSADMslO/UFW8pEVvAfYx1nsXysjPRdFEPDifSFpOA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.0.tgz",
+      "integrity": "sha512-s+y6wzz2eFtwFxV2J/HNsWHiekili41gKigxviegmHpPm1+of0gs7fwUsZGRd1nRQpa8CGYbTWqOQ5IGEdnw7Q==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -156,12 +156,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.7.0.tgz",
-      "integrity": "sha512-gxbn3E75Eo2COGxtzCxlRHOYGm5w6HPc2OjH5jTfMFl3qS4Tw5CCVClbDGgO9tUIV/rkuQZKF8RHv9ZBF21+bg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.8.0.tgz",
+      "integrity": "sha512-ab7wt27phpOi9ZvleNYIuETt0WrOQsDhlOcwVhGSgnhdEBv50Kj9MUACuJNELZiNMTbwQYKiJmz1o54m6l/xGw==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.7.0",
+        "@invokta/core": "0.8.0",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -37,19 +37,19 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/installer": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/installer": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.7.0",
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/deploy": "0.8.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.7.0",
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/deploy": "0.8.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
+    "@invokta/core": "0.8.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -17,15 +17,15 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
+    "@invokta/devtools": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -18,13 +18,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0"
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
+    "@invokta/devtools": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
+    "@invokta/devtools": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -17,14 +17,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
+    "@invokta/devtools": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -16,14 +16,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0",
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0",
-    "@invokta/tooling": "0.7.0",
+    "@invokta/devtools": "0.8.0",
+    "@invokta/tooling": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-harness/package.json
+++ b/examples/support-harness/package.json
@@ -13,6 +13,6 @@
     "@modelcontextprotocol/sdk": "1.30.0"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.7.0"
+    "@invokta/devtools": "0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0"
+    "@invokta/core": "0.8.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Typed capability and connector contracts with the execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.7.0",
+    "@invokta/deploy": "0.8.0",
     "tar": "7.5.22",
     "yaml": "2.9.0"
   }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.7.0",
+      "@invokta/deploy": "0.8.0",
       tar: "7.5.22",
       yaml: "2.9.0",
     });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Local MCP and CLI workbenches, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.7.0",
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0"
+    "@invokta/cli": "0.8.0",
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0"
   }
 }

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.7.0",
+      version: "0.8.0",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
+    "@invokta/core": "0.8.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.7.0";
+const CLIENT_VERSION = "0.8.0";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.7.0",
-    "@invokta/mcp": "0.7.0"
+    "@invokta/core": "0.8.0",
+    "@invokta/mcp": "0.8.0"
   }
 }


### PR DESCRIPTION
## Release 0.8.0

Carries ADR 0039 (`serveMcpHttp` mounts the MCP endpoint under a configurable path, with the Protected Resource Metadata document at the RFC 9728 path-suffix location; the deploy probe and OAuth inspection follow the mounted path) and the fast-uri and qs advisory resolutions in both dependency trees.

## Changes

- Root and every public package bumped to 0.8.0, together with the internal `@invokta/*` pins in packages and examples, the MCP client's self-identification, and the version assertions that track the release.
- The committed example lockfile (`examples/auth-self-hosted-oauth-engine/package-lock.json`) refreshed with integrity values derived from the locally packed 0.8.0 tarballs.
- Unreleased notes moved under `## [0.8.0] - 2026-09-03` with the release link.
- `docs/validation-record.md` refreshed with this run's evidence.

## Gates on this branch

- `yarn run check`: typecheck, lint, formatting, 3,144 tests with two intentional skips, V8 coverage 78.92% statements / 74.32% branches / 83.41% functions / 80.64% lines, full build, 19 example gates.
- `yarn audit`: 0 vulnerabilities across 307 packages.
- `yarn validate` in `apps/docs`: 15 contract tests, zero Astro diagnostics, 49 pages.
- `yarn release:verify`: metadata, clean tarballs, isolated ESM imports, packed engine profiles, authenticated MCP HTTP exchange, DevTools doctor, and creator smoke tests for all 10 public packages.

Metadata-only change: no executable behavior, so no RED step. After the merge, `yarn release:create-tag 0.8.0` starts the protected release workflow, whose `npm` environment needs the owner's approval before the publish job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBPAhspS9c2NTgjbrGz7GT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBPAhspS9c2NTgjbrGz7GT)_