### PR TITLE
chore(release): prepare 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-05
+
 ### Added
 
 - Interactive `remove` supports selecting multiple managed installations, with
@@ -17,7 +19,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 
 - The self-hosted OAuth example's lockfile includes `@invokta/tooling` and the
-  published 0.8.2 tarball integrity values, restoring clean `npm ci` installs.
+  matching release tarball integrity values, restoring clean `npm ci` installs.
 
 ## [0.8.2] - 2026-09-05
 
@@ -489,7 +491,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The deploy toolkit generates reviewable artifacts but does not build images or
   deploy them to a hosting provider.
 
-[Unreleased]: https://github.com/vinilana/invokta/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/vinilana/invokta/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/vinilana/invokta/releases/tag/v0.9.0
 [0.8.2]: https://github.com/vinilana/invokta/releases/tag/v0.8.2
 [0.8.1]: https://github.com/vinilana/invokta/releases/tag/v0.8.1
 [0.8.0]: https://github.com/vinilana/invokta/releases/tag/v0.8.0

--- a/apps/docs/src/content/docs/reference/installer.mdx
+++ b/apps/docs/src/content/docs/reference/installer.mdx
@@ -237,9 +237,12 @@ owned server entries and state records, preserving other installations and the
 surrounding client configuration. It reports each result and continues if an
 individual removal fails; successful removals remain committed.
 
-Multiple selection requires a build containing ADR 0041. The published installer
-0.8.2 still selects one entry at a time. From an updated Invokta source checkout,
-run `yarn build`, then `node packages/installer/dist/cli.js remove`.
+Multiple selection requires installer 0.9.0 or later (ADR 0041). Version 0.8.2
+and earlier select one entry at a time. To use the release with multiple removal:
+
+```sh
+npx @invokta/installer@0.9.0 remove
+```
 
 An entry changed outside the installer is drift and is never overwritten or
 removed automatically. A different server using the same name is a conflict.

--- a/docs/validation-record.md
+++ b/docs/validation-record.md
@@ -56,17 +56,15 @@ consumer can use the protocol surface without coupling to engine code.
   formatting, 3,190 tests with one intentional skip, V8 coverage, and the full
   TypeScript build, followed by 19 example gates. Coverage is 79% statements,
   74.4% branches, 83.52% functions, and 80.71% lines.
-- `yarn release:verify` passed during 0.8.2 preparation: metadata alignment and
+- `yarn release:verify` passes for 0.9.0: metadata alignment and
   clean tarball inspection for all 10 public packages, isolated ESM imports,
   all four packed engine profiles, authenticated MCP HTTP exchange, DevTools
   doctor checks, and the
   atomic and capability-library creator smoke tests.
 - `yarn validate` in `apps/docs` passes 15 route and link contract tests, zero
   Astro diagnostics, and the 49-page production site build.
-- The 0.8.2 preparation audits reported zero vulnerabilities across 307 audited
-  root packages and 537 documentation packages. These audits and packed release
-  verification were not rerun for ADR 0041, which changes no dependencies or
-  release metadata.
+- The 0.9.0 preparation audits report zero vulnerabilities across 307 audited
+  root packages and 537 documentation packages.
 
 ## Boundaries exercised
 
@@ -212,6 +210,34 @@ pairs, and the single confirmation defaulted to No. Refusing returned exit
 status 0. SHA-256 comparisons proved all nine involved configuration and state
 files byte-identical afterward; no live installation was removed.
 
