### PR TITLE
chore(release): prepare 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-09-04
+
+### Fixed
+
+- Release verification now runs on Node.js 24 with npm 11, avoiding the npm 10
+  Arborist peer-resolution crash that blocked the `v0.8.0` tag workflow. The
+  published packages continue to support Node.js 22.20.0 and later.
+
 ## [0.8.0] - 2026-09-03
 
 ### Added
@@ -458,7 +466,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/vinilana/invokta/releases/tag/v0.8.1
 [0.8.0]: https://github.com/vinilana/invokta/releases/tag/v0.8.0
 [0.7.0]: https://github.com/vinilana/invokta/releases/tag/v0.7.0
 [0.6.1]: https://github.com/vinilana/invokta/releases/tag/v0.6.1

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,6 +1,6 @@
 # Validation record
 
-- Last reviewed: 2026-09-03
+- Last reviewed: 2026-09-04
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
@@ -50,16 +50,18 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` passes typecheck, lint, formatting, 3,144 tests with two
-  intentional skips, V8 coverage, and the full TypeScript build. Coverage is
-  78.92% statements, 74.32% branches, 83.41% functions, and 80.64% lines.
+- `yarn run check` on Node.js 24.20.0 and npm 11.19.0 passes typecheck, lint,
+  formatting, 3,145 tests with one intentional skip, V8 coverage, and the full
+  TypeScript build. Coverage is 78.95% statements, 74.34% branches, 83.45%
+  functions, and 80.67% lines.
 - `yarn release:verify` passes metadata alignment and clean tarball inspection
   for all 10 public packages, isolated ESM imports, all four packed engine
   profiles, authenticated MCP HTTP exchange, DevTools doctor checks, and the
   atomic and capability-library creator smoke tests.
 - `yarn validate` in `apps/docs` passes 15 route and link contract tests, zero
   Astro diagnostics, and the 49-page production site build.
-- `yarn audit` reports zero vulnerabilities across 307 audited packages.
+- `yarn audit` reports zero vulnerabilities across 307 audited root packages;
+  the docs application audit reports zero vulnerabilities across 537 packages.
 
 ## Boundaries exercised
 

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -20,14 +20,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -14,12 +14,12 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0"
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.0",
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/deploy": "0.8.1",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -14,13 +14,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0"
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1"
   }
 }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -14,14 +14,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -14,14 +14,14 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.0",
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0"
+    "@invokta/deploy": "0.8.1",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1"
   }
 }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -13,12 +13,12 @@
     "devtools:doctor": "tsc -b --pretty false && invokta-devtools doctor dist/engine.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0"
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.0",
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/deploy": "0.8.1",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.8.0",
-        "@invokta/core": "0.8.0",
-        "@invokta/installer": "0.8.0",
-        "@invokta/mcp": "0.8.0",
+        "@invokta/cli": "0.8.1",
+        "@invokta/core": "0.8.1",
+        "@invokta/installer": "0.8.1",
+        "@invokta/mcp": "0.8.1",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,8 +21,8 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.8.0",
-        "@invokta/devtools": "0.8.0",
+        "@invokta/deploy": "0.8.1",
+        "@invokta/devtools": "0.8.1",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -83,21 +83,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.8.0.tgz",
-      "integrity": "sha512-DgRhVto4pqv5TzniGEloCmgoRtIgT+MuGGTcTI8cXxVl6mVSRVnDcDKGLmAV3Cb0Gg16QPfitTmOG+qGwdR9Wg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.8.1.tgz",
+      "integrity": "sha512-5I9rooNrS0rlTKQLrHiBXEnb7gjubA1Tladx29xopDbI7N6FXakMBPLKDhs4vhAcYSk+eZRSFmrNLMLal6Uk7w==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.0"
+        "@invokta/core": "0.8.1"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-I3S9+8x8t72BRSSfGvf7EAp139nVJcKxF/kL5/QEM9fsLzS0L/t2DCFbVIlCNhkCLarlOq8tpVQEzY+D1Ynowg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.8.1.tgz",
+      "integrity": "sha512-VIoQ4rSzfWUg+p78mUnkGlO5mASNbHjezchq8X8FedBCvA7vBujywQUsvaQtZGXwPWpFVLao6p88NY9hP358tQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.0.tgz",
-      "integrity": "sha512-sxlPenfeQiqi6Zh0TUm9HEq4+g989qCOV7/SmzEA7Dn4FIfas1lTFOTTw8YkGMkz7AXFJHxJIi2wEZ8NyjRpSg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.1.tgz",
+      "integrity": "sha512-/uh6w/cbx52/kO5CcbfS/LpjvpdcqEwCE2kaze6MFI9ApjqelTPERJrDMjtMqmzjVMqIQjAsq2pxL7/PeaL34Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -120,15 +120,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.0.tgz",
-      "integrity": "sha512-n0gci9YWCl0qqcU3gvUzfOTJh35qBM5MVNdrDMeUVEjh/qNdNMLaMYobnNMlbJCFWLQjfFRMsD55W5Dvf6UJuw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.1.tgz",
+      "integrity": "sha512-xKGBljs0wf4QaXCXK7EepmVYrn0ayLAlDEOUR3gE0mKH5V4xqmM+d7yxms9nqsIhMhV9mu/Gnlw0vVN/jWioWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/cli": "0.8.0",
-        "@invokta/core": "0.8.0",
-        "@invokta/mcp": "0.8.0"
+        "@invokta/cli": "0.8.1",
+        "@invokta/core": "0.8.1",
+        "@invokta/mcp": "0.8.1"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.0.tgz",
-      "integrity": "sha512-s+y6wzz2eFtwFxV2J/HNsWHiekili41gKigxviegmHpPm1+of0gs7fwUsZGRd1nRQpa8CGYbTWqOQ5IGEdnw7Q==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.1.tgz",
+      "integrity": "sha512-Dv9a1+LBXjXMyGYHZQkaFnJCjUifNEnMx5XTWpJo1v1ZVi1vzK/vB0EhZ/L5NGKQuF6pGXbxiAMwVvcCxJ30qw==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -156,12 +156,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.8.0.tgz",
-      "integrity": "sha512-ab7wt27phpOi9ZvleNYIuETt0WrOQsDhlOcwVhGSgnhdEBv50Kj9MUACuJNELZiNMTbwQYKiJmz1o54m6l/xGw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.8.1.tgz",
+      "integrity": "sha512-Vp4CgT9glKhbVea131PTOQRL8+lM3qFOJbIfS5AFnC6OeEKI858l5jheiK6YKcjr01jnKk5FdItrbM/Ld6LlpQ==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.0",
+        "@invokta/core": "0.8.1",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -37,19 +37,19 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/installer": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/installer": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.0",
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/deploy": "0.8.1",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.0",
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/deploy": "0.8.1",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
+    "@invokta/core": "0.8.1",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -17,15 +17,15 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
+    "@invokta/devtools": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -18,13 +18,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0"
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
+    "@invokta/devtools": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
+    "@invokta/devtools": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -17,14 +17,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
+    "@invokta/devtools": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -16,14 +16,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0",
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0",
-    "@invokta/tooling": "0.8.0",
+    "@invokta/devtools": "0.8.1",
+    "@invokta/tooling": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-harness/package.json
+++ b/examples/support-harness/package.json
@@ -13,6 +13,6 @@
     "@modelcontextprotocol/sdk": "1.30.0"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.0"
+    "@invokta/devtools": "0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0"
+    "@invokta/core": "0.8.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Typed capability and connector contracts with the execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.8.0",
+    "@invokta/deploy": "0.8.1",
     "tar": "7.5.22",
     "yaml": "2.9.0"
   }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.8.0",
+      "@invokta/deploy": "0.8.1",
       tar: "7.5.22",
       yaml: "2.9.0",
     });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Local MCP and CLI workbenches, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.0",
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0"
+    "@invokta/cli": "0.8.1",
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1"
   }
 }

--- a/packages/devtools/test/engine-host.test.ts
+++ b/packages/devtools/test/engine-host.test.ts
@@ -20,6 +20,26 @@ const devtoolsOrigin = "http://127.0.0.1:4100";
 
 type FixtureValue = Readonly<Record<string, unknown>>;
 
+interface Deferred {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+}
+
+function deferred(): Deferred {
+  let resolvePromise: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+let invocationOrderGate:
+  | {
+      readonly firstStarted: Deferred;
+      readonly releaseFirst: Deferred;
+    }
+  | undefined;
+
 const fixtureSchema = {
   "~standard": {
     version: 1,
@@ -57,11 +77,9 @@ function buildEngine(events: EngineEvent[]) {
         output: fixtureSchema,
         access: "public",
         async run({ input }) {
-          const delayMs = input.delayMs;
-          if (typeof delayMs === "number" && delayMs > 0) {
-            await new Promise((resolvePromise) =>
-              setTimeout(resolvePromise, delayMs),
-            );
+          if (input.call === "first" && invocationOrderGate !== undefined) {
+            invocationOrderGate.firstStarted.resolve();
+            await invocationOrderGate.releaseFirst.promise;
           }
           return { echoed: input };
         },
@@ -207,16 +225,23 @@ describe("startEngineHost", () => {
 
   it("keeps unique arrival sequences when concurrent calls finish out of order", async () => {
     records.length = 0;
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    invocationOrderGate = { firstStarted, releaseFirst };
 
     const first = callEcho(
-      { call: "first", delayMs: 40 },
+      { call: "first" },
       { authorization: `Bearer ${token}` },
     );
-    const second = callEcho(
-      { call: "second" },
-      { authorization: `Bearer ${token}` },
-    );
-    await Promise.all([first, second]);
+    try {
+      await firstStarted.promise;
+      await callEcho({ call: "second" }, { authorization: `Bearer ${token}` });
+      releaseFirst.resolve();
+      await first;
+    } finally {
+      releaseFirst.resolve();
+      invocationOrderGate = undefined;
+    }
 
     expect(records[0]?.sequence).toBe((records[1]?.sequence ?? 0) + 1);
     expect(new Set(records.map((record) => record.sequence)).size).toBe(2);

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.8.0",
+      version: "0.8.1",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
+    "@invokta/core": "0.8.1",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.8.0";
+const CLIENT_VERSION = "0.8.1";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.0",
-    "@invokta/mcp": "0.8.0"
+    "@invokta/core": "0.8.1",
+    "@invokta/mcp": "0.8.1"
   }
 }


### PR DESCRIPTION
## Acceptance criterion

Prepare Invokta 0.8.1 from the merged Node 24 release-toolchain fix with synchronized versions, exact internal pins, changelog links, packed lockfile integrity, and current validation evidence.

No public API, schema, error, port, event, persistence, configuration, or adapter contract changes.

## Changes

- align all 10 public package versions and exact internal package pins at 0.8.1
- refresh the committed OAuth example lockfile from the exact local 0.8.1 tarballs
- update release-tracking assertions and MCP client self-identification
- document the npm 10 Arborist failure fixed by the Node 24/npm 11 release environment
- stabilize the DevTools concurrent arrival-sequence test with a deterministic gate
- refresh the validation record

## RED / GREEN evidence

The release metadata is a tooling/documentation-only update, so it has no executable RED requirement.

During the full gate, the DevTools concurrent arrival-sequence test exposed a timing-dependent fixture. RED reproduced in two full checks and one focused run. GREEN used an explicit deferred gate; repeated focused runs and the full repository gate passed. The test preserves the behavior accepted by ADR 0021 and ADR 0028 without changing production code.

## Validation

Run with Node.js 24.20.0, npm 11.19.0, and Yarn 1.22.22:

- `yarn install --frozen-lockfile --non-interactive` — passed
- `yarn run check` — passed; 3,145 tests passed, 1 intentionally skipped
- `yarn audit` — 0 vulnerabilities across 307 root packages
- `yarn validate` in `apps/docs` — 15 tests, 0 Astro diagnostics, 49 pages
- `yarn audit` in `apps/docs` — 0 vulnerabilities across 537 packages
- Windows-specific creator coverage — 31 tests passed
- `yarn release:pack` — all 10 public packages passed
- `yarn release:verify` against the staged snapshot — all 10 packages, isolated ESM imports, generated engine profiles, and creator smoke tests passed
- `git diff --cached --check` and package-version alignment checks — passed

## Risks and follow-up

No blocking risks or skipped release gates. Node emits the existing `url.parse()` deprecation warning, npm reports inherited Yarn environment keys as future-compatibility warnings, and the isolated verifier install reports Vitest's optional Vite peer warning.
