### PR TITLE
fix(installer): support canonical mounted MCP URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- The installer accepts canonical mounted MCP URLs such as `/e/brain/mcp`
+  instead of rejecting them with `REMOTE_INVALID`. Direct remote installation,
+  registry entries, persisted state, and client configuration conversion now
+  preserve the full resource path using one validator. Existing `/mcp` URLs and
+  the HTTPS, literal-loopback HTTP, and credential restrictions remain unchanged
+  (ADR 0040).
+
 ## [0.8.1] - 2026-09-04
 
 ### Fixed

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -173,9 +173,21 @@ invokta-installer install --http support-engine https://support.example.com/mcp 
 ```
 
 This command performs no network request. The URL must be canonical HTTPS with
-the exact `/mcp` path. Canonical `http://127.0.0.1/mcp` and
-`http://[::1]/mcp` are accepted for local development. User information, query
-strings, fragments, embedded credentials, and other paths are rejected.
+a canonical MCP mount path: `/mcp` or an unreserved ASCII prefix ending in `/mcp`,
+with no empty or dot segments and at most 256 bytes. For example:
+
+```sh
+invokta-installer install --http brain http://127.0.0.1:3100/e/brain/mcp
+```
+
+Literal `127.0.0.1` and `[::1]` HTTP origins are accepted for local development.
+User information, query strings, fragments, embedded credentials, percent encoding,
+and other noncanonical paths are rejected.
+
+Mounted paths require a build containing ADR 0040. The published installer 0.8.1
+still accepts only `/mcp`; from an updated source checkout, build with `yarn build`
+and run `node packages/installer/dist/cli.js install --http brain <url>`.
+The installer registers the URL; the selected client handles OAuth when it connects.
 
 Authentication and header options name environment variables; they never read
 or persist their values. `--header-env` may be repeated. Header names are

--- a/docs/adr/0013-action-engine-mcp-installation-and-management.md
+++ b/docs/adr/0013-action-engine-mcp-installation-and-management.md
@@ -88,9 +88,10 @@ configuration writes.
 `install --http` accepts an explicit server name and canonical Streamable HTTP
 URL plus optional environment-variable references for a bearer token and HTTP
 headers. It performs no request. HTTPS is required except for canonical loopback
-HTTP development URLs. Credentials, query strings, fragments, user information,
-and non-`/mcp` paths are rejected. Only environment variable names are persisted;
-their values are never read into configuration, state, or diagnostics.
+HTTP development URLs. Credentials, query strings, fragments, and user information
+are rejected. ADR 0040 extends the original exact `/mcp` restriction to the
+canonical mounted paths defined by ADR 0039. Only environment variable names are
+persisted; their values are never read into configuration, state, or diagnostics.
 
 ### Selection and authority
 

