### PR TITLE
chore(release): prepare 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-09-05
+
 ### Fixed
 
 - The installer accepts canonical mounted MCP URLs such as `/e/brain/mcp`
@@ -475,7 +477,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/vinilana/invokta/releases/tag/v0.8.2
 [0.8.1]: https://github.com/vinilana/invokta/releases/tag/v0.8.1
 [0.8.0]: https://github.com/vinilana/invokta/releases/tag/v0.8.0
 [0.7.0]: https://github.com/vinilana/invokta/releases/tag/v0.7.0

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -184,9 +184,13 @@ Literal `127.0.0.1` and `[::1]` HTTP origins are accepted for local development.
 User information, query strings, fragments, embedded credentials, percent encoding,
 and other noncanonical paths are rejected.
 
-Mounted paths require a build containing ADR 0040. The published installer 0.8.1
-still accepts only `/mcp`; from an updated source checkout, build with `yarn build`
-and run `node packages/installer/dist/cli.js install --http brain <url>`.
+Mounted paths require installer 0.8.2 or later (ADR 0040). Version 0.8.1
+and earlier accept only `/mcp`. To select the compatible release explicitly:
+
+```sh
+npx @invokta/installer@0.8.2 install --http brain http://127.0.0.1:3100/e/brain/mcp
+```
+
 The installer registers the URL; the selected client handles OAuth when it connects.
 
 Authentication and header options name environment variables; they never read

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -53,8 +53,8 @@ consumer can use the protocol surface without coupling to engine code.
 
 - `yarn run check` on Node.js 24.20.0 and Yarn 1.22.22 passes typecheck, lint,
   formatting, 3,178 tests with one intentional skip, V8 coverage, and the full
-  TypeScript build. Coverage is 78.92% statements, 74.29% branches, 83.45%
-  functions, and 80.63% lines.
+  TypeScript build, followed by 19 example gates. Coverage is 78.92% statements,
+  74.30% branches, 83.45% functions, and 80.63% lines.
 - `yarn release:verify` passes metadata alignment and clean tarball inspection
   for all 10 public packages, isolated ESM imports, all four packed engine
   profiles, authenticated MCP HTTP exchange, DevTools doctor checks, and the
@@ -150,5 +150,18 @@ from the rebuilt source checkout against that URL. It reached client selection;
 the smoke test cancelled before confirmation or configuration writes. The live
 endpoint returned the expected OAuth 401 challenge and its path-specific RFC 9728
 metadata. No capability was invoked and no OAuth credentials were acquired.
-This verifies the source build; npm release 0.8.1 is unchanged and still rejects
-mounted endpoints.
+This initial smoke verified the source build. Installer 0.8.1 and earlier reject
+mounted endpoints; the compatible release is 0.8.2.
+
+## Release 0.8.2 preparation
+
+The release synchronizes all 10 public package versions, exact internal pins,
+example manifests, release assertions, and MCP client identification. The
+self-hosted OAuth example's committed lockfile uses integrity values derived
+from the matching locally packed artifacts. The changelog and installer
+reference identify 0.8.2 as the mounted-URL fix from ADR 0040.
+
+The full repository and documentation gates and both audits above were rerun
+for this release. These results establish local preparation evidence;
+publication requires the annotated release tag's successful GitHub Actions
+workflow and its protected npm environment approval.

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -54,7 +54,7 @@ consumer can use the protocol surface without coupling to engine code.
 - `yarn run check` on Node.js 24.20.0 and Yarn 1.22.22 passes typecheck, lint,
   formatting, 3,178 tests with one intentional skip, V8 coverage, and the full
   TypeScript build, followed by 19 example gates. Coverage is 78.92% statements,
-  74.30% branches, 83.45% functions, and 80.63% lines.
+  74.29% branches, 83.45% functions, and 80.63% lines.
 - `yarn release:verify` passes metadata alignment and clean tarball inspection
   for all 10 public packages, isolated ESM imports, all four packed engine
   profiles, authenticated MCP HTTP exchange, DevTools doctor checks, and the
@@ -165,3 +165,9 @@ The full repository and documentation gates and both audits above were rerun
 for this release. These results establish local preparation evidence;
 publication requires the annotated release tag's successful GitHub Actions
 workflow and its protected npm environment approval.