-This evidence covers the source build. Published installer 0.8.2 still removes
-one interactively selected installation per command; this feature does not
-change release versions or publish packages.
+This evidence initially covered the source build: published installer 0.8.2
+removes one interactively selected installation per command. The feature slice
+did not change release versions or publish packages; release 0.9.0 carries the
+multiple-selection behavior.
+
+## Release 0.9.0 preparation
+
+The release follows the repository's minor-version policy for added
+functionality. It synchronizes all 10 public versions, exact internal package
+and example pins, release assertions, and MCP client identification. The
+changelog and installer reference identify 0.9.0 as the multiple-removal
+release from ADR 0041. This preparation is metadata-only and adds no executable
+behavior, so it uses the documentation/tooling exception to a new RED test; the
+feature's RED/GREEN evidence remains recorded above.
+
+The full repository gate passes with 3,190 tests and one intentional skip, the
+coverage totals above, and 19 example gates. The documentation gate passes all
+15 tests, zero Astro diagnostics, and 49 built pages. Both dependency audits
+were rerun with the counts above. A clean throwaway checkout produced all 10
+release tarballs; the self-hosted OAuth example's seven locked Invokta packages
+use those artifacts' SHA-512 integrity values, derived before a workspace
+installation can alter generated command file modes. No dependency versions
+outside the Invokta package set changed.
+
+`yarn release:pack` passes all 10 package dry-runs. `yarn release:verify` passes
+from the staged release tree, including clean tarballs, isolated ESM imports,
+all four generated engine profiles, authenticated MCP HTTP, DevTools doctor,
+and atomic and capability-library consumers. Publication remains subject to
+the release PR CI, the annotated tag's Verify job, and the protected npm
+environment. Registry integrity and a clean example `npm ci` must be checked
+again after publication.

--- a/examples/agent-session-engine/package.json
+++ b/examples/agent-session-engine/package.json
@@ -20,14 +20,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-api-key-engine/package.json
+++ b/examples/auth-api-key-engine/package.json
@@ -14,12 +14,12 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2"
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0"
   }
 }

--- a/examples/auth-auth0-engine/package.json
+++ b/examples/auth-auth0-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.2",
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/deploy": "0.9.0",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-authjs-engine/package.json
+++ b/examples/auth-authjs-engine/package.json
@@ -14,13 +14,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2"
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0"
   }
 }

--- a/examples/auth-better-auth-engine/package.json
+++ b/examples/auth-better-auth-engine/package.json
@@ -14,14 +14,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-clerk-engine/package.json
+++ b/examples/auth-clerk-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-cognito-engine/package.json
+++ b/examples/auth-cognito-engine/package.json
@@ -14,14 +14,14 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.2",
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2"
+    "@invokta/deploy": "0.9.0",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0"
   }
 }

--- a/examples/auth-firebase-engine/package.json
+++ b/examples/auth-firebase-engine/package.json
@@ -13,12 +13,12 @@
     "devtools:doctor": "tsc -b --pretty false && invokta-devtools doctor dist/engine.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2"
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0"
   }
 }

--- a/examples/auth-jwt-bearer-engine/package.json
+++ b/examples/auth-jwt-bearer-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.2",
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/deploy": "0.9.0",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-self-hosted-oauth-engine/package-lock.json
+++ b/examples/auth-self-hosted-oauth-engine/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@invokta/example-auth-self-hosted-oauth",
       "version": "0.1.0",
       "dependencies": {
-        "@invokta/cli": "0.8.2",
-        "@invokta/core": "0.8.2",
-        "@invokta/installer": "0.8.2",
-        "@invokta/mcp": "0.8.2",
+        "@invokta/cli": "0.9.0",
+        "@invokta/core": "0.9.0",
+        "@invokta/installer": "0.9.0",
+        "@invokta/mcp": "0.9.0",
         "jose": "^6.2.8",
         "oidc-provider": "~9.11.3",
         "pg": "^8.16.3",
@@ -21,9 +21,9 @@
         "auth-self-hosted-oauth-engine": "dist/bin.js"
       },
       "devDependencies": {
-        "@invokta/deploy": "0.8.2",
-        "@invokta/devtools": "0.8.2",
-        "@invokta/tooling": "0.8.2",
+        "@invokta/deploy": "0.9.0",
+        "@invokta/devtools": "0.9.0",
+        "@invokta/tooling": "0.9.0",
         "@types/node": "26.1.2",
         "@types/oidc-provider": "^9.11.1",
         "@types/pg": "^8.15.5",
@@ -84,21 +84,21 @@
       }
     },
     "node_modules/@invokta/cli": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.8.2.tgz",