--- a/docs/adr/0040-installer-mounted-mcp-urls.md
+++ b/docs/adr/0040-installer-mounted-mcp-urls.md
@@ -1,0 +1,50 @@
+# ADR 0040: Installer support for mounted MCP URLs
+
+- Status: Accepted
+- Date: 2026-09-05
+- Evidence: [Issue #75](https://github.com/vinilana/invokta/issues/75)
+
+## Context
+
+ADR 0039 permits canonical MCP HTTP mount paths such as `/e/brain/mcp` and
+extends deploy inspection to preserve them. ADR 0013's installer contract still
+requires exactly `/mcp`. Consequently, a valid Gateway engine cannot be installed
+with `install --http`: version 0.8.1 returns `REMOTE_INVALID` before any network
+request. The same restriction also appears in registry parsing, persisted
+installation state, and inverse target configuration conversion.
+
+## Decision
+
+The installer accepts the canonical mount-path grammar of ADR 0039 wherever it
+reads or writes a remote MCP URL. The path MUST be absolute, contain only
+nonempty unreserved ASCII segments, end in the exact segment `mcp`, and be at
+most 256 bytes. Dot segments, percent encoding, backslashes, whitespace/control
+characters, empty segments, query strings, fragments, and trailing slashes are
+rejected. URL parsing MUST NOT normalize a noncanonical raw path into an accepted
+one.
+
+The complete path remains part of the resource identity in direct remote
+sources, bundled registry entries, client configurations, launch descriptors,
+and suspended descriptors. Registry, state, installation, and management use one
+internal URL validator so they cannot disagree about mounted endpoints.
+
+This extends the path restriction of ADR 0013 without changing its other rules.
+HTTPS remains required except for literal `127.0.0.1` and `[::1]` HTTP URLs;
+credentials and user information remain forbidden. `/mcp` remains valid.
+CLI syntax, descriptor/state schema versions, diagnostic codes, environment
+references, target compatibility, and explicit write confirmation are unchanged.
+
+The installer remains an offline supporting package. It does not depend on
+`@invokta/mcp` or `@invokta/deploy`, follow redirects, discover servers, authenticate
+the caller, or invoke capabilities. The configured client completes OAuth when
+it connects. The local path predicate implements the accepted contract without
+adding a shared runtime abstraction or a new public export.
+
+## Consequences
+
+- Gateway engines can be installed and managed with their published resource URL.
+- Existing default-path installations keep their identity and need no migration.
+- Old installer versions still reject mounted endpoints; consumers need a build
+  containing this change. Source-checkout validation is distinct from an npm release.
+- Tests cover direct descriptors, registry/state validation, target conversion,
+  path limits, alias rejection, and offline operation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,3 +46,4 @@ is defined by the architecture, guides, package APIs, and acceptance tests.
 | [0037](0037-typed-connector-definitions.md) | Typed connector definitions with explicit port injection | Accepted | 2026-08-22 |
 | [0038](0038-guided-openapi-capability-import.md) | Guided OpenAPI capability import | Accepted | 2026-08-21 |
 | [0039](0039-configurable-mcp-http-mount-path.md) | Configurable MCP HTTP mount path | Accepted | 2026-09-02 |
+| [0040](0040-installer-mounted-mcp-urls.md) | Installer support for mounted MCP URLs | Accepted | 2026-09-05 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -340,7 +340,9 @@ reviewed bundled descriptor, an explicitly selected project-local
 URL. It MUST NOT discover remote servers, download or load packages, reflect on
 or execute an engine, start a transport, call a capability, or open a network
 connection. Local manifests and persisted state contain environment variable
-names but no environment values or credentials.
+names but no environment values or credentials. Remote URLs preserve the complete
+canonical MCP mount path from ADRs 0039 and 0040, including through registry,
+client configuration, and managed-state validation.
 
 **AE-INSTALL-02 — Confirmed user scope.** Installation targets only the finite
 catalog of supported default user configurations. All compatible eligible

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -1,6 +1,6 @@
 # Validation record
 
-- Last reviewed: 2026-09-04
+- Last reviewed: 2026-09-05
 - Public API changes: standalone atomic capability and capability-library
   creators accepted in ADR 0014; engine and capability-library agent
   instruction aliases accepted in ADR 0015; generated development skills
@@ -23,7 +23,8 @@
   accepted in ADR 0035; engine-owned outbound connectors accepted in ADR 0036;
   typed connector definitions accepted in ADR 0037; guided OpenAPI
   capability import accepted in ADR 0038; and the configurable MCP HTTP
-  mount path accepted in ADR 0039.
+  mount path accepted in ADR 0039; installer support for those mounted URLs
+  accepted in ADR 0040.
 - Architectural conventions: ADR 0036 defines engine-owned outbound connectors;
   ADR 0037 adds their optional typed core authoring definition without changing
   capability contracts, the error-code taxonomy, or the execution path.
@@ -50,10 +51,10 @@ consumer can use the protocol surface without coupling to engine code.
 
 ## Current delivery gates
 
-- `yarn run check` on Node.js 24.20.0 and npm 11.19.0 passes typecheck, lint,
-  formatting, 3,145 tests with one intentional skip, V8 coverage, and the full
-  TypeScript build. Coverage is 78.95% statements, 74.34% branches, 83.45%
-  functions, and 80.67% lines.
+- `yarn run check` on Node.js 24.20.0 and Yarn 1.22.22 passes typecheck, lint,
+  formatting, 3,178 tests with one intentional skip, V8 coverage, and the full
+  TypeScript build. Coverage is 78.92% statements, 74.29% branches, 83.45%
+  functions, and 80.63% lines.
 - `yarn release:verify` passes metadata alignment and clean tarball inspection
   for all 10 public packages, isolated ESM imports, all four packed engine
   profiles, authenticated MCP HTTP exchange, DevTools doctor checks, and the
@@ -135,3 +136,19 @@ The examples validate framework reuse; they do not claim provider quality,
 production identity assurance, evaluation coverage, cost control, incident
 readiness, privacy compliance, or safety for a particular domain. Those claims
 require evidence from the engine and its deployment environment.
+
+## Mounted installer URLs (ADR 0040)
+
+Issue #75 was reproduced with `install --http brain` and a Gateway resource at
+`http://127.0.0.1:3100/e/brain/mcp`. Test-first validation found seven failures in
+remote-source/registry/state acceptance and six in target inverse conversion.
+After the shared URL validator change, all 698 installer tests passed, followed
+by the full repository gate and the documentation application's validation.
+
+The exact `npx @invokta/installer install --http brain` command was also exercised
+from the rebuilt source checkout against that URL. It reached client selection;
+the smoke test cancelled before confirmation or configuration writes. The live
+endpoint returned the expected OAuth 401 challenge and its path-specific RFC 9728
+metadata. No capability was invoked and no OAuth credentials were acquired.
+This verifies the source build; npm release 0.8.1 is unchanged and still rejects
+mounted endpoints.

--- a/packages/installer/src/installer-state.ts
+++ b/packages/installer/src/installer-state.ts
@@ -1,3 +1,4 @@
+import { validateRemoteMcpUrl } from "./remote-mcp-url.js";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -305,51 +306,7 @@ function validateStringArray(
 }
 
 function validateUrl(value: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  if (parsed.username !== "" || parsed.password !== "") return false;
-  const schemeSeparator = value.indexOf("://");
-  if (schemeSeparator <= 0) return false;
-  const authorityTail = value.slice(schemeSeparator + 3);
-  const authorityEnd = authorityTail.search(/[/?#]/u);
-  const authority = authorityTail.slice(
-    0,
-    authorityEnd === -1 ? undefined : authorityEnd,
-  );
-  const rawTarget =
-    authorityEnd === -1 ? "" : authorityTail.slice(authorityEnd);
-  const queryOrFragment = rawTarget.search(/[?#]/u);
-  const rawPath = rawTarget.slice(
-    0,
-    queryOrFragment === -1 ? undefined : queryOrFragment,
-  );
-  const rawHost = authority.startsWith("[")
-    ? authority.slice(0, authority.indexOf("]") + 1)
-    : authority.split(":", 1)[0];
-  if (
-    authority === "" ||
-    authority.includes("@") ||
-    parsed.hostname === "" ||
-    rawPath !== "/mcp" ||
-    parsed.pathname !== "/mcp" ||
-    value.includes("?") ||
-    value.includes("#")
-  ) {
-    return false;
-  }
-  if (
-    parsed.protocol === "http:" &&
-    rawHost !== "127.0.0.1" &&
-    rawHost !== "[::1]"
-  ) {
-    return false;
-  }
-  return true;
+  return validateRemoteMcpUrl(value).url !== undefined;
 }
 
 function validateAuthentication(

--- a/packages/installer/src/registry.ts
+++ b/packages/installer/src/registry.ts
@@ -1,3 +1,4 @@
+import { validateRemoteMcpUrl } from "./remote-mcp-url.js";
 import type { InstallerFileSystem } from "./file-system.js";
 import { InstallerError } from "./installer-error.js";
 
@@ -413,58 +414,8 @@ function validateUrl(
   path: JsonPath,
   issues: RegistryIssue[],
 ): void {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    addIssue(issues, path, "INVALID_URL");
-    return;
-  }
-  const schemeSeparator = value.indexOf("://");
-  if (schemeSeparator <= 0) {
-    addIssue(issues, path, "INVALID_URL");
-    return;
-  }
-  const authorityStart = schemeSeparator + 3;
-  const authorityTail = value.slice(authorityStart);
-  const authorityEnd = authorityTail.search(/[/?#]/u);
-  const authority = authorityTail.slice(
-    0,
-    authorityEnd === -1 ? undefined : authorityEnd,
-  );
-  const rawTarget =
-    authorityEnd === -1 ? "" : authorityTail.slice(authorityEnd);
-  const queryOrFragment = rawTarget.search(/[?#]/u);
-  const rawPath = rawTarget.slice(
-    0,
-    queryOrFragment === -1 ? undefined : queryOrFragment,
-  );
-  const rawHost = authority.startsWith("[")
-    ? authority.slice(0, authority.indexOf("]") + 1)
-    : authority.split(":", 1)[0];
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    addIssue(issues, path, "INVALID_URL");
-  }
-  if (authority.includes("@") || url.username !== "" || url.password !== "") {
-    addIssue(issues, path, "CREDENTIAL_URL");
-  }
-  if (
-    authority === "" ||
-    url.hostname === "" ||
-    rawPath !== "/mcp" ||
-    url.pathname !== "/mcp" ||
-    value.includes("?") ||
-    value.includes("#")
-  ) {
-    addIssue(issues, path, "INVALID_URL");
-  }
-  if (
-    url.protocol === "http:" &&
-    rawHost !== "127.0.0.1" &&
-    rawHost !== "[::1]"
-  ) {
-    addIssue(issues, path, "INSECURE_URL");
-  }
+  for (const code of validateRemoteMcpUrl(value).issues)
+    addIssue(issues, path, code);
 }
 
 function validateAuthentication(

--- a/packages/installer/src/remote-install-source.ts
+++ b/packages/installer/src/remote-install-source.ts
@@ -1,3 +1,4 @@
+import { validateRemoteMcpUrl } from "./remote-mcp-url.js";
 import { InstallerError } from "./installer-error.js";
 import type { CapabilityInstallDescriptor } from "./registry.js";
 
@@ -29,53 +30,9 @@ function invalid(cause?: unknown): never {
 }
 
 function canonicalUrl(value: string): string {
-  if (value.includes("\0")) return invalid();
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch (cause) {
-    return invalid(cause);
-  }
-  const schemeSeparator = value.indexOf("://");
-  if (schemeSeparator <= 0) return invalid();
-  const authorityTail = value.slice(schemeSeparator + 3);
-  const authorityEnd = authorityTail.search(/[/?#]/u);
-  const authority = authorityTail.slice(
-    0,
-    authorityEnd === -1 ? undefined : authorityEnd,
-  );
-  const rawTarget =
-    authorityEnd === -1 ? "" : authorityTail.slice(authorityEnd);
-  const queryOrFragment = rawTarget.search(/[?#]/u);
-  const rawPath = rawTarget.slice(
-    0,
-    queryOrFragment === -1 ? undefined : queryOrFragment,
-  );
-  const rawHost = authority.startsWith("[")
-    ? authority.slice(0, authority.indexOf("]") + 1)
-    : authority.split(":", 1)[0];
-  if (
-    (url.protocol !== "https:" && url.protocol !== "http:") ||
-    authority === "" ||
-    authority.includes("@") ||
-    url.hostname === "" ||
-    url.username !== "" ||
-    url.password !== "" ||
-    rawPath !== "/mcp" ||
-    url.pathname !== "/mcp" ||
-    value.includes("?") ||
-    value.includes("#")
-  ) {
-    return invalid();
-  }
-  if (
-    url.protocol === "http:" &&
-    rawHost !== "127.0.0.1" &&
-    rawHost !== "[::1]"
-  ) {
-    return invalid();
-  }
-  return url.href;
+  const result = validateRemoteMcpUrl(value);
+  if (result.url === undefined) return invalid();
+  return result.url;
 }
 
 function headersFromEnvironment(

--- a/packages/installer/src/remote-mcp-url.ts
+++ b/packages/installer/src/remote-mcp-url.ts
@@ -1,0 +1,81 @@
+/** One offline URL contract for remote sources, registry, managed state, and adapters. */
+export type RemoteMcpUrlIssue =
+  | "INVALID_URL"
+  | "CREDENTIAL_URL"
+  | "INSECURE_URL";
+
+export interface RemoteMcpUrlValidation {
+  readonly url: string | undefined;
+  readonly issues: readonly RemoteMcpUrlIssue[];
+}
+
+/** ADRs 0039 and 0040: unreserved ASCII segments, at most 256 bytes, ending in mcp. */
+function canonicalPath(value: string): boolean {
+  if (value.length > 256 || !value.startsWith("/")) return false;
+  const segments = value.slice(1).split("/");
+  return (
+    segments.at(-1) === "mcp" &&
+    segments.every(
+      (segment) =>
+        /^[A-Za-z0-9._~-]+$/u.test(segment) &&
+        segment !== "." &&
+        segment !== "..",
+    )
+  );
+}
+
+function hasUnsafeCharacters(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 32 || code === 127 || character === "\\") return true;
+  }
+  return false;
+}
+
+export function validateRemoteMcpUrl(value: string): RemoteMcpUrlValidation {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return { url: undefined, issues: ["INVALID_URL"] };
+  }
+  const schemeSeparator = value.indexOf("://");
+  if (schemeSeparator <= 0) return { url: undefined, issues: ["INVALID_URL"] };
+  const authorityTail = value.slice(schemeSeparator + 3);
+  const authorityEnd = authorityTail.search(/[/?#]/u);
+  const authority = authorityTail.slice(
+    0,
+    authorityEnd === -1 ? undefined : authorityEnd,
+  );
+  const rawTarget =
+    authorityEnd === -1 ? "" : authorityTail.slice(authorityEnd);
+  const queryOrFragment = rawTarget.search(/[?#]/u);
+  const rawPath = rawTarget.slice(
+    0,
+    queryOrFragment === -1 ? undefined : queryOrFragment,
+  );
+  const rawHost = authority.startsWith("[")
+    ? authority.slice(0, authority.indexOf("]") + 1)
+    : authority.split(":", 1)[0];
+  const issues: RemoteMcpUrlIssue[] = [];
+  if (authority.includes("@") || url.username !== "" || url.password !== "")
+    issues.push("CREDENTIAL_URL");
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    authority === "" ||
+    url.hostname === "" ||
+    !canonicalPath(rawPath) ||
+    url.pathname !== rawPath ||
+    hasUnsafeCharacters(value) ||
+    value.includes("?") ||
+    value.includes("#")
+  )
+    issues.push("INVALID_URL");
+  if (
+    url.protocol === "http:" &&
+    rawHost !== "127.0.0.1" &&
+    rawHost !== "[::1]"
+  )
+    issues.push("INSECURE_URL");
+  return { url: issues.length === 0 ? url.href : undefined, issues };
+}

--- a/packages/installer/src/target-adapters.ts
+++ b/packages/installer/src/target-adapters.ts
@@ -1,3 +1,4 @@
+import { validateRemoteMcpUrl } from "./remote-mcp-url.js";
 import { InstallerError } from "./installer-error.js";
 import type { SuspendedDescriptor } from "./installer-state.js";
 import {
@@ -249,53 +250,7 @@ function portableCompatibility(): { readonly supported: true } {
 }
 
 function validPortableMcpUrl(value: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return false;
-  }
-  if (parsed.username !== "" || parsed.password !== "") return false;
-  const schemeSeparator = value.indexOf("://");
-  if (schemeSeparator <= 0) return false;
-  const authorityTail = value.slice(schemeSeparator + 3);
-  const authorityEnd = authorityTail.search(/[/?#]/u);
-  const authority = authorityTail.slice(
-    0,
-    authorityEnd === -1 ? undefined : authorityEnd,
-  );
-  const rawTarget =
-    authorityEnd === -1 ? "" : authorityTail.slice(authorityEnd);
-  const queryOrFragment = rawTarget.search(/[?#]/u);
-  const rawPath = rawTarget.slice(
-    0,
-    queryOrFragment === -1 ? undefined : queryOrFragment,
-  );
-  const rawHost = authority.startsWith("[")
-    ? authority.slice(0, authority.indexOf("]") + 1)
-    : authority.split(":", 1)[0];
-  if (
-    authority === "" ||
-    authority.includes("@") ||
-    parsed.hostname === "" ||
-    rawPath !== "/mcp" ||
-    parsed.pathname !== "/mcp" ||
-    value.includes("?") ||
-    value.includes("#")
-  ) {
-    return false;
-  }
-  if (
-    parsed.protocol === "http:" &&
-    rawHost !== "127.0.0.1" &&
-    rawHost !== "[::1]"
-  ) {
-    return false;
-  }
-  return true;
+  return validateRemoteMcpUrl(value).url !== undefined;
 }
 
 const environmentNamePattern = /^[A-Z_][A-Z0-9_]{0,127}$/u;

--- a/packages/installer/test/installer-state.test.ts
+++ b/packages/installer/test/installer-state.test.ts
@@ -539,6 +539,14 @@ describe("installer state validation", () => {
 
   it.each([
     ["https://example.com/mcp", true],
+    ["http://127.0.0.1:3100/e/brain/mcp", true],
+    ["https://gateway.example.com/e/brain/mcp", true],
+    [`https://gateway.example.com/${"a".repeat(251)}/mcp`, true],
+    [`https://gateway.example.com/${"a".repeat(252)}/mcp`, false],
+    ["https://gateway.example.com/e//brain/mcp", false],
+    ["https://gateway.example.com/e/./brain/mcp", false],
+    ["https://gateway.example.com/e/%62rain/mcp", false],
+    ["https://gateway.example.com/e/brain/mcp/", false],
     ["http://127.0.0.1/mcp", true],
     ["http://[::1]/mcp", true],
     ["https:///mcp", false],

--- a/packages/installer/test/registry.test.ts
+++ b/packages/installer/test/registry.test.ts
@@ -101,6 +101,16 @@ function expectIssue(
 }
 
 describe("local capability registry", () => {
+  it("accepts mounted endpoints without changing their resource identity", () => {
+    const entry = httpEntry();
+    entry.server.transport.url = "http://127.0.0.1:3100/e/brain/mcp";
+    const result = validate(document([entry])).result;
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected a valid mounted endpoint.");
+    expect(
+      result.registry.entries[0]?.descriptor.server.transport,
+    ).toMatchObject({ url: entry.server.transport.url });
+  });
   it("defines exactly the eleven compatibility targets", () => {
     expect(configurationTargetIds).toEqual([
       "antigravity",

--- a/packages/installer/test/remote-install-source.test.ts
+++ b/packages/installer/test/remote-install-source.test.ts
@@ -13,6 +13,40 @@ function expectRemoteInvalid(operation: () => unknown): void {
 }
 
 describe("remote MCP installation source", () => {
+  it.each([
+    "http://127.0.0.1:3100/e/brain/mcp",
+    "http://[::1]:3100/e/brain/mcp",
+    "https://gateway.example.com/e/brain/mcp",
+    `https://gateway.example.com/${"a".repeat(251)}/mcp`,
+  ])("accepts the canonical mounted endpoint %s", (url) => {
+    expect(
+      createRemoteInstallDescriptor({ serverName: "brain", url }).server
+        .transport,
+    ).toMatchObject({ url });
+  });
+  it.each([
+    "/e/brain/mcp/",
+    "/e//brain/mcp",
+    "/e/./brain/mcp",
+    "/e/other/../brain/mcp",
+    "/e/%62rain/mcp",
+    "/e/brain%2fmcp",
+    "/e/brain/MCP",
+    "/e/brain/tools",
+    `/e/${"a".repeat(252)}/mcp`,
+    "/e/bráin/mcp",
+    "/e/brain/mcp?",
+    "/e/brain/mcp#",
+    "/e/brain/mcp\n",
+    "/e\\brain/mcp",
+  ])("rejects a mounted URL alias or unsupported path %s", (path) => {
+    expectRemoteInvalid(() =>
+      createRemoteInstallDescriptor({
+        serverName: "brain",
+        url: `https://gateway.example.com${path}`,
+      }),
+    );
+  });
   it("normalizes an HTTPS descriptor using environment references only", () => {
     const fetchBefore = globalThis.fetch;
     const fetchSpy = vi.fn();

--- a/packages/installer/test/target-adapters.test.ts
+++ b/packages/installer/test/target-adapters.test.ts
@@ -70,6 +70,59 @@ function credentialFreeHttpDescriptor(): CapabilityInstallDescriptor {
   };
 }
 
+describe("mounted MCP URLs", () => {
+  it.each([
+    "codex",
+    "hermes",
+    "openclaw",
+    "cursor",
+    "claude-code",
+    "vscode",
+  ] as const)(
+    "round-trips a mounted endpoint in %s configuration",
+    (targetId) => {
+      const adapter = configurationTargetAdapters[targetId];
+      const base = credentialFreeHttpDescriptor();
+      const descriptor: CapabilityInstallDescriptor = {
+        ...base,
+        server: {
+          ...base.server,
+          transport: {
+            type: "streamable-http",
+            url: "http://127.0.0.1:3100/e/brain/mcp",
+            authentication: { type: "none" },
+            headersFromEnv: {},
+          },
+        },
+      };
+      const definition = adapter.descriptorToDefinition(descriptor);
+      expect(
+        adapter.definitionToSuspendedDescriptor(
+          descriptor.server.name,
+          definition,
+        ),
+      ).toEqual(descriptor.server);
+      const patch = adapter.constructPatch({
+        action: "install",
+        definition,
+        inspection: adapter.inspect({
+          source: undefined,
+          serverName: descriptor.server.name,
+        }),
+      });
+      expect(patch.kind).toBe("changed");
+      if (patch.kind !== "changed")
+        throw new Error("Expected a changed patch.");
+      expect(
+        adapter.inspect({
+          source: patch.postImage,
+          serverName: descriptor.server.name,
+        }).currentServer,
+      ).toEqual({ kind: "present", definition });
+    },
+  );
+});
+
 function install(
   targetId: "codex" | "hermes" | "openclaw",
   descriptor: CapabilityInstallDescriptor,


### PR DESCRIPTION
The installer rejects valid engine URLs such as `/e/brain/mcp` with `REMOTE_INVALID`, even though ADR 0039 allows the MCP adapter to publish them. This change preserves the full canonical mounted URL through remote installation, registry validation, persisted state, and target configuration conversion using one internal validator. Existing HTTPS, literal-loopback HTTP, credential, alias, and write-confirmation rules remain in force.

ADR 0040 records the additive installer contract and the reference documents its release boundary. This source change does not publish a new npm version.

Validation:

- RED: seven failures in source/registry/state acceptance and six failures in target inverse conversion.
- GREEN: all 698 installer tests; full `yarn run check` on Node 24.20.0 (3,178 passing tests, one intentional skip, coverage, types, lint, formatting, build, and 19 example gates).
- `apps/docs`: `yarn validate` passed 15 tests, zero Astro diagnostics, and the 49-page build.
- The original `npx` command from the rebuilt source checkout reached client selection; the smoke test cancelled before configuration writes. The live Gateway endpoint returned its expected OAuth challenge and path-specific resource metadata.

Fixes #75.