+
+The first release PR CI run exposed a 25 ms deadline in the existing session
+lock recovery test. The successful recovery path now uses the store's normal
+lock budget; the live-owner rejection still exercises the short deadline.
+The CI timeout is the RED evidence. All 14 session example tests and the full
+repository gate passed after this test-only correction, with the totals above.

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -20,14 +20,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/agent-session-engine/test/agent-session-engine.test.ts
+++ b/examples/agent-session-engine/test/agent-session-engine.test.ts
@@ -357,7 +357,12 @@ describe("the agent session engine example", () => {
       { mode: 0o600 },
     );
     await utimes(lockPath, oldTime, oldTime);
-    await expect(store.create(session)).resolves.toBe("created");
+    // Successful recovery includes filesystem syncs; use the normal lock budget.
+    const recoveryStore = createFileAgentSessionStore({
+      dataDirectory,
+      staleLockMs: 1,
+    });
+    await expect(recoveryStore.create(session)).resolves.toBe("created");
   });
 
   it("persists every schema-valid maximum-length session identifier", async () => {

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -14,12 +14,12 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1"
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.1",
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/deploy": "0.8.2",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -14,13 +14,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1"
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2"
   }
 }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -14,14 +14,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -14,14 +14,14 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.1",
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1"
+    "@invokta/deploy": "0.8.2",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2"
   }
 }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -13,12 +13,12 @@
     "devtools:doctor": "tsc -b --pretty false && invokta-devtools doctor dist/engine.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1"
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.1",
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/deploy": "0.8.2",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.8.1",
-        "@invokta/core": "0.8.1",
-        "@invokta/installer": "0.8.1",
-        "@invokta/mcp": "0.8.1",
+        "@invokta/cli": "0.8.2",
+        "@invokta/core": "0.8.2",
+        "@invokta/installer": "0.8.2",
+        "@invokta/mcp": "0.8.2",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,8 +21,8 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.8.1",
-        "@invokta/devtools": "0.8.1",
+        "@invokta/deploy": "0.8.2",
+        "@invokta/devtools": "0.8.2",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -83,21 +83,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.8.1.tgz",
-      "integrity": "sha512-5I9rooNrS0rlTKQLrHiBXEnb7gjubA1Tladx29xopDbI7N6FXakMBPLKDhs4vhAcYSk+eZRSFmrNLMLal6Uk7w==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.8.2.tgz",
+      "integrity": "sha512-NmA7FHA1IPgCPGPfepUEE1t33H9ThI4We8zhUjxdbtDBO09HZ6g5oUGNzwZf1+bR6cCOhYU3oBcIiQv6jOcyvA==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.1"
+        "@invokta/core": "0.8.2"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.8.1.tgz",
-      "integrity": "sha512-VIoQ4rSzfWUg+p78mUnkGlO5mASNbHjezchq8X8FedBCvA7vBujywQUsvaQtZGXwPWpFVLao6p88NY9hP358tQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.8.2.tgz",
+      "integrity": "sha512-8Xu28k9MUHYIPCq4UJ4rkYz1aoyWoInP38nJqiLvFpNw7Iejz5SnXbjcBrplMOYYutQO8p8Z6y0y5a9c2OI5wA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.1.tgz",
-      "integrity": "sha512-/uh6w/cbx52/kO5CcbfS/LpjvpdcqEwCE2kaze6MFI9ApjqelTPERJrDMjtMqmzjVMqIQjAsq2pxL7/PeaL34Q==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.2.tgz",
+      "integrity": "sha512-mcmOqRBgKE4l2c7/IYpW1bVuSyuVu8zjqEAp2QCCoJFCAkCNtXyKN8Jczh3HFTbaCyzAPbQYm0zbCsZqeTANrQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -120,15 +120,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.1.tgz",
-      "integrity": "sha512-xKGBljs0wf4QaXCXK7EepmVYrn0ayLAlDEOUR3gE0mKH5V4xqmM+d7yxms9nqsIhMhV9mu/Gnlw0vVN/jWioWA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.2.tgz",
+      "integrity": "sha512-9FbNzEnKArs49w7ig4ermF7Md0iUd1SkLIF04bCJPEQP5oNm5Xs/5xgZ403x6Asc19h7RqGOw3WQnuc/A8fDUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/cli": "0.8.1",
-        "@invokta/core": "0.8.1",
-        "@invokta/mcp": "0.8.1"
+        "@invokta/cli": "0.8.2",
+        "@invokta/core": "0.8.2",
+        "@invokta/mcp": "0.8.2"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.1.tgz",
-      "integrity": "sha512-Dv9a1+LBXjXMyGYHZQkaFnJCjUifNEnMx5XTWpJo1v1ZVi1vzK/vB0EhZ/L5NGKQuF6pGXbxiAMwVvcCxJ30qw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.2.tgz",
+      "integrity": "sha512-NaDTa1oI72r9Ee6x/RhxMoNUVTvDgqbjxF+NVT7L3JXVaA7swIpI6qoA95Qgst+TMem/hlW3NrZLNfNSCe90xA==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -156,12 +156,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.8.1.tgz",
-      "integrity": "sha512-Vp4CgT9glKhbVea131PTOQRL8+lM3qFOJbIfS5AFnC6OeEKI858l5jheiK6YKcjr01jnKk5FdItrbM/Ld6LlpQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.8.2.tgz",
+      "integrity": "sha512-u26e6px2Dadb+PzU6DaCpVrFNGyHDX7SCQEf1NlAdCUaDqw77wj1kFzSbMpGckneu4apVJVr+tttxbGAocuCjw==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.1",
+        "@invokta/core": "0.8.2",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -37,19 +37,19 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/installer": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/installer": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.1",
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/deploy": "0.8.2",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.1",
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/deploy": "0.8.2",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
+    "@invokta/core": "0.8.2",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -17,15 +17,15 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
+    "@invokta/devtools": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -18,13 +18,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1"
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
+    "@invokta/devtools": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
+    "@invokta/devtools": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -17,14 +17,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
+    "@invokta/devtools": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -16,14 +16,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1",
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1",
-    "@invokta/tooling": "0.8.1",
+    "@invokta/devtools": "0.8.2",
+    "@invokta/tooling": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-harness/package.json
+++ b/examples/support-harness/package.json
@@ -13,6 +13,6 @@
     "@modelcontextprotocol/sdk": "1.30.0"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.1"
