### PR TITLE
fix(examples): align OAuth lockfile with published 0.8.2 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- The self-hosted OAuth example's lockfile includes `@invokta/tooling` and the
+  published 0.8.2 tarball integrity values, restoring clean `npm ci` installs.
+
 ## [0.8.2] - 2026-09-05
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,6 +65,9 @@ dry-runs. It does not require npm authentication and makes no registry change.
 
 ## Recovering a partial release
 
+When npm accepts a package but reports that it is still being processed, wait
+until its version and `gitHead` are readable before rerunning the workflow.
+
 npm package publication is irreversible and a ten-package release is not an
 atomic registry operation. If a publish job stops after creating a partial
 release, rerun the failed GitHub Actions workflow. The publication script skips
@@ -77,3 +80,15 @@ move `latest` backward, or recover a version that was previously published under
 a different dist-tag. Do not publish or repair a stable release from a local
 workstation; use the protected workflow so the OIDC identity and audit trail are
 preserved.
+
+## Example lockfile integrity
+
+Derive pre-release integrity values from artifacts built in a clean throwaway
+checkout. A workspace installation can mark generated command files executable,
+changing tarball hashes even when their contents match the CI build. Compare
+file modes as well as contents when investigating an integrity mismatch.
+
+After publication, verify every locked Invokta dependency against the registry's
+`dist.integrity` and run `npm ci --ignore-scripts --no-audit --no-fund` in an
+isolated copy of the example's manifest and lockfile. This also detects declared
+dependencies missing from the lockfile.

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -171,3 +171,15 @@ lock recovery test. The successful recovery path now uses the store's normal
 lock budget; the live-owner rejection still exercises the short deadline.
 The CI timeout is the RED evidence. All 14 session example tests and the full
 repository gate passed after this test-only correction, with the totals above.
+
+## Release 0.8.2 example lockfile follow-up
+
+Registry verification found that three local tarballs had executable command
+file modes while CI's tarballs used regular file modes. Every archived file's
+content matched, but the different modes changed the installer, deploy, and
+devtools integrity hashes. The example lockfile now uses the published hashes.
+
+An isolated `npm ci` also exposed the missing `@invokta/tooling@0.8.2` entry.
+After synchronizing that entry with the manifest, `npm ci --ignore-scripts
+--no-audit --no-fund` installed all 211 packages successfully. This follow-up
+changes example metadata and release guidance, not the published packages.

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@invokta/deploy": "0.8.2",
         "@invokta/devtools": "0.8.2",
+        "@invokta/tooling": "0.8.2",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -109,7 +110,7 @@
     "node_modules/@invokta/deploy": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.2.tgz",
-      "integrity": "sha512-mcmOqRBgKE4l2c7/IYpW1bVuSyuVu8zjqEAp2QCCoJFCAkCNtXyKN8Jczh3HFTbaCyzAPbQYm0zbCsZqeTANrQ==",
+      "integrity": "sha512-0FCmwUIaY/K1drUvMClJiSbSv8CayEku8oM6McF0YsmbYXnYcDDp3zU3Hprg00yPnFRw8FBQi9CfUSU0ef26mQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -122,7 +123,7 @@
     "node_modules/@invokta/devtools": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.2.tgz",
-      "integrity": "sha512-9FbNzEnKArs49w7ig4ermF7Md0iUd1SkLIF04bCJPEQP5oNm5Xs/5xgZ403x6Asc19h7RqGOw3WQnuc/A8fDUQ==",
+      "integrity": "sha512-sMR6BvGwX5bEn34lIu0aAedC5cQ8rkHBqUXq1luutOiDFEHJlwCwiK1dFQ5pBEEOE3Bh2FTvCvvWHZs16KWiFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -140,7 +141,7 @@
     "node_modules/@invokta/installer": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.2.tgz",
-      "integrity": "sha512-NaDTa1oI72r9Ee6x/RhxMoNUVTvDgqbjxF+NVT7L3JXVaA7swIpI6qoA95Qgst+TMem/hlW3NrZLNfNSCe90xA==",
+      "integrity": "sha512-GxrUbQwLe0xaIj/LM6uJQ98RAyV2L3RSYVPgeE0H1iRf8l6mV9gwCyeGEkHuonlmV1cdfOXO8tAVm4IL6beEzQ==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -163,6 +164,23 @@
       "dependencies": {
         "@invokta/core": "0.8.2",
         "@modelcontextprotocol/sdk": "1.30.0"
+      },
+      "engines": {
+        "node": ">=22.20.0"
+      }
+    },
+    "node_modules/@invokta/tooling": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@invokta/tooling/-/tooling-0.8.2.tgz",
+      "integrity": "sha512-t7hYx6rEbRBPCnshbyUOtBNP5D9gMBh+Q6e4hMD+SQDxbpROqCOiDSbUdXuOXIE7syZp2qsrMOUz0VmiTyI25A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@invokta/core": "0.8.2",
+        "@invokta/mcp": "0.8.2"
+      },
+      "bin": {
+        "invokta": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.20.0"


### PR DESCRIPTION
The self-hosted OAuth example's lockfile was missing `@invokta/tooling` and contained three integrity hashes calculated from local tarballs whose command files had different executable modes from the published artifacts. Clean `npm ci` installs now use the complete dependency set and the published 0.8.2 hashes. Package file contents and published packages are unchanged.

Validation: registry and archive comparison identified the mode-only differences; an isolated `npm ci` reproduced the missing dependency, then passed with all 211 packages after synchronization. Formatting and diff checks passed. The changelog, validation record, and release guidance document the correction and future clean-checkout verification.