-      "integrity": "sha512-NmA7FHA1IPgCPGPfepUEE1t33H9ThI4We8zhUjxdbtDBO09HZ6g5oUGNzwZf1+bR6cCOhYU3oBcIiQv6jOcyvA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/cli/-/cli-0.9.0.tgz",
+      "integrity": "sha512-AM8BXmTZGnVDb2fXXiV+ZvNNJrGu5ivW2EnHrMN7slCjVP57AQgcKAElj2duFpQHZmGVxJRnos8/IkE8Rpwc4Q==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.2"
+        "@invokta/core": "0.9.0"
       },
       "engines": {
         "node": ">=22.20.0"
       }
     },
     "node_modules/@invokta/core": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.8.2.tgz",
-      "integrity": "sha512-8Xu28k9MUHYIPCq4UJ4rkYz1aoyWoInP38nJqiLvFpNw7Iejz5SnXbjcBrplMOYYutQO8p8Z6y0y5a9c2OI5wA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/core/-/core-0.9.0.tgz",
+      "integrity": "sha512-VaszvtktrH+xcyhOAOf4VGRyDMrO80/GCz8gixMR770cyfLQymUj7thquTFh9E+5Sf3xAlX8XFmgBf8n+UQ+qQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0"
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@invokta/deploy": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.8.2.tgz",
-      "integrity": "sha512-0FCmwUIaY/K1drUvMClJiSbSv8CayEku8oM6McF0YsmbYXnYcDDp3zU3Hprg00yPnFRw8FBQi9CfUSU0ef26mQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/deploy/-/deploy-0.9.0.tgz",
+      "integrity": "sha512-19lRVhfuNTKTyo1zgpftJsHai0QYyOjypja5z4+n87ifywJBm23nwFToBUtC8S4Ue6Q6D7FIsBZ6vfpit3SU/A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -121,15 +121,15 @@
       }
     },
     "node_modules/@invokta/devtools": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.8.2.tgz",
-      "integrity": "sha512-sMR6BvGwX5bEn34lIu0aAedC5cQ8rkHBqUXq1luutOiDFEHJlwCwiK1dFQ5pBEEOE3Bh2FTvCvvWHZs16KWiFg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/devtools/-/devtools-0.9.0.tgz",
+      "integrity": "sha512-jg68DmGAZ2CFT9cQ2nP6HB7SRtdmDGai0uwUDqymlU7RxEkFCkiOKIUQZ+Q8OxnvFirz3yQCpPbeLr2taG8wpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/cli": "0.8.2",
-        "@invokta/core": "0.8.2",
-        "@invokta/mcp": "0.8.2"
+        "@invokta/cli": "0.9.0",
+        "@invokta/core": "0.9.0",
+        "@invokta/mcp": "0.9.0"
       },
       "bin": {
         "invokta-devtools": "dist/cli.js"
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@invokta/installer": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.8.2.tgz",
-      "integrity": "sha512-GxrUbQwLe0xaIj/LM6uJQ98RAyV2L3RSYVPgeE0H1iRf8l6mV9gwCyeGEkHuonlmV1cdfOXO8tAVm4IL6beEzQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/installer/-/installer-0.9.0.tgz",
+      "integrity": "sha512-5BbG6LgcYTxmC2F55rb/EFHMwRaNFTue+DeYowe1IwtQLlu4BC3+GIqFUxe9L77QQZ3Iz4dN44SWZKplKNRuEA==",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.7.0",
@@ -157,12 +157,12 @@
       }
     },
     "node_modules/@invokta/mcp": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.8.2.tgz",
-      "integrity": "sha512-u26e6px2Dadb+PzU6DaCpVrFNGyHDX7SCQEf1NlAdCUaDqw77wj1kFzSbMpGckneu4apVJVr+tttxbGAocuCjw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/mcp/-/mcp-0.9.0.tgz",
+      "integrity": "sha512-ISgTPvs9V5eoq/4Fi/UkPsikID88z13r+K+0wuEjPoCJ9wZPe5qdpzvyUna49vYVT2bvdYvIF0BkSn32foYjzg==",
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.2",
+        "@invokta/core": "0.9.0",
         "@modelcontextprotocol/sdk": "1.30.0"
       },
       "engines": {
@@ -170,14 +170,14 @@
       }
     },
     "node_modules/@invokta/tooling": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@invokta/tooling/-/tooling-0.8.2.tgz",