+    "@invokta/devtools": "0.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1"
+    "@invokta/core": "0.8.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Typed capability and connector contracts with the execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.8.1",
+    "@invokta/deploy": "0.8.2",
     "tar": "7.5.22",
     "yaml": "2.9.0"
   }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.8.1",
+      "@invokta/deploy": "0.8.2",
       tar: "7.5.22",
       yaml: "2.9.0",
     });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Local MCP and CLI workbenches, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.1",
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1"
+    "@invokta/cli": "0.8.2",
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2"
   }
 }

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.8.1",
+      version: "0.8.2",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
+    "@invokta/core": "0.8.2",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.8.1";
+const CLIENT_VERSION = "0.8.2";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.1",
-    "@invokta/mcp": "0.8.1"
+    "@invokta/core": "0.8.2",
+    "@invokta/mcp": "0.8.2"
   }
 }


### PR DESCRIPTION
Installer 0.8.1 rejects Gateway resource URLs such as `/e/brain/mcp` with `REMOTE_INVALID`. This patch release ships the mounted-URL fix from #76 and ADR 0040 while preserving the existing transport, credential, and authentication rules.

All ten public packages, internal dependency pins, example manifests, release assertions, and MCP client identification are aligned to 0.8.2. The changelog records the fix and the installer reference provides the versioned command. The committed example lockfile uses integrity hashes from the exact local tarballs, rechecked after the full build.

Validation on Node.js 24.20.0 and Yarn 1.22.22:

- Full repository gate: 3,178 tests passed, one intentional skip, coverage, types, lint, formatting, build, and 19 example gates.
- Windows archive-path regression gate: 31 tests passed.
- Documentation: 15 tests, zero Astro diagnostics, and 49 pages built.
- Root and documentation audits: zero vulnerabilities across 307 and 537 packages.
- All ten package dry-runs and the staged release verifier passed, including isolated consumers and generated engine profiles.

The first CI run exposed an existing 25 ms deadline in the session lock recovery test. Its successful recovery now uses the normal store timeout, while the live-owner rejection keeps the short deadline. All 14 focused tests and the full repository gate passed after this test-only stabilization. Installer regression coverage was delivered in #76. After merge, publication uses the annotated v0.8.2 tag and the protected GitHub Actions npm environment.