-      "integrity": "sha512-t7hYx6rEbRBPCnshbyUOtBNP5D9gMBh+Q6e4hMD+SQDxbpROqCOiDSbUdXuOXIE7syZp2qsrMOUz0VmiTyI25A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@invokta/tooling/-/tooling-0.9.0.tgz",
+      "integrity": "sha512-ke+V2M6UEg7OYSbl3HKfEFY+R10wBHibi0A5icsuQ5uSKheGJ7H3snI6cqD5RaQYBY/SiyXspy+z5LaVgVx51w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@invokta/core": "0.8.2",
-        "@invokta/mcp": "0.8.2"
+        "@invokta/core": "0.9.0",
+        "@invokta/mcp": "0.9.0"
       },
       "bin": {
         "invokta": "dist/cli.js"

--- a/examples/auth-self-hosted-oauth-engine/package.json
+++ b/examples/auth-self-hosted-oauth-engine/package.json
@@ -37,19 +37,19 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/installer": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/installer": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.2.8",
     "oidc-provider": "~9.11.3",
     "pg": "^8.16.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.2",
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/deploy": "0.9.0",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@types/node": "26.1.2",
     "@types/oidc-provider": "^9.11.1",
     "@types/pg": "^8.15.5",

--- a/examples/auth-supabase-engine/package.json
+++ b/examples/auth-supabase-engine/package.json
@@ -13,14 +13,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/auth-workos-engine/package.json
+++ b/examples/auth-workos-engine/package.json
@@ -14,15 +14,15 @@
     "deploy:inspect-oauth": "invokta-deploy inspect-oauth"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "jose": "^6.1.3",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/deploy": "0.8.2",
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/deploy": "0.9.0",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/community-capabilities/package.json
+++ b/examples/community-capabilities/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run test"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
+    "@invokta/core": "0.9.0",
     "zod": "4.4.3"
   }
 }

--- a/examples/composed-engine/package.json
+++ b/examples/composed-engine/package.json
@@ -17,15 +17,15 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
     "@invokta/example-community-capabilities": "0.1.0",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/crawl-engine/package.json
+++ b/examples/crawl-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
+    "@invokta/devtools": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/cursor-agent-routing-engine/package.json
+++ b/examples/cursor-agent-routing-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/hello-engine/package.json
+++ b/examples/hello-engine/package.json
@@ -18,13 +18,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2"
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0"
   }
 }

--- a/examples/image-engine/package.json
+++ b/examples/image-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
+    "@invokta/devtools": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/observability-engine/package.json
+++ b/examples/observability-engine/package.json
@@ -17,13 +17,13 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
+    "@invokta/devtools": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/obsidian-context-engine/package.json
+++ b/examples/obsidian-context-engine/package.json
@@ -17,14 +17,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
+    "@invokta/devtools": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/review-engine/package.json
+++ b/examples/review-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/spec-engine/package.json
+++ b/examples/spec-engine/package.json
@@ -19,14 +19,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-engine/package.json
+++ b/examples/support-engine/package.json
@@ -16,14 +16,14 @@
     "mcp:http": "node dist/mcp-http.js"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2",
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2",
-    "@invokta/tooling": "0.8.2",
+    "@invokta/devtools": "0.9.0",
+    "@invokta/tooling": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/examples/support-harness/package.json
+++ b/examples/support-harness/package.json
@@ -13,6 +13,6 @@
     "@modelcontextprotocol/sdk": "1.30.0"
   },
   "devDependencies": {
-    "@invokta/devtools": "0.8.2"
+    "@invokta/devtools": "0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invokta",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": true,
   "description": "A TypeScript framework for building reusable Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/cli",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Command-line adapter for invoking Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2"
+    "@invokta/core": "0.9.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/core",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Typed capability and connector contracts with the execution runtime for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability-library/package.json
+++ b/packages/create-invokta-capability-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability-library",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Create a standalone Invokta capability-library package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-capability/package.json
+++ b/packages/create-invokta-capability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-capability",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Create a standalone Invokta atomic capability package.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/create-invokta-engine/package.json
+++ b/packages/create-invokta-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-invokta-engine",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Create a standalone Invokta Action Engine.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/deploy": "0.8.2",
+    "@invokta/deploy": "0.9.0",
     "tar": "7.5.22",
     "yaml": "2.9.0"
   }

--- a/packages/create-invokta-engine/test/starter.test.ts
+++ b/packages/create-invokta-engine/test/starter.test.ts
@@ -117,7 +117,7 @@ describe("createStarterFiles", () => {
     expect(source).not.toContain("packages/deploy/src");
     expect(source).not.toContain("../deploy/");
     expect(manifest.dependencies).toEqual({
-      "@invokta/deploy": "0.8.2",
+      "@invokta/deploy": "0.9.0",
       tar: "7.5.22",
       yaml: "2.9.0",
     });

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/deploy",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "HTTP engine scaffolding, packaging, health probing, and OAuth inspection tools for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/devtools",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Local MCP and CLI workbenches, installation verifier, and engine diagnostics for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "test:run": "yarn --cwd ../.. test:run packages/devtools"
   },
   "dependencies": {
-    "@invokta/cli": "0.8.2",
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2"
+    "@invokta/cli": "0.9.0",
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0"
   }
 }

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/installer",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Install and manage Invokta Action Engines in local MCP clients.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",

--- a/packages/installer/test/package-boundary.test.ts
+++ b/packages/installer/test/package-boundary.test.ts
@@ -16,7 +16,7 @@ describe("@invokta/installer package boundary", () => {
 
     expect(manifest).toMatchObject({
       name: "@invokta/installer",
-      version: "0.8.2",
+      version: "0.9.0",
       type: "module",
       engines: { node: ">=22.20.0" },
       files: ["dist", "registry"],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/mcp",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "MCP server adapters and a plain client facade for Invokta Action Engines.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
+    "@invokta/core": "0.9.0",
     "@modelcontextprotocol/sdk": "1.30.0"
   }
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -190,7 +190,7 @@ export class McpClientError extends Error {
 
 const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
 const CLIENT_NAME = "invokta-mcp-client";
-const CLIENT_VERSION = "0.8.2";
+const CLIENT_VERSION = "0.9.0";
 const HTTP_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const ENVIRONMENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HTTP_WHITESPACE_AT_START_OR_END = /^(?:[\t ])|(?:[\t ])$/;

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invokta/tooling",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Development-time capability composition and MCP catalog checks for Invokta.",
   "author": "Vini Lana <vini@aicoders.academy>",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "prepack": "npm run --silent build"
   },
   "dependencies": {
-    "@invokta/core": "0.8.2",
-    "@invokta/mcp": "0.8.2"
+    "@invokta/core": "0.9.0",
+    "@invokta/mcp": "0.9.0"
   }
 }


### PR DESCRIPTION
Prepare Invokta 0.9.0 for publication through the protected release workflow. This minor release delivers the multiple-installation removal from #79 / ADR 0041: select individual engine/client pairs with Space or all eligible entries with A, review them, and confirm once. It also includes the self-hosted OAuth example lockfile correction from #78.

All ten public package versions, exact internal and example pins, version assertions, and MCP client identification now use 0.9.0. The changelog and installer reference identify the release. The example's seven locked Invokta packages use SHA-512 integrity derived from clean-checkout artifacts, before a workspace installation can change generated command file modes.

Validation on Node.js 24.20.0 / Yarn 1.22.22:

- Metadata-only release preparation uses the documentation/tooling exception to a new RED test. The feature's test-first evidence is recorded in #79 and `docs/validation-record.md`.
- Frozen dependency installation and `yarn run check` pass: 3,190 tests, one intentional skip, coverage, typecheck, lint, formatting, build, and 19 example gates.
- Root and documentation audits report zero vulnerabilities across 307 and 537 packages respectively.
- Documentation validation passes 15 tests, zero Astro diagnostics, and 49 built pages.
- `yarn release:pack` passes all ten package dry-runs.
- `yarn release:verify` passes clean tarballs, isolated ESM imports, four generated engine profiles, authenticated MCP HTTP, DevTools doctor, and atomic/library consumers.
- All ten versions and exact internal pins match 0.9.0; the seven locked artifact hashes match the clean packs. Staged diff checks pass.

After this PR's checks and merge, create annotated `v0.9.0` from clean `origin/main`, await the tag's Verify job, approve the protected npm environment, and confirm npm latest/gitHead and the GitHub Release. Recheck registry integrity and isolated example `npm ci` after publication. Package publication remains in GitHub Actions.
